### PR TITLE
fix: restore deep research stream execution

### DIFF
--- a/.changeset/deep-research-v0.0.2--host-v0.0.2--orchestration-v0.0.2.md
+++ b/.changeset/deep-research-v0.0.2--host-v0.0.2--orchestration-v0.0.2.md
@@ -1,0 +1,9 @@
+---
+"@agentrail/deep-research": patch
+"@agentrail/host": patch
+"@agentrail/orchestration": patch
+---
+
+Fix deep research mode on the playground stream route
+
+Add stream-route request interception so deep research mode can take over SSE handling, expose a streaming deep-research runner, and wire the playground server to emit deep_research_* and subagent_* events while keeping chat mode unchanged. Also fail fast when a spawned sub-agent never becomes ready, mark the orchestration/deep-research runs as failed instead of leaving them stuck in running state, and persist a readable assistant error message back to the session.

--- a/examples/playground-server/src/chat/deep-research.ts
+++ b/examples/playground-server/src/chat/deep-research.ts
@@ -3,9 +3,78 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { AgentrailChatHandledResponse, AgentrailResolvedChatContext } from "@agentrail/host";
-import { runDeepResearchBlocking } from "@agentrail/deep-research";
+import type {
+  AgentrailChatHandledResponse,
+  AgentrailResolvedChatContext,
+  AgentrailResolvedStreamContext,
+} from "@agentrail/host";
+import type { Message, Usage } from "@agentrail/runtime-core";
+import {
+  runDeepResearchBlocking,
+  runDeepResearchStreaming,
+  type DeepResearchStreamingRunInput,
+} from "@agentrail/deep-research";
 import { config } from "../config.js";
+
+function buildDeepResearchRuntime() {
+  return {
+    dataDir: config.dataDir,
+    model: {
+      provider: config.provider,
+      modelId: config.modelId,
+      ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+      ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    },
+    searchProvider: config.searchProvider,
+    tavilyApiKey: config.tavilyApiKey,
+    sandbox: config.sandbox,
+    orchestration: config.orchestration,
+  };
+}
+
+function zeroUsage(): Usage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+function buildDeepResearchFailureTurn(
+  userText: string,
+  errorMessage: string,
+): { messages: Message[]; usage: Usage } {
+  const timestamp = Date.now();
+  const usage = zeroUsage();
+  return {
+    messages: [
+      {
+        role: "user",
+        content: userText,
+        timestamp,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: `Deep Research failed: ${errorMessage}` }],
+        provider: config.provider,
+        modelId: config.modelId,
+        usage,
+        stopReason: "error",
+        timestamp: timestamp + 1,
+      },
+    ],
+    usage,
+  };
+}
 
 export async function handlePlaygroundDeepResearchMode(
   context: AgentrailResolvedChatContext,
@@ -20,19 +89,7 @@ export async function handlePlaygroundDeepResearchMode(
     query: context.request.message,
     sessionId: context.sessionId,
     sessionStore: context.sessionStore,
-    runtime: {
-      dataDir: config.dataDir,
-      model: {
-        provider: config.provider,
-        modelId: config.modelId,
-        ...(config.apiKey ? { apiKey: config.apiKey } : {}),
-        ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
-      },
-      searchProvider: config.searchProvider,
-      tavilyApiKey: config.tavilyApiKey,
-      sandbox: config.sandbox,
-      orchestration: config.orchestration,
-    },
+    runtime: buildDeepResearchRuntime(),
   });
 
   return {
@@ -44,3 +101,44 @@ export async function handlePlaygroundDeepResearchMode(
     },
   };
 }
+
+export function createPlaygroundDeepResearchModeStreamHandler(
+  runStreaming: typeof runDeepResearchStreaming = runDeepResearchStreaming,
+) {
+  return async function handlePlaygroundDeepResearchModeStream(
+    context: AgentrailResolvedStreamContext,
+  ): Promise<boolean> {
+    if (context.request.mode !== "deep_research") {
+      return false;
+    }
+
+    try {
+      await runStreaming({
+        tenantId: context.tenantId,
+        userId: context.userId,
+        query: context.request.message,
+        sessionId: context.sessionId,
+        sessionStore: context.sessionStore,
+        persistTurn: context.persistTurn,
+        runtime: buildDeepResearchRuntime(),
+        onEvent: context.writeEvent,
+      } satisfies DeepResearchStreamingRunInput);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const failureTurn = buildDeepResearchFailureTurn(
+        context.request.message,
+        message,
+      );
+      await context.writeEvent({
+        type: "error",
+        error: { message },
+      });
+      await context.persistTurn(failureTurn.messages, failureTurn.usage);
+    }
+
+    return true;
+  };
+}
+
+export const handlePlaygroundDeepResearchModeStream =
+  createPlaygroundDeepResearchModeStreamHandler();

--- a/examples/playground-server/src/routes/stream.ts
+++ b/examples/playground-server/src/routes/stream.ts
@@ -15,6 +15,7 @@ import {
 import { config } from "../config.js";
 import { playgroundPlugins } from "../plugins/index.js";
 import { resolvePlaygroundProfile } from "../profiles/default-profile.js";
+import { handlePlaygroundDeepResearchModeStream } from "../chat/deep-research.js";
 
 const summarize = buildSummarizeFn();
 
@@ -39,6 +40,7 @@ const stream = createStreamRoute({
       },
     });
   },
