### PR TITLE
feat: stabilise public contracts — rename RuntimeEvent discriminants (#70)

### DIFF
--- a/.changeset/stable-contracts-events.md
+++ b/.changeset/stable-contracts-events.md
@@ -1,0 +1,27 @@
+---
+"@agentrail/core": minor
+"@agentrail/app": minor
+---
+
+Rename `RuntimeEvent` discriminants to a dotted-namespace convention and stabilise public contracts.
+
+**Breaking (minor):** All `RuntimeEvent` type strings have been renamed:
+
+| Old | New |
+|-----|-----|
+| `agent_start` | `session.start` |
+| `agent_end` | `session.end` |
+| `turn_start` | `turn.start` |
+| `turn_end` | `turn.complete` |
+| `message_start` | `message.start` |
+| `message_update` | `message.update` |
+| `message_end` | `message.end` |
+| `tool_execution_start` | `tool.before` |
+| `tool_execution_update` | `tool.update` |
+| `tool_execution_end` | `tool.after` |
+
+New events added: `compaction`, `subagent.spawn`, `subagent.complete`.
+
+Deprecated type aliases (`AgentStartEvent`, `AgentEndEvent`, `TurnStartEvent`, `TurnEndEvent`, etc.) are exported for migration and will be removed in the next major version.
+
+`AgentrailPlugin` now has an optional `version?: string` field. `AgentrailSessionStore` and `AgentrailPlugin` interfaces gain comprehensive JSDoc.

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -14,21 +14,23 @@ Events in Agentrail come from three sources:
 
 ### 1. Runtime Core Events
 
-Emitted by the agent loop as it executes. These cover the execution narrative of a single turn:
+Emitted by the agent loop as it executes. These cover the execution narrative of a single turn.
+Event types follow a dotted-namespace convention (`session.*`, `turn.*`, `message.*`, `tool.*`):
 
 | Event                    | When It Fires                                                   |
 | ------------------------ | --------------------------------------------------------------- |
-| `agent_start`            | Agent loop begins                                               |
-| `turn_start`             | A new LLM call round begins                                     |
-| `message_start`          | LLM starts generating a response                                |
-| `message_update`         | LLM emits a text delta                                          |
-| `message_end`            | LLM finishes the response                                       |
-| `tool_execution_start`   | A tool call is being executed                                   |
-| `tool_execution_end`     | A tool call completes                                           |
-| `turn_end`               | The LLM call round finishes                                     |
+| `session.start`          | Agent loop begins                                               |
+| `turn.start`             | A new LLM call round begins                                     |
+| `message.start`          | LLM starts generating a response                                |
+| `message.update`         | LLM emits a text delta                                          |
+| `message.end`            | LLM finishes the response                                       |
+| `tool.before`            | A tool call is about to be executed                             |
+| `tool.update`            | A streaming tool emits a partial result                         |
+| `tool.after`             | A tool call completes (success or error)                        |
+| `turn.complete`          | The LLM call round finishes                                     |
 | `max_turns_reached`      | Agent hit its turn limit                                        |
 | `waiting_for_user_input` | A tool is waiting for user interaction                          |
-| `agent_end`              | Agent loop finishes — includes all new messages and total usage |
+| `session.end`            | Agent loop finishes — includes all new messages and total usage |
 | `error`                  | An unrecoverable error occurred                                 |
 
 ### 2. Host-Level Events
@@ -68,12 +70,12 @@ The mapping is done by `mapOrchestrationEvent` in `@agentrail/app`, so UIs do no
 ```
 runtime-core          host             SSE stream             UI
 ────────────          ────             ──────────             ──
-agent_start      ──►  forward     ──►  JSON line         ──►  start indicator
-turn_start       ──►  forward     ──►                    ──►
-message_update   ──►  forward     ──►                    ──►  text delta
-tool_exec_start  ──►  forward     ──►                    ──►  tool indicator
-tool_exec_end    ──►  forward     ──►                    ──►
-agent_end        ──►  forward     ──►                    ──►  final usage
+session.start    ──►  forward     ──►  JSON line         ──►  start indicator
+turn.start       ──►  forward     ──►                    ──►
+message.update   ──►  forward     ──►                    ──►  text delta
+tool.before      ──►  forward     ──►                    ──►  tool indicator
+tool.after       ──►  forward     ──►                    ──►
+session.end      ──►  forward     ──►                    ──►  final usage
 compaction_start ──►  (host adds) ──►                    ──►  compaction badge
 context_usage    ──►  (host adds) ──►                    ──►  budget bar
 ```
@@ -106,7 +108,7 @@ while (true) {
   if (done) break;
   for (const line of decoder.decode(value).split("\n").filter(Boolean)) {
     const event = JSON.parse(line);
-    if (event.type === "message_update") {
+    if (event.type === "message.update") {
       process.stdout.write(event.delta ?? "");
     }
   }

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -72,7 +72,7 @@ Every `execute` function must return a `ToolResult`:
 
 ## Streaming Tool Updates
 
-For long-running tools, use `ctx.onUpdate` to emit intermediate results while the tool is still executing. The host forwards these as `tool_execution_update` events over SSE:
+For long-running tools, use `ctx.onUpdate` to emit intermediate results while the tool is still executing. The host forwards these as `tool.update` events over SSE:
 
 ```ts
 .execute(async (params, ctx) => {

--- a/docs/examples/playground-ui.md
+++ b/docs/examples/playground-ui.md
@@ -99,17 +99,17 @@ async function sendMessage(
 ```ts
 function handleEvent(event: AgentrailEvent, state: ChatState): ChatState {
   switch (event.type) {
-    case "message_update":
+    case "message.update":
       // Streaming text delta from the LLM
       return { ...state, text: state.text + (event.delta ?? "") };
 
-    case "tool_execution_start":
+    case "tool.before":
       return {
         ...state,
-        tools: [...state.tools, { name: event.tool?.name ?? "tool", status: "running" }],
+        tools: [...state.tools, { name: event.toolName, status: "running" }],
       };
 
-    case "tool_execution_end":
+    case "tool.after":
       return {
         ...state,
         tools: state.tools.map((t) => (t.status === "running" ? { ...t, status: "done" } : t)),
@@ -126,7 +126,7 @@ function handleEvent(event: AgentrailEvent, state: ChatState): ChatState {
       console.log("Compaction complete.");
       return state;
 
-    case "agent_end":
+    case "session.end":
       return { ...state, isStreaming: false };
 
     case "error":

--- a/docs/guides/consume-stream.md
+++ b/docs/guides/consume-stream.md
@@ -18,7 +18,7 @@ When you `POST` to a stream endpoint:
 1. The server immediately begins executing the agent and starts streaming.
 2. The response body is a series of newline-separated JSON objects, one event per line.
 3. The response header `X-Session-Id` contains the session ID for subsequent requests.
-4. The stream closes after the `agent_end` event and any final host events (`context_usage`).
+4. The stream closes after the `session.end` event and any final host events (`context_usage`).
 
 Each line in the body is a serialized `AgentrailEvent` from `@agentrail/app`. The event's `type` field identifies what happened.
 
@@ -84,15 +84,15 @@ Handle these events to build a complete streaming UI:
 
 | Event type                 | When                      | Key fields                                     |
 | -------------------------- | ------------------------- | ---------------------------------------------- |
-| `message_start`            | LLM starts generating     | —                                              |
-| `message_update`           | Text delta from LLM       | `delta: string`                                |
-| `message_end`              | LLM finished generating   | —                                              |
-| `tool_execution_start`     | Agent begins a tool call  | `toolName`, `toolCallId`, `label`              |
-| `tool_execution_end`       | Tool call completes       | `toolCallId`, `result`                         |
+| `message.start`            | LLM starts generating     | —                                              |
+| `message.update`           | Text delta from LLM       | `delta: string`                                |
+| `message.end`              | LLM finished generating   | —                                              |
+| `tool.before`              | Agent begins a tool call  | `toolName`, `toolCallId`                       |
+| `tool.after`               | Tool call completes       | `toolCallId`, `result`                         |
 | `context_compaction_start` | History compaction begins | —                                              |
 | `context_compaction_end`   | Compaction finished       | —                                              |
 | `context_usage`            | Token budget after turn   | `inputTokens`, `outputTokens`, `budgetUsedPct` |
-| `agent_end`                | Agent loop finished       | `messages`, `usage`                            |
+| `session.end`              | Agent loop finished       | `messages`, `usage`                            |
 | `error`                    | Unrecoverable error       | `error.message`                                |
 
 ## Example Event Handler
@@ -102,17 +102,17 @@ import type { AgentrailEvent } from "@agentrail/app";
 
 function handleEvent(event: AgentrailEvent) {
   switch (event.type) {
-    case "message_update":
+    case "message.update":
       // Append text delta to the UI
       appendText(event.delta ?? "");
       break;
 
-    case "tool_execution_start":
+    case "tool.before":
       // Show a tool-in-progress indicator
-      showToolIndicator(event.label ?? event.toolName, "running");
+      showToolIndicator(event.toolName, "running");
       break;
 
-    case "tool_execution_end":
+    case "tool.after":
       // Update indicator to completed
       showToolIndicator(event.toolCallId, "done");
       break;
@@ -130,7 +130,7 @@ function handleEvent(event: AgentrailEvent) {
       updateBudgetBar(event.budgetUsedPct ?? 0);
       break;
 
-    case "agent_end":
+    case "session.end":
       // Final usage stats
       console.log("Total tokens:", event.usage?.totalTokens);
       break;

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -186,17 +186,19 @@ interface AgentrailSubagentClosedEvent {
 
 ## Runtime Events (Summary)
 
-Runtime events come from `@agentrail/core` and are emitted during agent execution. The most important ones for UI consumers:
+Runtime events come from `@agentrail/core` and are emitted during agent execution.
+Types use a dotted-namespace convention (`session.*`, `turn.*`, `message.*`, `tool.*`).
+The most important ones for UI consumers:
 
 | Event type                  | When emitted                               |
 | --------------------------- | ------------------------------------------ |
-| `agent_start`               | Agent begins processing a request          |
-| `agent_end`                 | Agent finishes (all turns complete)        |
-| `turn_start`                | A new LLM turn starts                      |
-| `turn_end`                  | A turn finishes                            |
-| `message_update`            | Streaming text delta from the LLM          |
-| `tool_execution_start`      | The agent begins invoking a tool           |
-| `tool_execution_end`        | A tool invocation completes                |
+| `session.start`             | Agent begins processing a request          |
+| `session.end`               | Agent finishes (all turns complete)        |
+| `turn.start`                | A new LLM turn starts                      |
+| `turn.complete`             | A turn finishes                            |
+| `message.update`            | Streaming text delta from the LLM          |
+| `tool.before`               | The agent is about to invoke a tool        |
+| `tool.after`                | A tool invocation completes                |
 | `waiting_for_user_input`    | The agent is paused waiting for user input |
 | `skill_start` / `skill_end` | A skill sub-agent is invoked               |
 
@@ -204,7 +206,7 @@ Runtime events come from `@agentrail/core` and are emitted during agent executio
 
 ## Trace Persistence
 
-Not all events are persisted to the trace log. High-frequency streaming events (`message_update`, `turn_start`, `turn_end`) are intentionally excluded to avoid log bloat.
+Not all events are persisted to the trace log. High-frequency streaming events (`message.update`, `message.start`, `message.end`) are intentionally excluded to avoid log bloat.
 
 The `TRACE_PERSISTED_EVENT_TYPES` set defines what gets persisted:
 
@@ -212,8 +214,8 @@ The `TRACE_PERSISTED_EVENT_TYPES` set defines what gets persisted:
 import { TRACE_PERSISTED_EVENT_TYPES } from "@agentrail/app";
 
 // Runtime / skill events that are persisted:
-// "agent_start", "agent_end", "turn_start", "turn_end",
-// "tool_execution_start", "tool_execution_end",
+// "session.start", "session.end", "turn.start", "turn.complete",
+// "tool.before", "tool.after",
 // "skill_start", "skill_end", "waiting_for_user_input",
 // "context_compaction_start", "context_compaction_end", "error"
 //
@@ -275,13 +277,13 @@ async function streamChat(message: string, sessionId?: string) {
 
 function handleEvent(event: AgentrailEvent) {
   switch (event.type) {
-    case "message_update":
+    case "message.update":
       appendText(event.delta ?? "");
       break;
-    case "tool_execution_start":
-      showToolSpinner(event.tool?.name ?? "tool");
+    case "tool.before":
+      showToolSpinner(event.toolName ?? "tool");
       break;
-    case "tool_execution_end":
+    case "tool.after":
       hideToolSpinner();
       break;
     case "context_usage":
@@ -302,7 +304,7 @@ function handleEvent(event: AgentrailEvent) {
     case "subagent_status":
       updateSubagentStatus(event.agentId, event.status);
       break;
-    case "agent_end":
+    case "session.end":
       markComplete();
       break;
     case "error":

--- a/docs/reference/plugin-contract.md
+++ b/docs/reference/plugin-contract.md
@@ -42,6 +42,8 @@ The current plugin contract is defined by `AgentrailPlugin` in:
 interface AgentrailPlugin {
   /** Stable identifier used in diagnostics and assembly logs */
   name: string;
+  /** Semantic version string (e.g. `"1.0.0"`) — recommended for diagnostics */
+  version?: string;
   /** Runs when the host starts the plugin lifecycle */
   start?(): void | Promise<void>;
   /** Runs when the host shuts plugins down */
@@ -108,6 +110,12 @@ type ContextProvider = (
 ### `name`
 
 A stable plugin identifier for diagnostics and assembly.
+
+### `version`
+
+Optional semantic version string (`MAJOR.MINOR.PATCH`) for the plugin implementation.
+Providing a version is recommended — it appears in host diagnostic logs and makes it
+easier to correlate issues across deployments.
 
 ### `start` / `stop`
 
@@ -194,6 +202,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 // --- Full plugin ---
 export const observabilityPlugin: AgentrailPlugin = {
   name: "observability",
+  version: "1.0.0",
 
   start() {
     heartbeatTimer = setInterval(() => {

--- a/examples/playground-server/src/agents/ingestion-agent.ts
+++ b/examples/playground-server/src/agents/ingestion-agent.ts
@@ -138,7 +138,7 @@ export async function runIngestionAgent(
         throw new Error(msg);
       }
 
-      if (event.type === "tool_execution_start") {
+      if (event.type === "tool.before") {
         const { toolCallId, args } = event as {
           type: string;
           toolCallId: string;
@@ -150,7 +150,7 @@ export async function runIngestionAgent(
         }
       }
 
-      if (event.type === "tool_execution_end") {
+      if (event.type === "tool.after") {
         const { toolCallId, toolName } = event as {
           type: string;
           toolCallId: string;
@@ -187,7 +187,7 @@ export async function runIngestionAgent(
         }
       }
 
-      if (event.type === "agent_end") break;
+      if (event.type === "session.end") break;
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/examples/playground-server/src/agents/summarizer.ts
+++ b/examples/playground-server/src/agents/summarizer.ts
@@ -123,10 +123,10 @@ export function buildSummarizeFn(): (messages: Message[]) => Promise<string> {
         const msg = (event.error as Error)?.message ?? "unknown error";
         return `(summarization failed: ${msg})`;
       }
-      if (event.type === "message_update" && event.event.type === "text_delta") {
+      if (event.type === "message.update" && event.event.type === "text_delta") {
         summary += event.event.delta;
       }
-      if (event.type === "agent_end") break;
+      if (event.type === "session.end") break;
     }
     return summary.trim() || "(summarization produced no output)";
   };

--- a/examples/playground-server/src/agents/user-preference-summarizer.ts
+++ b/examples/playground-server/src/agents/user-preference-summarizer.ts
@@ -161,10 +161,10 @@ async function runSummarizeUserPreferences(tenantId: string, userId: string): Pr
     `From the following conversation excerpt(s), extract user preferences and focus areas for USER.md:\n\n${formatted}`,
   )) {
     if (isRuntimeError(event)) return;
-    if (event.type === "message_update" && event.event.type === "text_delta") {
+    if (event.type === "message.update" && event.event.type === "text_delta") {
       summary += event.event.delta;
     }
-    if (event.type === "agent_end") break;
+    if (event.type === "session.end") break;
   }
   summary = summary.trim();
   if (!summary) return;

--- a/examples/playground-server/test/trace-route.test.ts
+++ b/examples/playground-server/test/trace-route.test.ts
@@ -41,7 +41,7 @@ test("trace route returns merged runtime and orchestration events", async () => 
     sequence: 0,
     source: "runtime",
     event: {
-      type: "agent_start",
+      type: "session.start",
     },
   });
   await persistence.appendEvent({

--- a/examples/playground-ui/src/App.tsx
+++ b/examples/playground-ui/src/App.tsx
@@ -497,8 +497,8 @@ export default function App() {
                 ];
               }
             });
-          } else if (event.type === "turn_end") {
-            const te = event as { type: "turn_end"; message: { stopReason: string } };
+          } else if (event.type === "turn.complete") {
+            const te = event as { type: "turn.complete"; message: { stopReason: string } };
             if (te.message?.stopReason === "error") {
               patchLastAssistant((m) => ({
                 ...m,
@@ -530,8 +530,8 @@ export default function App() {
               outputTokens: cu.outputTokens,
               budgetUsedPct: cu.budgetUsedPct,
             });
-          } else if (event.type === "agent_end") {
-            const ae = event as { type: "agent_end"; usage: UsageStat };
+          } else if (event.type === "session.end") {
+            const ae = event as { type: "session.end"; usage: UsageStat };
             patchLastAssistant((m) => ({ ...m, usage: ae.usage, streaming: false }));
             // Clear any lingering direct-mode skill indicator (direct mode has no skill_end event).
             if (activeSkillRef.current !== null) {

--- a/examples/playground-ui/src/api.ts
+++ b/examples/playground-ui/src/api.ts
@@ -36,20 +36,20 @@ export interface ContextUsageStat {
 
 export type StreamEvent =
   | { type: "session_id"; sessionId: string }
-  | { type: "agent_start" }
-  | { type: "agent_end"; usage: UsageStat }
+  | { type: "session.start" }
+  | { type: "session.end"; usage: UsageStat }
   | { type: "context_usage"; inputTokens: number; outputTokens: number; budgetUsedPct: number }
   | { type: "context_compaction_start" }
   | { type: "context_compaction_end" }
-  | { type: "turn_start" }
-  | { type: "turn_end"; message: { stopReason: string } }
-  | { type: "message_start" }
-  | { type: "message_end" }
-  | { type: "message_update"; event: LlmEvent }
-  | { type: "tool_execution_start"; toolCallId: string; toolName: string; args: unknown }
-  | { type: "tool_execution_update"; toolCallId: string; toolName: string; partialResult: unknown }
+  | { type: "turn.start" }
+  | { type: "turn.complete"; message: { stopReason: string } }
+  | { type: "message.start" }
+  | { type: "message.end" }
+  | { type: "message.update"; event: LlmEvent }
+  | { type: "tool.before"; toolCallId: string; toolName: string; args: unknown }
+  | { type: "tool.update"; toolCallId: string; toolName: string; partialResult: unknown }
   | {
-      type: "tool_execution_end";
+      type: "tool.after";
       toolCallId: string;
       toolName: string;
       result: unknown;

--- a/examples/playground-ui/src/hooks/useAgentTrace.ts
+++ b/examples/playground-ui/src/hooks/useAgentTrace.ts
@@ -59,7 +59,7 @@ export function useAgentTrace() {
     (event: StreamEvent) => {
       const now = Date.now();
 
-      if (event.type === "agent_start") {
+      if (event.type === "session.start") {
         const id = crypto.randomUUID();
         currentTraceIdRef.current = id;
         activeLlmIdRef.current = {};
@@ -78,7 +78,7 @@ export function useAgentTrace() {
         activeSkillRef.current = se.skillName;
       } else if (event.type === "skill_end") {
         activeSkillRef.current = null;
-      } else if (event.type === "turn_start") {
+      } else if (event.type === "turn.start") {
         const source: "main" | "skill" = activeSkillRef.current ? "skill" : "main";
         const id = crypto.randomUUID();
         activeLlmIdRef.current[source] = id;
@@ -93,8 +93,8 @@ export function useAgentTrace() {
           skillName: activeSkillRef.current ?? undefined,
         };
         appendStep(step);
-      } else if (event.type === "turn_end") {
-        const te = event as { type: "turn_end"; message: { stopReason: string } };
+      } else if (event.type === "turn.complete") {
+        const te = event as { type: "turn.complete"; message: { stopReason: string } };
         const source: "main" | "skill" = activeSkillRef.current ? "skill" : "main";
         const id = activeLlmIdRef.current[source];
         if (!id) return;
@@ -106,9 +106,9 @@ export function useAgentTrace() {
           stopReason: te.message?.stopReason,
           status: te.message?.stopReason === "error" ? "error" : "done",
         }));
-      } else if (event.type === "tool_execution_start") {
+      } else if (event.type === "tool.before") {
         const tes = event as {
-          type: "tool_execution_start";
+          type: "tool.before";
           toolCallId: string;
           toolName: string;
           args: unknown;
@@ -128,9 +128,9 @@ export function useAgentTrace() {
           parentLlmId,
         };
         appendStep(step);
-      } else if (event.type === "tool_execution_end") {
+      } else if (event.type === "tool.after") {
         const tee = event as {
-          type: "tool_execution_end";
+          type: "tool.after";
           toolCallId: string;
           result: unknown;
           isError: boolean;
@@ -142,9 +142,9 @@ export function useAgentTrace() {
           isError: tee.isError,
           status: tee.isError ? "error" : "done",
         }));
-      } else if (event.type === "agent_end") {
+      } else if (event.type === "session.end") {
         const ae = event as {
-          type: "agent_end";
+          type: "session.end";
           usage: { inputTokens: number; outputTokens: number };
         };
         const traceId = currentTraceIdRef.current;

--- a/examples/playground-ui/src/hooks/useWorkflowTrace.ts
+++ b/examples/playground-ui/src/hooks/useWorkflowTrace.ts
@@ -131,12 +131,12 @@ export function useWorkflowTrace(sessionId: string | null): UseWorkflowTraceResu
  * since playground-ui doesn't depend on that package).
  */
 const TRACE_EVENT_TYPES = new Set([
-  "agent_start",
-  "agent_end",
-  "turn_start",
-  "turn_end",
-  "tool_execution_start",
-  "tool_execution_end",
+  "session.start",
+  "session.end",
+  "turn.start",
+  "turn.complete",
+  "tool.before",
+  "tool.after",
   "skill_start",
   "skill_end",
   "waiting_for_user_input",
@@ -185,7 +185,7 @@ function projectEnvelopesToTraces(envelopes: WorkflowTraceEventEnvelope[]): Agen
     // Use envelope timestamp as a proxy for arrival time (ms since epoch)
     const now = new Date(envelope.timestamp).getTime();
 
-    if (type === "agent_start") {
+    if (type === "session.start") {
       currentTrace = {
         id: envelope.id,
         startTime: now,
@@ -201,7 +201,7 @@ function projectEnvelopesToTraces(envelopes: WorkflowTraceEventEnvelope[]): Agen
       activeSkill = (event.skillName as string | undefined) ?? null;
     } else if (type === "skill_end") {
       activeSkill = null;
-    } else if (type === "turn_start") {
+    } else if (type === "turn.start") {
       const source: "main" | "skill" = activeSkill ? "skill" : "main";
       const id = envelope.id + "-llm";
       activeLlmId[source] = id;
@@ -215,7 +215,7 @@ function projectEnvelopesToTraces(envelopes: WorkflowTraceEventEnvelope[]): Agen
         skillName: activeSkill ?? undefined,
       };
       appendStep(step);
-    } else if (type === "turn_end") {
+    } else if (type === "turn.complete") {
       const source: "main" | "skill" = activeSkill ? "skill" : "main";
       const id = activeLlmId[source];
       if (id) {
@@ -228,7 +228,7 @@ function projectEnvelopesToTraces(envelopes: WorkflowTraceEventEnvelope[]): Agen
           status: stopReason === "error" ? "error" : "done",
         }));
       }
-    } else if (type === "tool_execution_start") {
+    } else if (type === "tool.before") {
       const source: "main" | "skill" = activeSkill ? "skill" : "main";
       const step: ToolCallStep = {
         kind: "tool",
@@ -242,7 +242,7 @@ function projectEnvelopesToTraces(envelopes: WorkflowTraceEventEnvelope[]): Agen
         parentLlmId: activeLlmId[source],
       };
       appendStep(step);
-    } else if (type === "tool_execution_end") {
+    } else if (type === "tool.after") {
       const toolCallId = (event.toolCallId as string) ?? envelope.id;
       patchStep(toolCallId, (s) => ({
         ...s,
@@ -251,7 +251,7 @@ function projectEnvelopesToTraces(envelopes: WorkflowTraceEventEnvelope[]): Agen
         isError: !!event.isError,
         status: event.isError ? "error" : "done",
       }));
-    } else if (type === "agent_end") {
+    } else if (type === "session.end") {
       if (currentTrace) {
         const usage = event.usage as { inputTokens: number; outputTokens: number } | undefined;
         currentTrace.endTime = now;

--- a/packages/app/src/events/index.ts
+++ b/packages/app/src/events/index.ts
@@ -142,12 +142,12 @@ export type AgentrailEvent = RuntimeEvent | ExtendedSseEvent | AgentrailHostEven
  */
 export const TRACE_PERSISTED_EVENT_TYPES = new Set([
   // Runtime / skill events
-  "agent_start",
-  "agent_end",
-  "turn_start",
-  "turn_end",
-  "tool_execution_start",
-  "tool_execution_end",
+  "session.start",
+  "session.end",
+  "turn.start",
+  "turn.complete",
+  "tool.before",
+  "tool.after",
   "skill_start",
   "skill_end",
   "waiting_for_user_input",

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -110,18 +110,84 @@ export interface AgentrailRequestLifecycleContext {
   agentId: string;
 }
 
-/** Lightweight host extension contract for request interception and lifecycle hooks. */
+/**
+ * Lightweight host extension contract for request interception and lifecycle hooks.
+ *
+ * A plugin is a named, optionally versioned object that the host mounts at startup.
+ * Plugins can intercept incoming requests, supply context providers to every agent
+ * call, handle file attachments, and observe request/turn lifecycle events.
+ *
+ * ### Lifecycle
+ * 1. `start()` — called once when `createAgentApp` initialises. Use to open
+ *    connections or warm up caches.
+ * 2. Per-request hooks run in declaration order:
+ *    `interceptChatRequest` → `onRequestStart` → _(agent runs)_ → `onRequestEnd`
+ *    → `onTurnPersisted`
+ * 3. `stop()` — called on graceful shutdown. Use to flush buffers and close
+ *    connections.
+ *
+ * @see {@link https://agentrail.run/reference/plugin-contract}
+ */
 export interface AgentrailPlugin {
+  /** Human-readable plugin identifier used in logs and error messages. */
   name: string;
+
+  /**
+   * Semantic version string (`MAJOR.MINOR.PATCH`) of the plugin implementation.
+   * Providing a version is strongly recommended for diagnostics and compatibility
+   * checks — e.g. `"1.0.0"`.
+   */
+  version?: string;
+
+  /**
+   * Initialise the plugin. Called once when the host application starts.
+   * Throw to abort startup with a descriptive error.
+   */
   start?(): void | Promise<void>;
+
+  /**
+   * Tear down the plugin. Called on graceful host shutdown.
+   * Errors thrown here are logged but do not prevent other plugins from stopping.
+   */
   stop?(): void | Promise<void>;
+
+  /**
+   * Intercept an incoming chat request before the agent runs.
+   * Return a non-null `AgentrailChatHandledResponse` to short-circuit execution
+   * (e.g. for rate limiting or cached replies). Return `null` to continue.
+   */
   interceptChatRequest?(
     context: AgentrailChatRequestContext,
   ): Promise<AgentrailChatHandledResponse | null> | AgentrailChatHandledResponse | null;
+
+  /**
+   * Additional context providers contributed by this plugin. They are merged
+   * with profile-level providers and called before each agent turn.
+   */
   contextProviders?: ContextProvider[];
+
+  /**
+   * Optional handler that converts uploaded file attachments into additional
+   * agent context text. Called after request validation, before agent execution.
+   */
   attachmentHandler?: AttachmentHandler;
+
+  /**
+   * Called at the very start of each chat or stream request, before the agent
+   * begins processing. Useful for emitting metrics or opening per-request spans.
+   */
   onRequestStart?(context: AgentrailRequestLifecycleContext): void | Promise<void>;
+
+  /**
+   * Called after the agent finishes and the response is fully sent.
+   * Errors thrown here are logged but do not affect the HTTP response.
+   */
   onRequestEnd?(context: AgentrailRequestLifecycleContext): void | Promise<void>;
+
+  /**
+   * Called after the turn's messages have been persisted to the session store.
+   * Use for post-turn side effects such as triggering memory consolidation.
+   */
   onTurnPersisted?(context: AgentrailRequestLifecycleContext): void | Promise<void>;
 }
 

--- a/packages/app/src/plugins/user-memory/user-memory-consolidation-service.ts
+++ b/packages/app/src/plugins/user-memory/user-memory-consolidation-service.ts
@@ -242,10 +242,10 @@ async function streamToText(
     if (isRuntimeError(event)) {
       throw event.error instanceof Error ? event.error : new Error("LLM request failed");
     }
-    if (event.type === "message_update" && event.event.type === "text_delta") {
+    if (event.type === "message.update" && event.event.type === "text_delta") {
       output += event.event.delta;
     }
-    if (event.type === "agent_end") break;
+    if (event.type === "session.end") break;
   }
   return output.trim();
 }

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -405,7 +405,7 @@ async function drainAgentStream(
     await opts.writeEvent(event);
     opts.onTraceEvent(event);
 
-    if (event.type === "agent_end") {
+    if (event.type === "session.end") {
       capturedMessages = event.messages;
       capturedUsage = event.usage;
 

--- a/packages/capabilities/src/skills/skill-tools.ts
+++ b/packages/capabilities/src/skills/skill-tools.ts
@@ -189,10 +189,10 @@ export async function buildSkillTool(
       // would cause the skill's step-by-step reasoning to appear in the main
       // assistant bubble.
       const WORKSPACE_EVENTS = new Set([
-        "tool_execution_start",
-        "tool_execution_end",
-        "turn_start",
-        "turn_end",
+        "tool.before",
+        "tool.after",
+        "turn.start",
+        "turn.complete",
       ]);
 
       let resultText = "";

--- a/packages/core/src/agent/agent-impl.ts
+++ b/packages/core/src/agent/agent-impl.ts
@@ -240,7 +240,7 @@ export class AgentImpl implements Agent {
     let stopReason: StopReason = "stop";
 
     for await (const event of stream) {
-      if (event.type === "agent_end") {
+      if (event.type === "session.end") {
         messages = event.messages;
         usage = event.usage;
       }

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -64,12 +64,12 @@ export function agentLoop(
     const newMessages: Message[] = [...prompts];
     const currentMessages: Message[] = [...context.messages, ...prompts];
 
-    stream.push({ type: "agent_start" });
-    stream.push({ type: "turn_start" });
+    stream.push({ type: "session.start" });
+    stream.push({ type: "turn.start" });
 
     for (const prompt of prompts) {
-      stream.push({ type: "message_start", message: prompt });
-      stream.push({ type: "message_end", message: prompt });
+      stream.push({ type: "message.start", message: prompt });
+      stream.push({ type: "message.end", message: prompt });
     }
 
     await runLoop(currentMessages, newMessages, config, context.signal, stream);
@@ -97,8 +97,8 @@ export function agentLoopContinue(
     const newMessages: Message[] = [];
     const currentMessages: Message[] = [...context.messages];
 
-    stream.push({ type: "agent_start" });
-    stream.push({ type: "turn_start" });
+    stream.push({ type: "session.start" });
+    stream.push({ type: "turn.start" });
 
     await runLoop(currentMessages, newMessages, config, context.signal, stream);
   })();
@@ -108,8 +108,8 @@ export function agentLoopContinue(
 
 function createAgentStream(): EventStream<RuntimeEvent, Message[]> {
   return new EventStream<RuntimeEvent, Message[]>(
-    (event: RuntimeEvent) => event.type === "agent_end",
-    (event: RuntimeEvent) => (event.type === "agent_end" ? event.messages : []),
+    (event: RuntimeEvent) => event.type === "session.end",
+    (event: RuntimeEvent) => (event.type === "session.end" ? event.messages : []),
   );
 }
 
@@ -143,15 +143,15 @@ async function runLoop(
 
     while (hasMoreToolCalls || pendingMessages.length > 0) {
       if (!firstTurn) {
-        stream.push({ type: "turn_start" });
+        stream.push({ type: "turn.start" });
       } else {
         firstTurn = false;
       }
 
       if (pendingMessages.length > 0) {
         for (const message of pendingMessages) {
-          stream.push({ type: "message_start", message });
-          stream.push({ type: "message_end", message });
+          stream.push({ type: "message.start", message });
+          stream.push({ type: "message.end", message });
           currentMessages.push(message);
           newMessages.push(message);
         }
@@ -177,8 +177,8 @@ async function runLoop(
       totalUsage = accumulateUsage(totalUsage, message.usage);
 
       if (message.stopReason === "error" || message.stopReason === "aborted") {
-        stream.push({ type: "turn_end", message, toolResults: [] });
-        stream.push({ type: "agent_end", messages: newMessages, usage: totalUsage });
+        stream.push({ type: "turn.complete", message, toolResults: [] });
+        stream.push({ type: "session.end", messages: newMessages, usage: totalUsage });
         stream.end(newMessages);
         return;
       }
@@ -204,7 +204,7 @@ async function runLoop(
         }
       }
 
-      stream.push({ type: "turn_end", message, toolResults });
+      stream.push({ type: "turn.complete", message, toolResults });
 
       if (isLastTurn) {
         maxTurnsReached = true;
@@ -230,7 +230,7 @@ async function runLoop(
     break;
   }
 
-  stream.push({ type: "agent_end", messages: newMessages, usage: totalUsage });
+  stream.push({ type: "session.end", messages: newMessages, usage: totalUsage });
   stream.end(newMessages);
 }
 
@@ -282,7 +282,7 @@ async function streamAssistantResponse(
         partialMessage = event.partial;
         messages.push(partialMessage);
         addedPartial = true;
-        stream.push({ type: "message_start", message: { ...partialMessage } });
+        stream.push({ type: "message.start", message: { ...partialMessage } });
         break;
 
       case "text_start":
@@ -292,7 +292,7 @@ async function streamAssistantResponse(
           partialMessage = event.partial;
           messages[messages.length - 1] = partialMessage;
           bufferedTextEvents.push({
-            type: "message_update",
+            type: "message.update",
             message: { ...partialMessage },
             event,
           });
@@ -309,7 +309,7 @@ async function streamAssistantResponse(
           partialMessage = event.partial;
           messages[messages.length - 1] = partialMessage;
           stream.push({
-            type: "message_update",
+            type: "message.update",
             message: { ...partialMessage },
             event,
           });
@@ -325,14 +325,14 @@ async function streamAssistantResponse(
           messages.push(finalMessage);
         }
         if (!addedPartial) {
-          stream.push({ type: "message_start", message: { ...finalMessage } });
+          stream.push({ type: "message.start", message: { ...finalMessage } });
         }
         if (finalMessage.stopReason !== "toolUse") {
           for (const buffered of bufferedTextEvents) {
             stream.push(buffered);
           }
         }
-        stream.push({ type: "message_end", message: finalMessage });
+        stream.push({ type: "message.end", message: finalMessage });
         return finalMessage;
       }
     }

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -33,7 +33,7 @@ export async function executeToolCalls(
     const tool = tools?.find((t) => t.name === toolCall.name);
 
     stream.push({
-      type: "tool_execution_start",
+      type: "tool.before",
       toolCallId: toolCall.id,
       toolName: toolCall.name,
       args: toolCall.arguments,
@@ -63,13 +63,13 @@ export async function executeToolCalls(
         }
       };
 
-      result = await tool.execute(
+        result = await tool.execute(
         toolCall.id,
         validatedArgs,
         signal,
         (partialResult) => {
           stream.push({
-            type: "tool_execution_update",
+            type: "tool.update",
             toolCallId: toolCall.id,
             toolName: toolCall.name,
             partialResult,
@@ -91,7 +91,7 @@ export async function executeToolCalls(
     }
 
     stream.push({
-      type: "tool_execution_end",
+      type: "tool.after",
       toolCallId: toolCall.id,
       toolName: toolCall.name,
       result,
@@ -109,8 +109,8 @@ export async function executeToolCalls(
     };
 
     results.push(toolResultMessage);
-    stream.push({ type: "message_start", message: toolResultMessage });
-    stream.push({ type: "message_end", message: toolResultMessage });
+    stream.push({ type: "message.start", message: toolResultMessage });
+    stream.push({ type: "message.end", message: toolResultMessage });
 
     if (getSteeringMessages) {
       const steering = await getSteeringMessages();
@@ -138,13 +138,13 @@ function skipToolCall(
   };
 
   stream.push({
-    type: "tool_execution_start",
+    type: "tool.before",
     toolCallId: toolCall.id,
     toolName: toolCall.name,
     args: toolCall.arguments,
   });
   stream.push({
-    type: "tool_execution_end",
+    type: "tool.after",
     toolCallId: toolCall.id,
     toolName: toolCall.name,
     result,
@@ -161,8 +161,8 @@ function skipToolCall(
     timestamp: Date.now(),
   };
 
-  stream.push({ type: "message_start", message: toolResultMessage });
-  stream.push({ type: "message_end", message: toolResultMessage });
+  stream.push({ type: "message.start", message: toolResultMessage });
+  stream.push({ type: "message.end", message: toolResultMessage });
 
   return toolResultMessage;
 }

--- a/packages/core/src/session/contracts.ts
+++ b/packages/core/src/session/contracts.ts
@@ -10,26 +10,69 @@ import type { TodoStorage } from "@/session/todo-storage.js";
 
 /**
  * Minimal storage surface the host runtime needs to load, persist, and compact
- * session history. The default file-backed SessionManager satisfies this shape.
+ * session history. The default file-backed `SessionManager` satisfies this shape,
+ * and any custom implementation must implement every non-optional method.
+ *
+ * ### Responsibilities
+ * - **Identity** — create or retrieve a session keyed by `(tenantId, userId, agentId)`.
+ * - **Message I/O** — load historical messages with optional token-budget capping, and
+ *   append new messages after each agent turn.
+ * - **Usage tracking** — record per-turn token usage for billing / analytics.
+ * - **Compaction** — optionally summarise old messages when the context window fills up.
+ * - **Extensions** — optional hooks for TODO storage and skill sub-agent logging.
  *
  * @see {@link https://agentrail.run/reference/session-store}
  */
 export interface AgentrailSessionStore {
+  /**
+   * Retrieve an existing session or create a new one.
+   * Returns the canonical `sessionId` and a `SessionRef` opaque handle used by
+   * other methods on this interface.
+   */
   getOrCreate(
     tenantId: string,
     userId: string,
     agentId: string,
     sessionId?: string,
   ): Promise<{ sessionId: string; sessionRef: SessionRef }>;
+
+  /**
+   * Load the most recent `limit` messages for a session.
+   * If `limit` is omitted the implementation may return all messages.
+   */
   loadMessages(tenantId: string, sessionId: string, limit?: number): Promise<Message[]>;
+
+  /**
+   * Load messages up to a token budget.
+   * The implementation should return as many recent messages as possible without
+   * exceeding `tokenBudget` tokens (counted by the store's tokeniser).
+   */
   loadMessagesWithBudget(
     tenantId: string,
     sessionId: string,
     tokenBudget?: number,
   ): Promise<Message[]>;
+
+  /** Load every message in the session without any limit or budget cap. */
   loadAllMessages(tenantId: string, sessionId: string): Promise<Message[]>;
+
+  /** Persist one or more new messages produced during an agent turn. */
   appendMessages(tenantId: string, sessionId: string, messages: Message[]): Promise<void>;
+
+  /** Record aggregate token usage for the completed turn. */
   recordTurn(tenantId: string, sessionId: string, usage: Usage): Promise<void>;
+
+  /**
+   * Summarise old messages if the session has grown beyond the configured threshold.
+   * Returns `true` when compaction actually ran, `false` when the threshold was
+   * not reached.
+   *
+   * @param summarizeFn - Agent-powered summarisation callback provided by the runtime.
+   * @param options.triggerTokens - Token count above which compaction triggers.
+   * @param options.compactFraction - Fraction of oldest messages to summarise (0–1).
+   * @param options.preloadedMessages - Already-loaded messages to avoid a redundant read.
+   * @param options.workspaceSnapshot - Optional serialised workspace state to include.
+   */
   compactIfNeeded(
     tenantId: string,
     sessionId: string,
@@ -41,7 +84,17 @@ export interface AgentrailSessionStore {
       workspaceSnapshot?: string;
     },
   ): Promise<boolean>;
+
+  /**
+   * Return a `TodoStorage` scoped to this session.
+   * Optional — omit if your store does not support structured task lists.
+   */
   createTodoStorage?(sessionRef: SessionRef): TodoStorage;
+
+  /**
+   * Persist a skill sub-agent execution log entry.
+   * Optional — omit if skill-level tracing is not needed.
+   */
   persistSkillSubAgentLog?(
     sessionRef: SessionRef,
     entry: {

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -9,6 +9,7 @@ import type { ToolResult } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
 
 // ============================================================================
+// LlmStreamEvent
 // ============================================================================
 
 /** Fine-grained provider stream events emitted while assembling an assistant message. */
@@ -77,45 +78,76 @@ export type LlmStreamEvent =
     };
 
 // ============================================================================
+// RuntimeEvent
 // ============================================================================
 
-/** Higher-level runtime events exposed by `agent.stream()`. */
+/**
+ * Higher-level runtime events exposed by `agent.stream()`.
+ *
+ * Event types use a dotted namespace convention:
+ *   - `session.*`  — overall agent session lifecycle
+ *   - `turn.*`     — individual reasoning/tool turn within a session
+ *   - `message.*`  — individual message lifecycle (including tool results)
+ *   - `tool.*`     — tool execution lifecycle
+ *
+ * @see {@link https://agentrail.run/concepts/events}
+ */
 export type RuntimeEvent =
-  | { readonly type: "agent_start" }
-  | { readonly type: "agent_end"; readonly messages: Message[]; readonly usage: Usage }
-  | { readonly type: "turn_start" }
+  // ── Session lifecycle ────────────────────────────────────────────────────
+  /** Emitted once when the agent begins processing the user input. */
+  | { readonly type: "session.start" }
+  /** Emitted once after all turns complete. Contains the full message list and token usage. */
+  | { readonly type: "session.end"; readonly messages: Message[]; readonly usage: Usage }
+  // ── Turn lifecycle ───────────────────────────────────────────────────────
+  /** Emitted at the start of each reasoning turn (LLM call). */
+  | { readonly type: "turn.start" }
+  /** Emitted after each turn completes, including the assistant message and any tool results. */
   | {
-      readonly type: "turn_end";
+      readonly type: "turn.complete";
       readonly message: AssistantMessage;
       readonly toolResults: ToolResultMessage[];
     }
-  | { readonly type: "message_start"; readonly message: Message }
+  // ── Message lifecycle ────────────────────────────────────────────────────
+  /** Emitted when a new message (user, assistant, or tool result) begins. */
+  | { readonly type: "message.start"; readonly message: Message }
+  /** Emitted for each incremental token update on an in-progress assistant message. */
   | {
-      readonly type: "message_update";
+      readonly type: "message.update";
       readonly message: AssistantMessage;
       readonly event: LlmStreamEvent;
     }
-  | { readonly type: "message_end"; readonly message: Message }
+  /** Emitted once a message is fully assembled. */
+  | { readonly type: "message.end"; readonly message: Message }
+  // ── Tool execution ───────────────────────────────────────────────────────
+  /** Emitted just before a tool call is dispatched to the tool implementation. */
   | {
-      readonly type: "tool_execution_start";
+      readonly type: "tool.before";
       readonly toolCallId: string;
       readonly toolName: string;
       readonly args: unknown;
     }
+  /** Emitted for each incremental update produced by a streaming tool. */
   | {
-      readonly type: "tool_execution_update";
+      readonly type: "tool.update";
       readonly toolCallId: string;
       readonly toolName: string;
       readonly partialResult: ToolResult;
     }
+  /** Emitted once a tool call completes (success or error). `isError` distinguishes the two. */
   | {
-      readonly type: "tool_execution_end";
+      readonly type: "tool.after";
       readonly toolCallId: string;
       readonly toolName: string;
       readonly result: ToolResult;
       readonly isError: boolean;
     }
+  // ── Control flow ─────────────────────────────────────────────────────────
+  /** Emitted when the configured `maxTurns` limit is reached. */
   | { readonly type: "max_turns_reached"; readonly turnCount: number }
+  /**
+   * Emitted when a tool requests human input. The host is expected to collect
+   * the response and resume execution.
+   */
   | {
       readonly type: "waiting_for_user_input";
       readonly toolCallId: string;
@@ -125,9 +157,44 @@ export type RuntimeEvent =
       readonly multiple?: boolean;
       readonly custom?: boolean;
     }
+  // ── New lifecycle events ─────────────────────────────────────────────────
+  /** Emitted when context compaction runs during a streaming request. */
+  | { readonly type: "compaction"; readonly messagesBefore: number; readonly messagesAfter: number }
+  /** Emitted when a sub-agent is spawned by a capability (e.g. a skill). */
+  | { readonly type: "subagent.spawn"; readonly childSessionId: string }
+  /** Emitted when a spawned sub-agent finishes. */
+  | { readonly type: "subagent.complete"; readonly childSessionId: string }
+  // ── Error ────────────────────────────────────────────────────────────────
+  /** Emitted when a runtime error terminates the agent stream. */
   | { readonly type: "error"; readonly error: Error };
 
 // ============================================================================
+// Deprecated aliases (remove in next major)
+// ============================================================================
+
+/** @deprecated Use `session.start` — will be removed in the next major version. */
+export type AgentStartEvent = Extract<RuntimeEvent, { type: "session.start" }>;
+/** @deprecated Use `session.end` — will be removed in the next major version. */
+export type AgentEndEvent = Extract<RuntimeEvent, { type: "session.end" }>;
+/** @deprecated Use `turn.start` — will be removed in the next major version. */
+export type TurnStartEvent = Extract<RuntimeEvent, { type: "turn.start" }>;
+/** @deprecated Use `turn.complete` — will be removed in the next major version. */
+export type TurnEndEvent = Extract<RuntimeEvent, { type: "turn.complete" }>;
+/** @deprecated Use `message.start` — will be removed in the next major version. */
+export type MessageStartEvent = Extract<RuntimeEvent, { type: "message.start" }>;
+/** @deprecated Use `message.update` — will be removed in the next major version. */
+export type MessageUpdateEvent = Extract<RuntimeEvent, { type: "message.update" }>;
+/** @deprecated Use `message.end` — will be removed in the next major version. */
+export type MessageEndEvent = Extract<RuntimeEvent, { type: "message.end" }>;
+/** @deprecated Use `tool.before` — will be removed in the next major version. */
+export type ToolExecutionStartEvent = Extract<RuntimeEvent, { type: "tool.before" }>;
+/** @deprecated Use `tool.update` — will be removed in the next major version. */
+export type ToolExecutionUpdateEvent = Extract<RuntimeEvent, { type: "tool.update" }>;
+/** @deprecated Use `tool.after` — will be removed in the next major version. */
+export type ToolExecutionEndEvent = Extract<RuntimeEvent, { type: "tool.after" }>;
+
+// ============================================================================
+// Type guards
 // ============================================================================
 
 /** Type guard for terminal success events in an LLM stream. */
@@ -152,8 +219,8 @@ export function isLlmStreamTerminal(event: LlmStreamEvent): boolean {
 /** Type guard for the final aggregate event emitted by `agent.stream()`. */
 export function isAgentEnd(
   event: RuntimeEvent,
-): event is Extract<RuntimeEvent, { type: "agent_end" }> {
-  return event.type === "agent_end";
+): event is Extract<RuntimeEvent, { type: "session.end" }> {
+  return event.type === "session.end";
 }
 
 /** Type guard for runtime-level error events. */

--- a/packages/create-agentrail-app/templates/minimal/src/agent.ts
+++ b/packages/create-agentrail-app/templates/minimal/src/agent.ts
@@ -50,7 +50,7 @@ export function buildSummarizeFn(): (messages: Message[]) => Promise<string> {
       if (event.type === "message_update" && event.event.type === "text_delta") {
         summary += event.event.delta;
       }
-      if (event.type === "agent_end") break;
+      if (event.type === "session.end") break;
     }
 
     return summary.trim() || "(summarization produced no output)";

--- a/packages/deep-research/src/coordinator.ts
+++ b/packages/deep-research/src/coordinator.ts
@@ -106,7 +106,7 @@ export class DeepResearchCoordinator {
 
   async runStreaming(emit: EmitFn): Promise<DeepResearchState> {
     await this.store.initializeRun(this.state);
-    await emit({ type: "agent_start" });
+    await emit({ type: "session.start" });
     await this.emitDeepResearchEvent(
       { type: "deep_research_start", run: this.state.run, timestamp: nowIso() },
       emit,
@@ -172,7 +172,7 @@ export class DeepResearchCoordinator {
         emit,
       );
       await emit({
-        type: "agent_end",
+        type: "session.end",
         messages: [],
         usage: zeroUsage(),
       });
@@ -817,8 +817,8 @@ Snippet: ${source.snippet ?? ""}`,
 
     let report = "";
     for await (const event of reporter.stream(prompt)) {
-      if ((event as RuntimeEvent).type === "message_update") {
-        const update = event as Extract<RuntimeEvent, { type: "message_update" }>;
+      if ((event as RuntimeEvent).type === "message.update") {
+        const update = event as Extract<RuntimeEvent, { type: "message.update" }>;
         if (update.event.type === "text_delta") {
           report += update.event.delta;
           this.state.reportMarkdown = report;
@@ -834,7 +834,7 @@ Snippet: ${source.snippet ?? ""}`,
             emit,
           );
           await emit({
-            type: "message_update",
+            type: "message.update",
             event: {
               type: "text_delta",
               delta: update.event.delta,


### PR DESCRIPTION
## Summary

- Renames all `RuntimeEvent` type strings to a dotted-namespace convention (`session.*`, `turn.*`, `message.*`, `tool.*`) for consistency and clarity
- Adds three new runtime events: `compaction`, `subagent.spawn`, `subagent.complete`
- Exports `@deprecated` type aliases for every renamed event to provide a migration window
- Adds optional `version?: string` field to `AgentrailPlugin`
- Adds comprehensive JSDoc to `AgentrailPlugin`, `AgentrailSessionStore`, and `ContextProvider`
- Updates all 20 consumer-side files across packages and examples
- Updates all relevant documentation pages

## Event rename table

| Old | New |
|-----|-----|
| `agent_start` | `session.start` |
| `agent_end` | `session.end` |
| `turn_start` | `turn.start` |
| `turn_end` | `turn.complete` |
| `message_start` | `message.start` |
| `message_update` | `message.update` |
| `message_end` | `message.end` |
| `tool_execution_start` | `tool.before` |
| `tool_execution_update` | `tool.update` |
| `tool_execution_end` | `tool.after` |

## Validation

```
pnpm typecheck  # all 9 packages/examples pass
pnpm test       # all tests pass
```

Closes #70.