### PR TITLE
fix: ignore out-of-docs relative links in VitePress build

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,8 +10,13 @@ export default defineConfig({
 
   cleanUrls: true,
 
-  // Links to source files within the monorepo don't resolve inside the docs site
-  ignoreDeadLinks: [/\/examples\/playground-ui\/src\//],
+  // Links pointing to source files or root-level files outside docs/ are valid
+  // when browsing on GitHub but don't resolve inside the VitePress site.
+  ignoreDeadLinks: [
+    /\.\.\/\.\.\/packages\//,
+    /\.\.\/\.\.\/examples\//,
+    /\.\.\/\.\.\/ROADMAP/,
+  ],
 
   head: [
     ["link", { rel: "icon", type: "image/svg+xml", href: "/agentrail/docs/favicon.svg" }],

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -94,4 +94,4 @@ Use this for container orchestrator liveness and readiness probes.
 
 ## Limitations
 
-The current storage layer is filesystem-based. For horizontal scaling across multiple server instances, you would need a shared filesystem or a custom `AgentrailSessionStore` implementation backed by a database. See [ROADMAP.md](../../ROADMAP.md) for planned improvements.
+The current storage layer is filesystem-based. For horizontal scaling across multiple server instances, you would need a shared filesystem or a custom `AgentrailSessionStore` implementation backed by a database. See the [Roadmap](https://yai-dev.github.io/agentrail/roadmap.html) for planned improvements.


### PR DESCRIPTION
Fixes VitePress build failure caused by dead link checks on relative paths that point to source files outside the `docs/` directory (`../../packages/`, `../../examples/`, `../../ROADMAP`). These links are valid when browsing on GitHub but don't resolve inside the VitePress site — so we tell VitePress to ignore them.

Made with [Cursor](https://cursor.com)