+  handleResolvedRequest: handlePlaygroundDeepResearchModeStream,
 });
 
 export { stream };

--- a/examples/playground-server/test/deep-research-stream-handler.test.ts
+++ b/examples/playground-server/test/deep-research-stream-handler.test.ts
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import type { Message, Usage } from "@agentrail/runtime-core";
+
+const dataDir = await mkdtemp(join(tmpdir(), "agentrail-deep-research-stream-handler-"));
+const configPath = join(dataDir, "agentrail.yaml");
+await writeFile(
+  configPath,
+  `version: 1\npaths:\n  dataDir: ${JSON.stringify(dataDir)}\n`,
+  "utf8",
+);
+process.env.AGENTRAIL_CONFIG_PATH = configPath;
+
+const { createPlaygroundDeepResearchModeStreamHandler } = await import(
+  "../src/chat/deep-research.js"
+);
+
+after(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+  delete process.env.AGENTRAIL_CONFIG_PATH;
+});
+
+function makeUsage(): Usage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+test("deep research stream handler delegates matching requests to the streaming runner", async () => {
+  const events: object[] = [];
+  const persisted: { messages: Message[]; usage: Usage }[] = [];
+  let capturedQuery = "";
+
+  const handler = createPlaygroundDeepResearchModeStreamHandler(async (input) => {
+    capturedQuery = input.query;
+    await input.onEvent?.({ type: "subagent_spawned", agentId: "researcher-1" });
+    await input.persistTurn?.(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "deep research report" }],
+          provider: "mock",
+          modelId: "mock-model",
+          usage: makeUsage(),
+          stopReason: "stop",
+          timestamp: Date.now(),
+        },
+      ],
+      makeUsage(),
+    );
+    return {
+      sessionId: input.sessionId ?? "session-1",
+      state: {
+        run: {
+          id: "run-1",
+          sessionId: input.sessionId ?? "session-1",
+          tenantId: input.tenantId,
+          userId: input.userId,
+          query: input.query,
+          title: input.query,
+          status: "completed",
+          createdAt: "2026-03-30T00:00:00.000Z",
+          updatedAt: "2026-03-30T00:00:00.000Z",
+        },
+        plan: null,
+        steps: [],
+        sources: [],
+        artifacts: [],
+        reportMarkdown: "deep research report",
+        entityProfile: null,
+      },
+    };
+  });
+
+  const handled = await handler({
+    request: {
+      message: "Investigate the issue",
+      mode: "deep_research",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      sessionId: "session-1",
+    },
+    agentId: "agent-1",
+    tenantId: "tenant-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sessionDir: "/tmp/session-1",
+    signal: new AbortController().signal,
+    sessionStore: {} as never,
+    uploadedFiles: [],
+    writeEvent: async (event) => {
+      events.push(event);
+    },
+    persistTurn: async (messages, usage) => {
+      persisted.push({ messages, usage });
+    },
+  });
+
+  assert.equal(handled, true);
+  assert.equal(capturedQuery, "Investigate the issue");
+  assert.deepEqual(events, [{ type: "subagent_spawned", agentId: "researcher-1" }]);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0]?.messages[0]?.role, "assistant");
+});
+
+test("deep research stream handler emits an error event on failure", async () => {
+  const events: object[] = [];
+  const persisted: { messages: Message[]; usage: Usage }[] = [];
+
+  const handler = createPlaygroundDeepResearchModeStreamHandler(async () => {
+    throw new Error("Sub-agent worker did not become ready within 5000ms");
+  });
+
+  const handled = await handler({
+    request: {
+      message: "Investigate the issue",
+      mode: "deep_research",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      sessionId: "session-1",
+    },
+    agentId: "agent-1",
+    tenantId: "tenant-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sessionDir: "/tmp/session-1",
+    signal: new AbortController().signal,
+    sessionStore: {} as never,
+    uploadedFiles: [],
+    writeEvent: async (event) => {
+      events.push(event);
+    },
+    persistTurn: async (messages, usage) => {
+      persisted.push({ messages, usage });
+    },
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(events, [
+    {
+      type: "error",
+      error: {
+        message: "Sub-agent worker did not become ready within 5000ms",
+      },
+    },
+  ]);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0]?.messages[1]?.role, "assistant");
+  assert.match(
+    String(
+      (persisted[0]?.messages[1]?.content as Array<{ type: string; text?: string }>)[0]?.text,
+    ),
+    /Deep Research failed: Sub-agent worker did not become ready within 5000ms/,
+  );
+});
+
+test("deep research stream handler ignores normal chat mode", async () => {
+  const handler = createPlaygroundDeepResearchModeStreamHandler(async () => {
+    throw new Error("should not run");
+  });
+
+  const handled = await handler({
+    request: {
+      message: "hello",
+      mode: "chat",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      sessionId: "session-1",
+    },
+    agentId: "agent-1",
+    tenantId: "tenant-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sessionDir: "/tmp/session-1",
+    signal: new AbortController().signal,
+    sessionStore: {} as never,
+    uploadedFiles: [],
+    writeEvent: async () => {},
+    persistTurn: async () => {},
+  });
+
+  assert.equal(handled, false);
+});

