### PR TITLE
chore: fix stale changeset package references after consolidation

### DIFF
--- a/.changeset/host-toolset-sort-0.0.5.md
+++ b/.changeset/host-toolset-sort-0.0.5.md
@@ -1,5 +1,5 @@
 ---
-"@agentrail/host": patch
+"@agentrail/app": patch
 ---
 
 Sort the assembled tool list alphabetically by name in `createDefaultToolset` to ensure a deterministic tool order across requests.

--- a/.changeset/orchestration-concurrent-runs.md
+++ b/.changeset/orchestration-concurrent-runs.md
@@ -1,5 +1,5 @@
 ---
-"@agentrail/orchestration": patch
+"@agentrail/capabilities": patch
 ---
 
 Support multiple concurrent orchestration runs in a single `OrchestrationManager`.

--- a/.changeset/sessiondir-sandbox-cleanup.md
+++ b/.changeset/sessiondir-sandbox-cleanup.md
@@ -1,10 +1,7 @@
 ---
+"@agentrail/app": patch
+"@agentrail/capabilities": patch
 "@agentrail/deep-research": patch
-"@agentrail/host": patch
-"@agentrail/memo": patch
-"@agentrail/orchestration": patch
-"@agentrail/sandbox": patch
-"@agentrail/tools": patch
 ---
 
 Finish the session storage and sandbox execution cleanup across the framework packages.


### PR DESCRIPTION
## Summary

- Remap `@agentrail/host` → `@agentrail/app` in two changesets
- Remap `@agentrail/orchestration` → `@agentrail/capabilities`
- Remove references to deleted packages (`@agentrail/memo`, `@agentrail/sandbox`, `@agentrail/tools`) that were merged during the consolidation refactor

Fixes the release CI error:
```
Error: Found changeset host-toolset-sort-0.0.5 for package @agentrail/host which is not in the workspace
```