### PR TITLE
fix(docs): update links in HomeLayout.vue to remove agentrail prefix

### DIFF
--- a/docs/.vitepress/theme/HomeLayout.vue
+++ b/docs/.vitepress/theme/HomeLayout.vue
@@ -16,7 +16,7 @@
           locking you into any platform.
         </p>
         <div class="at-hero-actions">
-          <a href="/agentrail/guides/quickstart" class="at-btn at-btn-primary">
+          <a href="/guides/quickstart" class="at-btn at-btn-primary">
             Quickstart →
           </a>
           <a
@@ -190,7 +190,7 @@
             {{ installCopied ? 'copied!' : 'copy' }}
           </button>
         </div>
-        <a href="/agentrail/guides/quickstart" class="at-btn at-btn-primary">
+        <a href="/guides/quickstart" class="at-btn at-btn-primary">
           Read the quickstart →
         </a>
       </div>
@@ -281,8 +281,8 @@
           Agentrail
         </div>
         <ul class="at-footer-links">
-          <li><a href="/agentrail/guides/quickstart">Docs</a></li>
-          <li><a href="/agentrail/roadmap">Roadmap</a></li>
+          <li><a href="/guides/quickstart">Docs</a></li>
+          <li><a href="/roadmap">Roadmap</a></li>
           <li
           ><a
               href="https://github.com/yai-dev/agentrail"


### PR DESCRIPTION
update links in HomeLayout.vue to remove agentrail prefix