--- a/examples/playground-server/test/default-subagent-process.test.ts
+++ b/examples/playground-server/test/default-subagent-process.test.ts
@@ -19,6 +19,7 @@ import { OrchestrationStore } from "@agentrail/orchestration";
 import {
   createSubAgentProcess,
   createManagedSubAgentInstance,
+  resolveWorkerCwd,
   resolveWorkerExecArgv,
 } from "@agentrail/orchestration/worker";
 
@@ -33,9 +34,15 @@ function getWorkerPath(): string {
 
 class FakeChildProcess extends EventEmitter {
   readonly sent: unknown[] = [];
+  readonly killSignals: Array<NodeJS.Signals | number | undefined> = [];
 
   send(message: unknown): void {
     this.sent.push(message);
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killSignals.push(signal);
+    return true;
   }
 }
 
@@ -202,6 +209,28 @@ test("subscribes to autonomous worker lifecycle events", async () => {
   ]);
 });
 
+test("fails fast when the worker never reports ready", async () => {
+  const child = new FakeChildProcess();
+
+  const instancePromise = createManagedSubAgentInstance(child as never, {
+    tenantId: "tenant-test",
+    userId: "user-test",
+    sessionId: "session-test",
+    sessionDir: "/tmp/session-test",
+    input: createInput(),
+    workerPath: getWorkerPath(),
+    runtimeConfig: {},
+    readyTimeoutMs: 20,
+  });
+
+  await assert.rejects(
+    instancePromise,
+    /did not become ready within 20ms/,
+  );
+  assert.equal(child.sent[0] && typeof child.sent[0] === "object", true);
+  assert.deepEqual(child.killSignals, ["SIGTERM"]);
+});
+
 test("real default sub-agent worker completes a wake-driven turn", async () => {
   const sessionDir = await mkdtemp(join(tmpdir(), "default-subagent-process-real-"));
 
@@ -283,6 +312,17 @@ test("filters parent execArgv down to runtime-safe loader flags", () => {
       "-r",
       "./register.js",
     ],
+  );
+});
+
+test("uses the parent working directory for worker process resolution", () => {
+  assert.equal(
+    resolveWorkerCwd("/tmp/worker-entry.ts", "/tmp/example-app"),
+    "/tmp/example-app",
+  );
+  assert.equal(
+    resolveWorkerCwd("/tmp/worker-entry.js", "/tmp/example-app"),
+    "/tmp/example-app",
   );
 });
 

--- a/examples/playground-server/test/tsconfig.json
+++ b/examples/playground-server/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/examples/playground-ui/package.json
+++ b/examples/playground-ui/package.json
@@ -25,6 +25,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/examples/playground-ui/test/tsconfig.json
+++ b/examples/playground-ui/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*.ts", "./**/*.tsx", "../src/**/*.ts", "../src/**/*.tsx"]
+}

