### PR TITLE
fix: add missing shebang to create-agentrail-app CLI

### DIFF
--- a/.changeset/create-agentrail-app-v0.1.1.md
+++ b/.changeset/create-agentrail-app-v0.1.1.md
@@ -1,0 +1,7 @@
+---
+"@agentrail/create-agentrail-app": patch
+---
+
+Fix missing shebang line causing CLI to fail on execution
+
+Added `#!/usr/bin/env node` as the first line of `src/index.ts` so the compiled `dist/index.js` is correctly identified as a Node.js script by the OS. Without this, running `npx @agentrail/create-agentrail-app` failed with "Permission denied" and "Syntax error" because the shell tried to interpret the JavaScript file as a shell script.

--- a/packages/create-agentrail-app/src/index.ts
+++ b/packages/create-agentrail-app/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) 2026 The Agentrail Authors


### PR DESCRIPTION
## Summary

- Added `#!/usr/bin/env node` as the first line of `packages/create-agentrail-app/src/index.ts`
- Without this shebang, the OS has no idea the file should be executed by Node.js, so it falls back to the shell, which fails to parse JavaScript syntax
- Includes a patch changeset (`@agentrail/create-agentrail-app@0.1.1`)

## Root cause

`npm`/`npx` creates a symlink in `.bin/` pointing to `dist/index.js`. When the OS executes a file without a shebang it defaults to `/bin/sh`, which interprets the JS source as shell commands and immediately errors out:

```
create-agentrail-app: 1: /Docker: Permission denied
create-agentrail-app: 2: *: Permission denied
create-agentrail-app: 3: Syntax error: "(" unexpected
```

## Test plan

- [ ] `npx @agentrail/create-agentrail-app my-app` completes successfully after publishing `0.1.1`
- [ ] `dist/index.js` first line is `#!/usr/bin/env node`

Closes #16

Made with [Cursor](https://cursor.com)