### PR TITLE
chore: add missing changeset for @agentrail/runtime-core (PR #78)

### DIFF
--- a/.changeset/runtime-core-0.0.3.md
+++ b/.changeset/runtime-core-0.0.3.md
@@ -1,0 +1,9 @@
+---
+"@agentrail/runtime-core": minor
+---
+
+Make `LlmProviderRegistry` instantiable and add `llmClient` injection to `AgentConfig`.
+
+- `LlmProviderRegistry`: constructor is no longer `private`, allowing callers to create independent instances without sharing the global singleton. `getInstance()` and `resetInstance()` are preserved for backward compatibility.
+- `AgentConfig`: new optional `llmClient?: LlmClient` field for injecting a client directly into an agent definition.
+- `AgentImpl`: uses the injected client in `stream()` when provided, falling back to `new DefaultLlmClient()` when not — existing behavior is unchanged.


### PR DESCRIPTION
## Summary

PR #78 was merged without a changeset. This adds the missing one.

**Package:** `@agentrail/runtime-core` — `minor` bump (`0.0.2` → `0.0.3`)

**Changes covered:**
- `LlmProviderRegistry`: constructor made non-private, enabling independent instances
- `AgentConfig`: new optional `llmClient?: LlmClient` field
- `AgentImpl`: uses injected `llmClient` with fallback to `DefaultLlmClient`

Closes #78 (retroactive changeset).