--- a/packages/config/test/tsconfig.json
+++ b/packages/config/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/deep-research/src/coordinator-internals.ts
+++ b/packages/deep-research/src/coordinator-internals.ts
@@ -19,7 +19,7 @@ import { nowIso } from "./utils.js";
 export function getDeepResearchWorkerPath(): string {
   const currentFile = fileURLToPath(import.meta.url);
   const extension = currentFile.endsWith(".ts") ? ".ts" : ".js";
-  return join(dirname(currentFile), `../agents/deep-research-worker-entry${extension}`);
+  return join(dirname(currentFile), `./agents/deep-research-worker-entry${extension}`);
 }
 
 export function zeroUsage(): Usage {

--- a/packages/deep-research/src/coordinator.ts
+++ b/packages/deep-research/src/coordinator.ts
@@ -158,6 +158,7 @@ export class DeepResearchCoordinator {
       }
 
       this.state.reportMarkdown = await this.generateReport(emit);
+      await this.manager.completeRun({ status: "completed" });
       this.state.run.status = "completed";
       this.state.run.updatedAt = nowIso();
       this.state.run.completedAt = this.state.run.updatedAt;
@@ -180,8 +181,15 @@ export class DeepResearchCoordinator {
       return this.state;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      if (this.manager) {
+        await this.manager.completeRun({
+          status: "failed",
+          error: message,
+        }).catch(() => undefined);
+      }
       this.state.run.status = "failed";
       this.state.run.error = message;
+      this.state.run.completedAt = nowIso();
       this.state.run.updatedAt = nowIso();
       await this.store.writeState(this.state);
       await this.emitDeepResearchEvent(
@@ -482,29 +490,62 @@ export class DeepResearchCoordinator {
     }
 
     const agentId = `${role}:${this.runId}:${stepId}`;
-    await this.manager.spawnAgent({
-      id: agentId,
-      role,
-    });
-    await this.manager.sendInput({
-      id: `input:${agentId}`,
-      agentId,
-      payload: { prompt },
-    });
-    await this.manager.waitForAgents({
-      id: `wait:${agentId}`,
-      agentId,
-      kind: "agent-idle",
-      description: `Wait for ${role} to complete`,
-    });
-    const snapshot = this.manager.getSnapshot();
-    const outputText = snapshot.agents[agentId]?.lastJob?.outputText ?? "";
+    let closeReason = "step completed";
+
+    try {
+      await this.manager.spawnAgent({
+        id: agentId,
+        role,
+      });
+      await this.manager.sendInput({
+        id: `input:${agentId}`,
+        agentId,
+        payload: { prompt },
+      });
+      await this.manager.waitForAgents({
+        id: `wait:${agentId}`,
+        agentId,
+        kind: "agent-idle",
+        description: `Wait for ${role} to complete`,
+      });
+      const snapshot = this.manager.getSnapshot();
+      const lastJob = snapshot.agents[agentId]?.lastJob;
+
+      if (!lastJob) {
+        throw new Error(`${role} agent ${agentId} became idle without reporting a job result.`);
+      }
+
+      if (lastJob.outcome !== "completed") {
+        throw new Error(
+          lastJob.error ??
+            `${role} agent ${agentId} finished with outcome ${lastJob.outcome}.`,
+        );
+      }
+
+      return lastJob.outputText ?? "";
+    } catch (error) {
+      closeReason = `step failed: ${error instanceof Error ? error.message : String(error)}`;
+      throw error;
+    } finally {
+      await this.closeManagedAgent(agentId, closeReason);
+    }
+  }
+
+  private async closeManagedAgent(agentId: string, reason: string): Promise<void> {
+    if (!this.manager) {
+      return;
+    }
+
+    const agent = this.manager.getSnapshot().agents[agentId];
+    if (!agent || agent.status === "closed" || agent.status === "closing") {
+      return;
+    }
+
     await this.manager.closeAgent({
-      id: `close:${agentId}`,
+      id: `close:${agentId}:${randomUUID()}`,
       agentId,
-      reason: "step completed",
-    });
-    return outputText;
+      reason,
+    }).catch(() => undefined);
   }
 
   private async mergeSources(

--- a/packages/deep-research/src/run.ts
+++ b/packages/deep-research/src/run.ts
@@ -6,7 +6,7 @@
 import { Hono } from "hono";
 import type { Message, Usage } from "@agentrail/runtime-core";
 import { DeepResearchCoordinator } from "./coordinator.js";
-import type { DeepResearchState } from "./types.js";
+import type { DeepResearchEvent, DeepResearchState } from "./types.js";
 import type { DeepResearchRuntimeConfig } from "./runtime.js";
 
 export interface DeepResearchSessionStore {
@@ -34,11 +34,18 @@ export interface DeepResearchBlockingRunInput {
   sessionStore: DeepResearchSessionStore;
   runtime: DeepResearchRuntimeConfig;
   agentId?: string;
+  persistTurn?: (messages: Message[], usage: Usage) => Promise<void>;
 }
 
 export interface DeepResearchBlockingRunResult {
   sessionId: string;
   state: DeepResearchState;
+}
+
+export type DeepResearchStreamingEvent = DeepResearchEvent | Record<string, unknown>;
+
+export interface DeepResearchStreamingRunInput extends DeepResearchBlockingRunInput {
+  onEvent?: (event: DeepResearchStreamingEvent) => Promise<void> | void;
 }
 
 export interface DeepResearchRunRouteOptions {
@@ -56,6 +63,19 @@ interface DeepResearchRunRequest {
 
 export async function runDeepResearchBlocking(
   input: DeepResearchBlockingRunInput,
+): Promise<DeepResearchBlockingRunResult> {
+  return runDeepResearchInternal(input);
+}
+
+export async function runDeepResearchStreaming(
+  input: DeepResearchStreamingRunInput,
+): Promise<DeepResearchBlockingRunResult> {
+  return runDeepResearchInternal(input, (event) => input.onEvent?.(event));
+}
+
+async function runDeepResearchInternal(
+  input: DeepResearchBlockingRunInput,
+  emit?: (event: DeepResearchStreamingEvent) => Promise<void> | void,
 ): Promise<DeepResearchBlockingRunResult> {
   const sessionInfo = await input.sessionStore.getOrCreate(
     input.tenantId,
@@ -77,15 +97,18 @@ export async function runDeepResearchBlocking(
     runtime: input.runtime,
   });
 
-  const state = await coordinator.runBlocking();
+  const state = emit
+    ? await coordinator.runStreaming(emit)
+    : await coordinator.runBlocking();
   await persistDeepResearchTurn(
-    input.sessionStore,
+    input.persistTurn ? undefined : input.sessionStore,
     input.runtime.model.provider,
     input.runtime.model.modelId,
     input.tenantId,
     sessionId,
     input.query,
     state.reportMarkdown,
+    input.persistTurn,
   );
 
   return {
@@ -147,15 +170,17 @@ export function createDeepResearchRunRoute(
 }
 
 async function persistDeepResearchTurn(
-  sessionStore: Pick<DeepResearchSessionStore, "appendMessages" | "recordTurn">,
+  sessionStore: Pick<DeepResearchSessionStore, "appendMessages" | "recordTurn"> | undefined,
   provider: string,
   modelId: string,
   tenantId: string,
   sessionId: string,
   userText: string,
   reportMarkdown: string,
+  persistTurn?: (messages: Message[], usage: Usage) => Promise<void>,
 ): Promise<void> {
   const timestamp = Date.now();
+  const usage = zeroUsage();
   const messages: Message[] = [
     {
       role: "user",
@@ -167,15 +192,24 @@ async function persistDeepResearchTurn(
       content: [{ type: "text", text: reportMarkdown }],
       provider,
       modelId,
-      usage: zeroUsage(),
+      usage,
       stopReason: "stop",
       timestamp: timestamp + 1,
     },
   ];
 
+  if (persistTurn) {
+    await persistTurn(messages, usage);
+    return;
+  }
+
+  if (!sessionStore) {
+    throw new Error("Deep research turn persistence requires either sessionStore or persistTurn.");
+  }
+
   await Promise.all([
     sessionStore.appendMessages(tenantId, sessionId, messages),
-    sessionStore.recordTurn(tenantId, sessionId, zeroUsage()),
+    sessionStore.recordTurn(tenantId, sessionId, usage),
   ]);
 }
 

--- a/packages/deep-research/test/tsconfig.json
+++ b/packages/deep-research/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/events/test/tsconfig.json
+++ b/packages/events/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/host/src/stream-route-internals.ts
+++ b/packages/host/src/stream-route-internals.ts
@@ -27,6 +27,7 @@ interface AttachmentInput {
 export interface StreamRequest {
   message: string;
   agentId?: string;
+  mode?: string;
   tenantId: string;
   userId: string;
   sessionId?: string;

--- a/packages/host/src/stream-route.ts
+++ b/packages/host/src/stream-route.ts
@@ -83,6 +83,23 @@ export interface AgentrailStreamRouteOptions {
     userId: string;
     sessionId: string;
   }) => Promise<OrchestrationManager>;
+  handleResolvedRequest?: (
+    context: AgentrailResolvedStreamContext,
+  ) => Promise<boolean> | boolean;
+}
+
+export interface AgentrailResolvedStreamContext {
+  request: StreamRequest;
+  agentId: string;
+  tenantId: string;
+  userId: string;
+  sessionId: string;
+  sessionDir: string;
+  signal: AbortSignal;
+  sessionStore: AgentrailSessionStore;
+  uploadedFiles: AttachmentFile[];
+  writeEvent: (event: object) => Promise<void>;
+  persistTurn: (messages: Message[], usage: Usage) => Promise<void>;
 }
 
 export function createStreamRoute(
@@ -146,15 +163,17 @@ export function createStreamRoute(
     void options.sandboxManager.ensureSandbox(sid, tenantId, userId);
 
     let forwardSubAgentEvent: (event: object) => void = () => {};
-    const profile = await options.resolveProfile(
-      agentId,
-      { tenantId, userId, sessionId: sid, sessionDir },
-      (event) => forwardSubAgentEvent(event),
-    );
-    if (!profile) {
-      return c.json({ error: `Agent profile '${agentId}' not found` }, 404);
+    let preloadedProfile: AgentrailProfile | null | undefined;
+    if (!options.handleResolvedRequest) {
+      preloadedProfile = await options.resolveProfile(
+        agentId,
+        { tenantId, userId, sessionId: sid, sessionDir },
+        (event) => forwardSubAgentEvent(event),
+      );
+      if (!preloadedProfile) {
+        return c.json({ error: `Agent profile '${agentId}' not found` }, 404);
+      }
     }
-
     const abortController = new AbortController();
     c.req.raw.signal.addEventListener("abort", () => abortController.abort());
     c.header("X-Session-Id", sid);
@@ -164,7 +183,55 @@ export function createStreamRoute(
       forwardSubAgentEvent = forwardEvent;
 
       let unsubscribeOrchestration: (() => void) | undefined;
+      const persistTurn = async (messages: Message[], usage: Usage) => {
+        await Promise.all([
+          options.sessionStore.appendMessages(tenantId, sid, messages),
+          options.sessionStore.recordTurn(tenantId, sid, usage),
+        ]);
+        await options.onTurnPersisted?.(requestContext);
+        await runPluginRequestHook(plugins, "onTurnPersisted", requestContext);
+      };
       try {
+        if (options.handleResolvedRequest) {
+          const handled = await options.handleResolvedRequest({
+            request: {
+              ...body,
+              message: effectiveMessage,
+              agentId,
+              sessionId: sid,
+            },
+            agentId,
+            tenantId,
+            userId,
+            sessionId: sid,
+            sessionDir,
+            signal: abortController.signal,
+            sessionStore: options.sessionStore,
+            uploadedFiles,
+            writeEvent,
+            persistTurn,
+          });
+          if (handled) {
+            return;
+          }
+        }
+
+        const profile = preloadedProfile ?? await options.resolveProfile(
+          agentId,
+          { tenantId, userId, sessionId: sid, sessionDir },
+          (event) => forwardSubAgentEvent(event),
+        );
+        if (!profile) {
+          const errorEvent: AgentrailErrorEvent = {
+            type: "error",
+            error: {
+              message: `Agent profile '${agentId}' not found`,
+            },
+          };
+          await writeEvent(errorEvent);
+          return;
+        }
+
         const agent = await profile.createAgent(
           { tenantId, userId, sessionId: sid, sessionDir },
           (event) => forwardSubAgentEvent(event),
@@ -257,12 +324,7 @@ export function createStreamRoute(
         }
 
         if (capturedMessages && capturedUsage) {
-          await Promise.all([
-            options.sessionStore.appendMessages(tenantId, sid, capturedMessages),
-            options.sessionStore.recordTurn(tenantId, sid, capturedUsage),
-          ]);
-          await options.onTurnPersisted?.(requestContext);
-          await runPluginRequestHook(plugins, "onTurnPersisted", requestContext);
+          await persistTurn(capturedMessages, capturedUsage);
         }
       } finally {
         unsubscribeOrchestration?.();

--- a/packages/host/test/stream-route.test.ts
+++ b/packages/host/test/stream-route.test.ts
@@ -279,4 +279,87 @@ describe("createStreamRoute", () => {
     ]);
     expect(contextProvider).toHaveBeenCalledOnce();
   });
+
+  it("lets a resolved stream handler take over SSE and persistence", async () => {
+    const appended: Message[][] = [];
+    const sessionManager = {
+      getOrCreate: vi.fn(async () => ({ sessionId: "session-1" })),
+      getSessionDir: vi.fn(() => "/tmp/session-1"),
+      loadAllMessages: vi.fn(async () => []),
+      compactIfNeeded: vi.fn(async () => {}),
+      loadMessagesWithBudget: vi.fn(async () => []),
+      appendMessages: vi.fn(async (_tenantId: string, _sid: string, messages: Message[]) => {
+        appended.push(messages);
+      }),
+      recordTurn: vi.fn(async () => {}),
+    };
+    const sandboxManager = {
+      ensureSandbox: vi.fn(async () => {}),
+      listWorkspace: vi.fn(async () => []),
+    };
+    const onTurnPersisted = vi.fn(async () => {});
+    const resolveProfile = vi.fn(async () => ({
+      id: "agent-1",
+      name: "Test Agent",
+      createAgent: async () => makeAgent([]),
+    }));
+    const handleResolvedRequest = vi.fn(async (context) => {
+      expect(context.request.mode).toBe("deep_research");
+      await context.writeEvent({ type: "deep_research_start" });
+      await context.persistTurn(
+        [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "handled" }],
+            provider: "mock",
+            modelId: "mock-model",
+            usage: makeUsage(),
+            stopReason: "stop",
+            timestamp: 1,
+          },
+        ],
+        makeUsage(),
+      );
+      return true;
+    });
+
+    const route = createStreamRoute({
+      dataDir: "/tmp/agentrail",
+      defaultAgentId: "agent-1",
+      sessionStore: sessionManager as never,
+      sandboxManager: sandboxManager as never,
+      summarize: async () => "summary",
+      compaction: {
+        triggerTokens: 100,
+        minMessages: 100,
+      },
+      resolveProfile,
+      onTurnPersisted,
+      handleResolvedRequest,
+    });
+
+    const response = await route.request("http://localhost/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        message: "research this",
+        tenantId: "tenant-1",
+        userId: "user-1",
+        mode: "deep_research",
+      }),
+    });
+
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("\"type\":\"deep_research_start\"");
+    expect(handleResolvedRequest).toHaveBeenCalledOnce();
+    expect(resolveProfile).not.toHaveBeenCalled();
+    expect(sessionManager.appendMessages).toHaveBeenCalledOnce();
+    expect(appended[0]?.[0]?.role).toBe("assistant");
+    expect(onTurnPersisted).toHaveBeenCalledOnce();
+    expect(sessionManager.loadMessagesWithBudget).not.toHaveBeenCalled();
+  });
 });

--- a/packages/host/test/tsconfig.json
+++ b/packages/host/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/memo/test/tsconfig.json
+++ b/packages/memo/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/orchestration/src/orchestration-manager.ts
+++ b/packages/orchestration/src/orchestration-manager.ts
@@ -27,6 +27,7 @@ import type {
   OrchestrationEvent,
   OrchestrationSnapshot,
   RemoveInputInput,
+  RunStatus,
   SpawnAgentInput,
   WaitAgentInput,
   WaitCondition,
@@ -374,6 +375,37 @@ export class OrchestrationManager {
     for (const waitId of pendingWaitIds) {
       await this.reconcileWait(waitId);
     }
+  }
+
+  async completeRun(input: {
+    status: Extract<RunStatus, "completed" | "failed">;
+    error?: string;
+  }): Promise<void> {
+    const run = this.snapshot.run;
+
+    if (!run) {
+      throw new Error("No orchestration run has been started");
+    }
+
+    if (run.status !== "running") {
+      if (
+        run.status === input.status &&
+        run.completedAt
+      ) {
+        return;
+      }
+
+      throw new Error(`Orchestration run ${run.id} is already ${run.status}`);
+    }
+
+    await this.recordEvent({
+      eventId: this.createEventId(),
+      type: "run_completed",
+      occurredAt: this.now(),
+      runId: run.id,
+      status: input.status,
+      error: input.error,
+    });
   }
 
   private async initialize(): Promise<void> {

--- a/packages/orchestration/src/worker/subagent-process.ts
+++ b/packages/orchestration/src/worker/subagent-process.ts
@@ -4,7 +4,6 @@
  */
 
 import { fork } from "node:child_process";
-import { dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import type {
   AgentInputEnvelope,
@@ -59,13 +58,20 @@ type WorkerResponseMessage =
 interface ChildProcessLike {
   send(message: unknown): void;
   on(event: "message", listener: (message: WorkerResponseMessage) => void): this;
-  once(event: "error", listener: (error: Error) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): this;
   once(
     event: "exit",
     listener: (code: number | null, signal: NodeJS.Signals | null) => void,
   ): this;
+  kill?(signal?: NodeJS.Signals | number): boolean;
   stderr?: NodeJS.ReadableStream | null;
 }
+
+export const DEFAULT_SUBAGENT_READY_TIMEOUT_MS = 5_000;
 
 export interface CreateSubAgentProcessInput {
   tenantId: string;
@@ -77,13 +83,14 @@ export interface CreateSubAgentProcessInput {
   // biome-ignore lint/suspicious/noExplicitAny: Runtime config is serialized
   runtimeConfig: any;
   workerConfig?: Partial<SubagentWorkerConfig>;
+  readyTimeoutMs?: number;
 }
 
 export async function createSubAgentProcess(
   options: CreateSubAgentProcessInput,
 ): Promise<ManagedAgentInstance> {
   const child = fork(options.workerPath, [], {
-    cwd: dirname(options.workerPath),
+    cwd: resolveWorkerCwd(options.workerPath),
     execArgv: resolveWorkerExecArgv(),
     env: process.env,
     stdio: ["ignore", "ignore", "pipe", "ipc"],
@@ -106,6 +113,7 @@ export async function createManagedSubAgentInstance(
   let handlers: ManagedAgentEventHandlers | undefined;
   const bufferedEvents: WorkerResponseMessage[] = [];
   const recentStderr: string[] = [];
+  const readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_SUBAGENT_READY_TIMEOUT_MS;
 
   child.stderr?.on("data", (chunk) => {
     const text = chunk.toString().trim();
@@ -119,15 +127,55 @@ export async function createManagedSubAgentInstance(
     }
   });
 
+  const rejectPending = (error: Error) => {
+    for (const request of pending.values()) {
+      request.reject(error);
+    }
+    pending.clear();
+  };
+  const buildWorkerError = (message: string): Error => {
+    const stderrSuffix =
+      recentStderr.length > 0
+        ? ` stderr=${JSON.stringify(recentStderr.join("\n"))}`
+        : "";
+    return new Error(`${message}${stderrSuffix}`);
+  };
+
+  let settleReady!: () => void;
+  let failReady!: (error: Error) => void;
+  let readySettled = false;
+  let readyTimeout: ReturnType<typeof setTimeout> | undefined;
+  const markReadyResolved = () => {
+    if (readySettled) {
+      return;
+    }
+    readySettled = true;
+    if (readyTimeout) {
+      clearTimeout(readyTimeout);
+    }
+    settleReady();
+  };
+  const markReadyRejected = (error: Error) => {
+    if (readySettled) {
+      return;
+    }
+    readySettled = true;
+    if (readyTimeout) {
+      clearTimeout(readyTimeout);
+    }
+    failReady(error);
+  };
+
   const ready = new Promise<void>((resolve, reject) => {
-    child.once("error", reject);
+    settleReady = resolve;
+    failReady = reject;
     child.on("message", (message: WorkerResponseMessage) => {
       if (!message || typeof message !== "object") {
         return;
       }
 
       if (message.type === "ready") {
-        resolve();
+        markReadyResolved();
         return;
       }
 
@@ -180,25 +228,36 @@ export async function createManagedSubAgentInstance(
           return;
         }
 
-        reject(new Error(message.error));
+        const error = buildWorkerError(message.error);
+        rejectPending(error);
+        markReadyRejected(error);
       }
     });
-    child.once("exit", (code, signal) => {
-      const stderrSuffix =
-        recentStderr.length > 0
-          ? ` stderr=${JSON.stringify(recentStderr.join("\n"))}`
-          : "";
-      const error = new Error(
-        `Sub-agent worker exited before completion (code=${code}, signal=${signal})${stderrSuffix}`,
+    child.on("error", (error) => {
+      rejectPending(error);
+      markReadyRejected(error);
+    });
+    child.on("exit", (code, signal) => {
+      const error = buildWorkerError(
+        `Sub-agent worker exited before completion (code=${code}, signal=${signal})`,
       );
-      for (const request of pending.values()) {
-        request.reject(error);
-      }
-      pending.clear();
+      rejectPending(error);
+      markReadyRejected(error);
     });
   });
+  readyTimeout = setTimeout(() => {
+    const error = buildWorkerError(
+      `Sub-agent worker did not become ready within ${readyTimeoutMs}ms`,
+    );
+    rejectPending(error);
+    terminateChild(child);
+    markReadyRejected(error);
+  }, readyTimeoutMs);
+  if (options.readyTimeoutMs === undefined) {
+    readyTimeout.unref?.();
+  }
 
-  child.send({
+  safeSend(child, {
     type: "init",
     tenantId: options.tenantId,
     userId: options.userId,
@@ -209,7 +268,7 @@ export async function createManagedSubAgentInstance(
       input: options.runtimeConfig?.input ?? options.input,
     },
     workerConfig: options.workerConfig,
-  });
+  }, recentStderr);
   await ready;
 
   return {
@@ -236,10 +295,10 @@ export async function createManagedSubAgentInstance(
 
       return new Promise<ManagedAgentDeliveryResult>((resolve, reject) => {
         pending.set(requestId, { resolve, reject });
-        child.send({
+        safeSend(child, {
           type: "run_turn",
           requestId,
-        });
+        }, recentStderr);
       });
     },
 
@@ -249,10 +308,10 @@ export async function createManagedSubAgentInstance(
           resolve();
         });
       });
-      child.send({
+      safeSend(child, {
         type: "close",
         reason,
-      });
+      }, recentStderr);
       await closed;
     },
   };
@@ -298,4 +357,36 @@ export function resolveWorkerExecArgv(
   }
 
   return nextExecArgv;
+}
+
+export function resolveWorkerCwd(
+  _workerPath: string,
+  parentCwd: string = process.cwd(),
+): string {
+  return parentCwd;
+}
+
+function safeSend(
+  child: ChildProcessLike,
+  message: unknown,
+  recentStderr: string[],
+): void {
+  try {
+    child.send(message);
+  } catch (error) {
+    const stderrSuffix =
+      recentStderr.length > 0
+        ? ` stderr=${JSON.stringify(recentStderr.join("\n"))}`
+        : "";
+    const baseMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Sub-agent worker IPC send failed: ${baseMessage}${stderrSuffix}`);
+  }
+}
+
+function terminateChild(child: ChildProcessLike): void {
+  try {
+    child.kill?.("SIGTERM");
+  } catch {
+    // Best-effort shutdown for hung worker processes.
+  }
 }

--- a/packages/orchestration/test/orchestration-manager.test.ts
+++ b/packages/orchestration/test/orchestration-manager.test.ts
@@ -376,6 +376,51 @@ describe("OrchestrationManager", () => {
     );
   });
 
+  it("marks the orchestration run as failed when completed with an error", async () => {
+    const sessionDir = await createSessionDir();
+    const runtimeHarness = createRuntimeHarness();
+    const manager = await OrchestrationManager.create({
+      sessionDir,
+      runtime: runtimeHarness.runtime,
+      now: createClock(
+        "2026-03-23T09:04:00.000Z",
+        "2026-03-23T09:04:01.000Z",
+      ),
+    });
+
+    await manager.startRun({
+      runId: "run-failed",
+      initialTask: {
+        id: "task-failed",
+        kind: "deep-research",
+        input: {
+          prompt: "Fail fast on startup timeout",
+        },
+      },
+    });
+
+    await manager.completeRun({
+      status: "failed",
+      error: "Sub-agent worker did not become ready within 5000ms",
+    });
+
+    expect(manager.getSnapshot().run).toMatchObject({
+      id: "run-failed",
+      status: "failed",
+      completedAt: "2026-03-23T09:04:01.000Z",
+    });
+    await expect(OrchestrationStore.loadEvents(sessionDir)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "run_completed",
+          runId: "run-failed",
+          status: "failed",
+          error: "Sub-agent worker did not become ready within 5000ms",
+        }),
+      ]),
+    );
+  });
+
   it("retries attaching a spawned agent after an initial runtime creation failure", async () => {
     const sessionDir = await createSessionDir();
     const runtimeHarness = createFlakyRuntimeHarness();

--- a/packages/orchestration/test/tsconfig.json
+++ b/packages/orchestration/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/plugin-user-memory/test/tsconfig.json
+++ b/packages/plugin-user-memory/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/prompts/test/tsconfig.json
+++ b/packages/prompts/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/runtime-core/test/tsconfig.json
+++ b/packages/runtime-core/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/sandbox/test/tsconfig.json
+++ b/packages/sandbox/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/skills/test/tsconfig.json
+++ b/packages/skills/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/slash-commands/test/tsconfig.json
+++ b/packages/slash-commands/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "../../..",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
         specifier: ^0.18.5
         version: 0.18.5
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14


### PR DESCRIPTION
## Summary
- route `deep_research` stream requests through the playground server's SSE flow instead of falling back to the normal chat agent
- add streaming deep-research execution hooks and orchestration fail-fast handling for sub-agents that never become ready
- improve deep-research failure persistence and add regression tests around stream handling and sub-agent startup
- include the test TypeScript configs needed by the current workspace test setup

## Validation
- `pnpm --filter @agentrail/host test`
- `pnpm --filter @agentrail/deep-research test`
- `pnpm --filter @agentrail/orchestration test -- orchestration-manager.test.ts`
- `pnpm --filter @agentrail/orchestration typecheck`
- `pnpm --filter @agentrail/deep-research typecheck`
- `pnpm --filter @agentrail/playground-server typecheck`
- `pnpm --dir examples/playground-server exec tsx --test test/default-subagent-process.test.ts test/deep-research-stream-handler.test.ts`
- `pnpm build:packages`
