### PR TITLE
chore: add missing changeset for @agentrail/host toolset sort (PR #75)

### DIFF
--- a/.changeset/host-toolset-sort-0.0.5.md
+++ b/.changeset/host-toolset-sort-0.0.5.md
@@ -1,0 +1,7 @@
+---
+"@agentrail/host": patch
+---
+
+Sort the assembled tool list alphabetically by name in `createDefaultToolset` to ensure a deterministic tool order across requests.
+
+Previously, tool order depended on import order and conditional inclusion, which could vary between requests and invalidate the LLM provider's prompt cache, incurring full input token costs on every call.


### PR DESCRIPTION
## Summary

PR #75 was merged without a changeset. This adds the missing one.

**Package:** `@agentrail/host` — `patch` bump

**Change covered:** Sort assembled tool list alphabetically by name in `createDefaultToolset` to guarantee deterministic tool order and preserve LLM prompt cache hits across requests.

Closes #58 (changeset entry).