### PR TITLE
fix: security alerts - upgrade deps and fix code scanning issues

### DIFF
--- a/.changeset/fix-security-redos-deps.md
+++ b/.changeset/fix-security-redos-deps.md
@@ -1,0 +1,11 @@
+---
+"@agentrail/app": patch
+"@agentrail/deep-research": patch
+---
+
+fix: upgrade dependencies and harden regex patterns against ReDoS
+
+- Upgrade `hono` to ^4.12.12, `@hono/node-server` to ^1.19.13, and `vite` to ^6.4.2 to address known CVEs
+- Replace `stripHtml` regex chain with `node-html-parser` to eliminate polynomial ReDoS and handle malformed HTML robustly
+- Bound all unbounded quantifiers (`\d+`, ` +`) in compaction and fenced-code-block regexes to prevent ReDoS on crafted input
+- Remove Chinese-only regex fallbacks (`extractOfficialName`, `extractExcludedEntities`, etc.) that were non-functional for non-Chinese users; rely on structured LLM output instead


### PR DESCRIPTION
## Summary

- Upgrade `hono` ^4.7.4 → ^4.12.12, `@hono/node-server` ^1.13.7 → ^1.19.13, `vite` ^6.0.0 → ^6.4.2 to address known CVEs (medium/high Dependabot alerts)
- Replace `stripHtml` regex chain with `node-html-parser` to eliminate `js/polynomial-redos` and `js/double-escaping` CodeQL alerts in `deep-research/tools.ts`
- Bound all unbounded quantifiers in compaction and fenced-code-block regexes (`COMPRESSED_COUNT_RE`, `FENCED_JSON_RE`) to fix remaining `js/polynomial-redos` alerts
- Fix `js/bad-tag-filter` by matching whitespace before `>` in script close-tag pattern
- Remove Chinese-only regex fallbacks (`extractOfficialName`, `extractExcludedEntities`, `extractRelatedEntities`, `extractAliases`, `deriveScopeTerms`, `inferProfileModeFromQuery`) that were non-functional for non-Chinese users; rely on structured LLM `entityProfile` output instead

> **xlsx alerts #2–#5**: no upstream patch available; applies only to private example code. Dismiss manually via Security tab as `tolerable_risk`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] CodeQL re-scan on PR branch — all previous alerts marked Fixed