### PR TITLE
fix(docs): set base to "/" for custom domain agentrail.run

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   description:
     "Open-source agent harness framework for building, hosting, and orchestrating tool-using AI agents.",
 
-  // Deployed at https://yai-dev.github.io/agentrail/
-  base: "/agentrail/",
+  // Custom domain: https://agentrail.run (root path, no sub-directory prefix)
+  base: "/",
 
   cleanUrls: true,
   appearance: "force-dark",


### PR DESCRIPTION
## Problem

After adding the custom domain `https://agentrail.run`, all static assets returned 404. The browser was requesting paths like `/agentrail/assets/style.xxx.css` but the server serves files from the root `/`.

Root cause: `docs/.vitepress/config.ts` had `base: "/agentrail/"` which matched the old GitHub Pages default URL (`yai-dev.github.io/agentrail/`). With a custom domain the site root is `/`, so the prefix is wrong.

## Fix

Change `base` from `"/agentrail/"` to `"/"` in `docs/.vitepress/config.ts`.

## Test plan

- [x] Merge and let GitHub Actions redeploy the docs site
- [x] Verify `https://agentrail.run` loads correctly with no 404s for CSS/JS assets