### PR TITLE
fix: surface sandbox errors as SSE, fix budgetUsedPct, scope prompt cache

### DIFF
--- a/.changeset/fix-21-25-30.md
+++ b/.changeset/fix-21-25-30.md
@@ -1,0 +1,18 @@
+---
+"@agentrail/host": patch
+"@agentrail/prompts": patch
+---
+
+Fix sandbox error swallowing, budgetUsedPct hardcoding, and prompt cache leaking
+
+Fixes #21: replace `void ensureSandbox(...)` with a stored promise that is
+awaited inside the streamText callback; failures are surfaced as an SSE error
+event so clients are immediately aware of sandbox startup problems.
+
+Fixes #25: add optional `contextWindow` field to `AgentrailProfile`; stream
+route uses `profile.contextWindow ?? 200_000` instead of the hardcoded 200k,
+giving correct budget percentages for GPT-4o, Gemini, and other models.
+
+Fixes #30: introduce `PromptLoader` class with instance-level mtime cache;
+`createPromptBuilder` now creates a private `PromptLoader` per builder so
+caches never bleed between instances or between test runs.

--- a/packages/host/src/stream-route.ts
+++ b/packages/host/src/stream-route.ts
@@ -172,7 +172,7 @@ export function createStreamRoute(
 
     await options.onRequestStart?.(requestContext);
     await runPluginRequestHook(plugins, "onRequestStart", requestContext);
-    void options.sandboxManager.ensureSandbox(sid, tenantId, userId);
+    const sandboxReady = options.sandboxManager.ensureSandbox(sid, tenantId, userId);
 
     let forwardSubAgentEvent: (event: object) => void = () => {};
     let preloadedProfile: AgentrailProfile | null | undefined;
@@ -218,6 +218,18 @@ export function createStreamRoute(
         await runPluginRequestHook(plugins, "onTurnPersisted", requestContext);
       };
       try {
+        try {
+          await sandboxReady;
+        } catch (err) {
+          const errorEvent: AgentrailErrorEvent = {
+            type: "error",
+            error: { message: `Sandbox initialization failed: ${String(err)}` },
+          };
+          await writeEvent(errorEvent);
+          maybeTraceEvent(errorEvent);
+          return;
+        }
+
         if (options.handleResolvedRequest) {
           const handled = await options.handleResolvedRequest({
             request: {
@@ -346,7 +358,7 @@ export function createStreamRoute(
               type: "context_usage",
               inputTokens: totalInputTokens,
               outputTokens: event.usage.outputTokens ?? 0,
-              budgetUsedPct: Math.round((totalInputTokens / 200_000) * 100),
+              budgetUsedPct: Math.round((totalInputTokens / (profile?.contextWindow ?? 200_000)) * 100),
             };
             await writeEvent(usageEvent);
             break;

--- a/packages/host/src/types.ts
+++ b/packages/host/src/types.ts
@@ -16,6 +16,8 @@ export interface AgentrailProfileContext {
 export interface AgentrailProfile {
   id: string;
   name: string;
+  /** Context window size in tokens for the model used by this profile. Defaults to 200_000. */
+  contextWindow?: number;
   createAgent(
     context: AgentrailProfileContext,
     onSubAgentEvent?: (event: object) => void,

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -58,7 +58,39 @@ const LAYER_ORDER: PromptLayerName[] = [
   "mode",
 ];
 
-const fileCache = new Map<string, CachedPromptFile>();
+/**
+ * A per-instance prompt file loader with its own mtime-based cache.
+ * Using an instance rather than a module-level map prevents cache state
+ * from bleeding between test runs and between independent PromptBuilder
+ * instances.
+ */
+export class PromptLoader {
+  private cache = new Map<string, CachedPromptFile>();
+
+  loadFile(filePath: string, options: LoadPromptFileOptions = {}): string {
+    const { stripMetadata = true, vars = {} } = options;
+    const stats = statSync(filePath);
+    const cached = this.cache.get(filePath);
+
+    let raw: string;
+    if (cached && cached.mtimeMs === stats.mtimeMs) {
+      raw = cached.raw;
+    } else {
+      raw = readFileSync(filePath, "utf8");
+      this.cache.set(filePath, { mtimeMs: stats.mtimeMs, raw });
+    }
+
+    const normalized = stripMetadata ? stripPromptMetadata(raw) : raw.trim();
+    return renderPrompt(normalized, vars);
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+}
+
+// Module-level loader kept for backward compatibility with loadPromptFile().
+const moduleLoader = new PromptLoader();
 
 export function definePromptFragment<T extends PromptFragment>(fragment: T): T {
   return fragment;
@@ -68,8 +100,9 @@ export function definePromptBundle<T extends PromptBundle>(bundle: T): T {
   return bundle;
 }
 
+/** @deprecated Use a PromptLoader instance or createPromptBuilder instead. */
 export function clearPromptFileCache(): void {
-  fileCache.clear();
+  moduleLoader.clearCache();
 }
 
 export function stripPromptMetadata(content: string): string {
@@ -90,39 +123,25 @@ export function renderPrompt(
   });
 }
 
+/** @deprecated Use a PromptLoader instance for isolated caching. */
 export function loadPromptFile(
   filePath: string,
   options: LoadPromptFileOptions = {},
 ): string {
-  const { stripMetadata = true, vars = {} } = options;
-  const stats = statSync(filePath);
-  const cached = fileCache.get(filePath);
-
-  let raw: string;
-  if (cached && cached.mtimeMs === stats.mtimeMs) {
-    raw = cached.raw;
-  } else {
-    raw = readFileSync(filePath, "utf8");
-    fileCache.set(filePath, {
-      mtimeMs: stats.mtimeMs,
-      raw,
-    });
-  }
-
-  const normalized = stripMetadata ? stripPromptMetadata(raw) : raw.trim();
-  return renderPrompt(normalized, vars);
+  return moduleLoader.loadFile(filePath, options);
 }
 
 export function createPromptBuilder(bundle: PromptBundle): PromptBuilder {
+  const loader = new PromptLoader();
   return {
     render(options: PromptRenderOptions = {}): string {
       const source =
         options.bundle ??
         (options.overlay ? mergePromptBundles(bundle, options.overlay) : bundle);
-      return renderPromptBundle(source, options.vars);
+      return renderPromptBundle(source, options.vars, loader);
     },
     clearCache() {
-      clearPromptFileCache();
+      loader.clearCache();
     },
   };
 }
@@ -130,6 +149,7 @@ export function createPromptBuilder(bundle: PromptBundle): PromptBuilder {
 function renderPromptBundle(
   bundle: PromptBundle,
   vars: PromptVars = {},
+  loader: PromptLoader = moduleLoader,
 ): string {
   const mergedVars = {
     ...(bundle.vars ?? {}),
@@ -148,7 +168,7 @@ function renderPromptBundle(
       ...(layer.vars ?? {}),
     };
     for (const fragment of materializeLayer(layer)) {
-      fragments.push(renderPromptFragment(fragment, layerVars));
+      fragments.push(renderPromptFragment(fragment, layerVars, loader));
     }
   }
 
@@ -158,9 +178,9 @@ function renderPromptBundle(
     .join("\n\n");
 }
 
-function renderPromptFragment(fragment: PromptFragment, vars: PromptVars): string {
+function renderPromptFragment(fragment: PromptFragment, vars: PromptVars, loader: PromptLoader = moduleLoader): string {
   if (fragment.filePath) {
-    return loadPromptFile(fragment.filePath, {
+    return loader.loadFile(fragment.filePath, {
       stripMetadata: fragment.stripMetadata,
       vars,
     });


### PR DESCRIPTION
## Summary

- Fixes #21: `void ensureSandbox()` is replaced with a stored promise awaited inside the `streamText` callback; startup failures are emitted as SSE `error` events, giving clients and developers immediate, actionable feedback instead of silent breakage
- Fixes #25: add optional `contextWindow` field to `AgentrailProfile`; `budgetUsedPct` now divides by `profile.contextWindow ?? 200_000` instead of the hardcoded Claude constant — GPT-4o, Gemini, and other models will now report correct context budget percentages
- Fixes #30: introduce `PromptLoader` class with an instance-level mtime cache; `createPromptBuilder` creates a private `PromptLoader` per builder so prompt file caches never bleed between builder instances or between test runs

## Changes

**`packages/host/src/types.ts`**
- `AgentrailProfile`: add optional `contextWindow?: number` field

**`packages/host/src/stream-route.ts`**
- Store `ensureSandbox` promise; await inside `streamText` with SSE error on failure
- Compute `budgetUsedPct` using `profile.contextWindow ?? 200_000`

**`packages/prompts/src/index.ts`**
- New `PromptLoader` class with instance-level cache and `loadFile`/`clearCache` methods
- `createPromptBuilder` uses a private `PromptLoader` per instance
- Module-level `loadPromptFile` and `clearPromptFileCache` kept for backward compatibility (now delegate to a module-level `PromptLoader` instance)

## Test plan

- [x] Run `pnpm -F @agentrail/prompts test` — all 5 tests pass
- [x] Run `pnpm -F @agentrail/host exec vitest run test/chat-route.test.ts` — all 3 tests pass
- [x] Start server with Docker stopped; confirm the stream endpoint emits `{"type":"error","error":{"message":"Sandbox initialization failed: ..."}}` instead of hanging or returning a confusing tool error
- [x] Configure a profile with `contextWindow: 128_000`; confirm `budgetUsedPct` in SSE events reflects the 128k window