### PR TITLE
feat(app): per-plugin error isolation, priority ordering, and onPluginError callback

### DIFF
--- a/.changeset/plugin-error-isolation.md
+++ b/.changeset/plugin-error-isolation.md
@@ -1,0 +1,29 @@
+---
+"@agentrail/app": minor
+---
+
+Add per-plugin error isolation, `priority` ordering, and `onPluginError` observability callback.
+
+All plugin hooks (`start`, `stop`, request lifecycle hooks, `interceptChatRequest`,
+`attachmentHandler`) are now wrapped in individual try/catch blocks so that a throwing
+plugin never propagates to the host request unless `critical: true` is set.
+
+New fields on `AgentrailPlugin`:
+
+- `priority?: number` — controls execution order (descending for start/request hooks,
+  ascending for stop). Defaults to `0`.
+- `critical?: boolean` — when `true`, errors in `interceptChatRequest` propagate and
+  abort the request. Defaults to `false`.
+
+New types exported from `@agentrail/app`:
+
+- `PluginErrorContext` — payload passed to the error handler.
+- `PluginErrorHandler` — callback type `(ctx: PluginErrorContext) => void | Promise<void>`.
+
+New option `onPluginError?: PluginErrorHandler` on `CreateAgentAppOptions`,
+`AgentrailChatRouteOptions`, and `AgentrailStreamRouteOptions`. Pass the same handler
+to `runPluginLifecycle()` for unified error reporting across lifecycle and request-time paths.
+
+The `runPluginLifecycle` signature gains an optional third parameter `onError?:
+PluginErrorHandler`. Existing callers that omit it fall back to `console.warn` — no
+breaking change.

--- a/docs/reference/plugin-contract.md
+++ b/docs/reference/plugin-contract.md
@@ -44,6 +44,20 @@ interface AgentrailPlugin {
   name: string;
   /** Semantic version string (e.g. `"1.0.0"`) — recommended for diagnostics */
   version?: string;
+  /**
+   * Execution order relative to other plugins.
+   * Higher values run first during start() and all request-time hooks.
+   * stop() runs in reverse order (lowest priority first).
+   * Defaults to 0.
+   */
+  priority?: number;
+  /**
+   * When true, an error thrown by interceptChatRequest propagates and aborts
+   * the request (after being reported to onPluginError).
+   * Use for auth/rate-limit plugins where a throw means "deny this request".
+   * Defaults to false.
+   */
+  critical?: boolean;
   /** Runs when the host starts the plugin lifecycle */
   start?(): void | Promise<void>;
   /** Runs when the host shuts plugins down */
@@ -116,6 +130,38 @@ A stable plugin identifier for diagnostics and assembly.
 Optional semantic version string (`MAJOR.MINOR.PATCH`) for the plugin implementation.
 Providing a version is recommended — it appears in host diagnostic logs and makes it
 easier to correlate issues across deployments.
+
+### `priority`
+
+Controls execution order relative to other plugins. Higher values run **first** during
+`start()` and all request-time hooks. `stop()` runs in the **reverse** order (lowest
+priority stops first), mirroring standard dependency teardown semantics.
+
+Defaults to `0`. Plugins with equal priority run in registration order.
+
+```ts
+// Auth plugin must intercept before any feature plugin
+const authPlugin: AgentrailPlugin = { name: "auth", priority: 100, ... };
+const featurePlugin: AgentrailPlugin = { name: "feature", priority: 0, ... };
+```
+
+| Phase | Order | Rationale |
+|-------|-------|-----------|
+| `start()` | Descending (high first) | High-priority plugins may be dependencies of others |
+| `stop()` | Ascending (low first) | Teardown mirrors initialisation |
+| Request hooks | Descending (high first) | Auth/policy plugins run before feature plugins |
+| Context providers | Descending (high first) | High-priority context is injected first |
+
+### `critical`
+
+When `true`, an error thrown by `interceptChatRequest` propagates and aborts the request
+(after being reported to `onPluginError`).
+
+Use this for auth, rate-limit, or policy plugins where a throw means "deny this request".
+Non-critical plugin errors are isolated — the request continues as if the plugin returned
+`null`.
+
+Defaults to `false`.
 
 ### `start` / `stop`
 
@@ -203,6 +249,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 export const observabilityPlugin: AgentrailPlugin = {
   name: "observability",
   version: "1.0.0",
+  priority: 10,
 
   start() {
     heartbeatTimer = setInterval(() => {
@@ -274,6 +321,51 @@ app.route(
 );
 ```
 
+## Error Isolation
+
+All plugin hooks are wrapped in per-plugin try/catch. An error from one plugin never
+propagates to the calling request unless `critical: true` is set on that plugin.
+
+### Error strategy per hook
+
+| Hook | On error |
+|------|----------|
+| `start()` | Report to `onPluginError`, then rethrow (startup is aborted) |
+| `stop()` | Report to `onPluginError`, continue (all plugins always get to stop) |
+| `onRequestStart/End/onTurnPersisted` | Report, continue |
+| `interceptChatRequest` (non-critical) | Report, skip plugin (treated as `null`) |
+| `interceptChatRequest` (critical) | Report, rethrow (request is aborted) |
+| `attachmentHandler` | Report, skip plugin result, merge others |
+
+### `onPluginError` callback
+
+To receive plugin errors in your own logging or tracing system, pass an `onPluginError`
+callback to `createAgentApp()` and to `runPluginLifecycle()`:
+
+```ts
+import type { PluginErrorHandler } from "@agentrail/app";
+import { createAgentApp, runPluginLifecycle } from "@agentrail/app";
+
+const onPluginError: PluginErrorHandler = async ({ plugin, hook, error }) => {
+  await myLogger.warn({ plugin, hook, err: error }, "plugin hook failed");
+};
+
+// Thread the same handler to lifecycle calls and createAgentApp
+void runPluginLifecycle(plugins, "start", onPluginError);
+
+const app = createAgentApp({
+  // ...
+  plugins,
+  onPluginError,
+});
+```
+
+The callback may be synchronous or asynchronous — the host `await`s its result before
+deciding whether to continue or rethrow. If the callback itself throws, the host falls back
+to `console.error`; the main request flow is never affected by callback instability.
+
+When `onPluginError` is omitted, the default behavior is to log to `console.warn`.
+
 ## Execution Model
 
 The current plugin runtime helpers live in:
@@ -282,12 +374,11 @@ The current plugin runtime helpers live in:
 
 Important characteristics of the current model:
 
-- plugins run in registration order
+- plugins run in `priority` order (descending); equal-priority plugins run in registration order
 - request hooks are awaited sequentially
 - chat interceptors stop at the first plugin that returns a handled response
 - attachment handlers are merged by concatenating returned context text
-
-That model is intentionally simple. It keeps the plugin contract easy to reason about while the framework API is still stabilizing.
+- every hook is error-isolated per plugin; a throwing plugin does not affect others
 
 ## Repository Examples
 

--- a/examples/playground-server/src/main.ts
+++ b/examples/playground-server/src/main.ts
@@ -6,7 +6,7 @@
 // Register built-in LLM providers (Anthropic, OpenAI) as side effects
 import "@agentrail/core/providers";
 
-import { runPluginLifecycle } from "@agentrail/app";
+import { runPluginLifecycle, type PluginErrorHandler } from "@agentrail/app";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { logger } from "hono/logger";
@@ -48,12 +48,16 @@ app.route("/api/sessions", deepResearch);
 app.route("/api/sessions", trace);
 app.route("/api/knowledge", knowledge);
 
+const onPluginError: PluginErrorHandler = ({ plugin, hook, error }) => {
+  console.warn(`[plugin] "${plugin}" threw in ${hook}:`, error);
+};
+
 // Pre-pull sandbox image at startup so the first request doesn't wait.
 // Non-blocking: server starts immediately, pull runs in the background.
 void sandboxManager.ensureImage().catch((err: unknown) => {
   console.warn("[sandbox] Image pre-pull failed (will retry on first use):", err);
 });
-void runPluginLifecycle(playgroundPlugins, "start");
+void runPluginLifecycle(playgroundPlugins, "start", onPluginError);
 
 const server = serve(
   {
@@ -68,7 +72,7 @@ const server = serve(
 // Destroy all sandbox containers on graceful shutdown
 async function onShutdown() {
   console.log("[sandbox] Shutting down — destroying all containers...");
-  await runPluginLifecycle(playgroundPlugins, "stop").catch(() => {});
+  await runPluginLifecycle(playgroundPlugins, "stop", onPluginError).catch(() => {});
   await sandboxManager.destroyAll().catch(() => {});
   process.exit(0);
 }

--- a/packages/app/src/app/create-agent-app.ts
+++ b/packages/app/src/app/create-agent-app.ts
@@ -6,7 +6,7 @@
 import type { Message } from "@agentrail/core";
 import type { AgentrailSessionStore } from "@agentrail/core";
 import type { SandboxManager } from "@agentrail/capabilities";
-import type { AgentrailPlugin, ContextProvider } from "@/host/types.js";
+import type { AgentrailPlugin, ContextProvider, PluginErrorHandler } from "@/host/types.js";
 import type { AgentrailOrchestrationRegistry } from "@/host/orchestration-registry.js";
 import type { ProfileDefinition } from "@/profile/define-profile.js";
 import type { ProfileResolver } from "@/host/profile-registry.js";
@@ -75,6 +75,16 @@ export interface CreateAgentAppOptions {
    */
   plugins?: AgentrailPlugin[];
   /**
+   * Called whenever a plugin hook throws an isolated error.
+   * Defaults to `console.warn`. May be async.
+   *
+   * Pass the same handler to `runPluginLifecycle()` if you call it manually so
+   * that lifecycle errors share the same reporting path as request-time errors.
+   *
+   * @see {@link PluginErrorHandler}
+   */
+  onPluginError?: PluginErrorHandler;
+  /**
    * Static context providers prepended to every request.
    */
   contextProviders?: ContextProvider[];
@@ -141,6 +151,7 @@ export function createAgentApp(options: CreateAgentAppOptions): Hono {
     contextProviders = [],
     sandboxManager,
     orchestrationRegistry,
+    onPluginError,
   } = options;
 
   if (profiles.length === 0 && !customResolver) {
@@ -209,6 +220,7 @@ export function createAgentApp(options: CreateAgentAppOptions): Hono {
     resolveProfile,
     plugins,
     contextProviders,
+    ...(onPluginError ? { onPluginError } : {}),
   };
 
   const app = new Hono();

--- a/packages/app/src/host/plugins.ts
+++ b/packages/app/src/host/plugins.ts
@@ -12,66 +12,174 @@ import type {
   AttachmentHandler,
   AttachmentHandlerResult,
   ContextProvider,
+  PluginErrorContext,
+  PluginErrorHandler,
 } from "@/host/types.js";
 
-type RequestHookName = "onRequestStart" | "onRequestEnd" | "onTurnPersisted";
+// ============================================================================
+// Internal helpers
+// ============================================================================
 
-/** Collects static context providers exposed by installed plugins. */
+const defaultErrorHandler: PluginErrorHandler = ({ plugin, hook, error }) => {
+  console.warn(`[agentrail] Plugin "${plugin}" threw in ${hook}:`, error);
+};
+
+/**
+ * Calls `onError` and swallows any error the callback itself throws,
+ * falling back to `console.error`. This ensures the callback can never
+ * interfere with the main request flow.
+ */
+async function safeNotify(
+  onError: PluginErrorHandler,
+  ctx: PluginErrorContext,
+): Promise<void> {
+  try {
+    await onError(ctx);
+  } catch (notifyErr) {
+    console.error(
+      `[agentrail] onPluginError threw while reporting "${ctx.plugin}" / ${ctx.hook}:`,
+      notifyErr,
+    );
+  }
+}
+
+/** Returns a new array sorted by descending priority (higher runs first). */
+function sortByPriority(plugins: AgentrailPlugin[]): AgentrailPlugin[] {
+  return [...plugins].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+}
+
+/**
+ * Returns a new array sorted by ascending priority (lower priority first).
+ * Used for `stop()` so teardown order is the reverse of startup order.
+ */
+function sortByPriorityReverse(plugins: AgentrailPlugin[]): AgentrailPlugin[] {
+  return [...plugins].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/** Collects static context providers exposed by installed plugins, in priority order. */
 export function collectPluginContextProviders(
   plugins: AgentrailPlugin[],
   baseProviders: ContextProvider[] = [],
 ): ContextProvider[] {
-  return [...baseProviders, ...plugins.flatMap((plugin) => plugin.contextProviders ?? [])];
+  return [
+    ...baseProviders,
+    ...sortByPriority(plugins).flatMap((plugin) => plugin.contextProviders ?? []),
+  ];
 }
 
+/**
+ * Runs the `start` or `stop` lifecycle phase for all plugins.
+ *
+ * - **`start`**: plugins run in descending priority order. If a plugin throws,
+ *   `onError` is notified and the error propagates (startup is aborted).
+ * - **`stop`**: plugins run in ascending priority order (reverse of start) so
+ *   teardown mirrors initialisation. Errors are isolated — all plugins always
+ *   get a chance to stop.
+ */
 export async function runPluginLifecycle(
   plugins: AgentrailPlugin[],
   phase: "start" | "stop",
+  onError: PluginErrorHandler = defaultErrorHandler,
 ): Promise<void> {
-  for (const plugin of plugins) {
-    await plugin[phase]?.();
+  const ordered = phase === "stop" ? sortByPriorityReverse(plugins) : sortByPriority(plugins);
+
+  for (const plugin of ordered) {
+    try {
+      await plugin[phase]?.();
+    } catch (err) {
+      await safeNotify(onError, { plugin: plugin.name, hook: phase, error: err });
+      if (phase === "start") {
+        throw err;
+      }
+      // stop: continue so every plugin gets a chance to clean up
+    }
   }
 }
 
+/**
+ * Runs a request lifecycle hook (`onRequestStart`, `onRequestEnd`,
+ * `onTurnPersisted`) for all plugins in priority order.
+ *
+ * Errors are isolated per plugin: `onError` is called and execution continues.
+ */
 export async function runPluginRequestHook(
   plugins: AgentrailPlugin[],
-  hook: RequestHookName,
+  hook: "onRequestStart" | "onRequestEnd" | "onTurnPersisted",
   context: AgentrailRequestLifecycleContext,
+  onError: PluginErrorHandler = defaultErrorHandler,
 ): Promise<void> {
-  for (const plugin of plugins) {
-    await plugin[hook]?.(context);
+  for (const plugin of sortByPriority(plugins)) {
+    try {
+      await plugin[hook]?.(context);
+    } catch (err) {
+      await safeNotify(onError, { plugin: plugin.name, hook, error: err });
+    }
   }
 }
 
+/**
+ * Runs `interceptChatRequest` on each plugin in priority order, stopping at
+ * the first non-null response.
+ *
+ * - **Non-critical plugins**: errors are isolated — `onError` is called and
+ *   the plugin is skipped (treated as returning `null`).
+ * - **Critical plugins** (`plugin.critical === true`): `onError` is called
+ *   first, then the error propagates so the request is aborted. Use this for
+ *   auth or policy plugins where a throw means "deny".
+ */
 export async function runPluginChatRequestInterceptors(
   plugins: AgentrailPlugin[],
   context: AgentrailChatRequestContext,
+  onError: PluginErrorHandler = defaultErrorHandler,
 ): Promise<AgentrailChatHandledResponse | null> {
-  for (const plugin of plugins) {
-    const result = await plugin.interceptChatRequest?.(context);
-    if (result) {
-      return result;
+  for (const plugin of sortByPriority(plugins)) {
+    try {
+      const result = await plugin.interceptChatRequest?.(context);
+      if (result) {
+        return result;
+      }
+    } catch (err) {
+      await safeNotify(onError, { plugin: plugin.name, hook: "interceptChatRequest", error: err });
+      if (plugin.critical) {
+        throw err;
+      }
     }
   }
 
   return null;
 }
 
+/**
+ * Runs attachment handlers from all plugins and the optional fallback, merging
+ * all returned `contextText` values.
+ *
+ * Errors from individual handlers are isolated: `onError` is called and that
+ * plugin's result is skipped; other handlers still run.
+ */
 export async function runAttachmentHandlers(
   files: AttachmentFile[],
   plugins: AgentrailPlugin[],
   fallbackHandler?: AttachmentHandler,
+  onError: PluginErrorHandler = defaultErrorHandler,
 ): Promise<AttachmentHandlerResult | null> {
   const results: AttachmentHandlerResult[] = [];
 
-  for (const plugin of plugins) {
+  for (const plugin of sortByPriority(plugins)) {
     if (!plugin.attachmentHandler) {
       continue;
     }
 
-    const result = await plugin.attachmentHandler(files);
-    if (result?.contextText) {
-      results.push(result);
+    try {
+      const result = await plugin.attachmentHandler(files);
+      if (result?.contextText) {
+        results.push(result);
+      }
+    } catch (err) {
+      await safeNotify(onError, { plugin: plugin.name, hook: "attachmentHandler", error: err });
     }
   }
 

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -16,6 +16,44 @@ import type {
 } from "@agentrail/core";
 export type { AgentrailSessionStore, ContextProvider, ContextProviderContext } from "@agentrail/core";
 
+// ============================================================================
+// Plugin error reporting
+// ============================================================================
+
+/**
+ * Contextual information passed to `onPluginError` when a plugin hook throws.
+ */
+export interface PluginErrorContext {
+  /** The `name` of the plugin that threw. */
+  plugin: string;
+  /** The hook that was executing, e.g. `"interceptChatRequest"` or `"onRequestStart"`. */
+  hook: string;
+  /** The original error thrown by the plugin hook. */
+  error: unknown;
+}
+
+/**
+ * Callback invoked whenever a plugin hook throws an error that has been
+ * isolated by the host runtime.
+ *
+ * The callback may be synchronous or asynchronous — the host `await`s its
+ * result before deciding whether to continue or rethrow. If the callback
+ * itself throws, the host catches and falls back to `console.error`; the
+ * main request flow is never affected by callback instability.
+ *
+ * ### Usage
+ * ```ts
+ * const onPluginError: PluginErrorHandler = async ({ plugin, hook, error }) => {
+ *   await myLogger.warn({ plugin, hook, err: error }, "plugin hook failed");
+ * };
+ *
+ * // Thread the same handler into both lifecycle calls and createAgentApp.
+ * void runPluginLifecycle(plugins, "start", onPluginError);
+ * createAgentApp({ ..., onPluginError });
+ * ```
+ */
+export type PluginErrorHandler = (ctx: PluginErrorContext) => void | Promise<void>;
+
 /**
  * Context passed to a hosted profile when constructing a runtime agent.
  *
@@ -138,6 +176,37 @@ export interface AgentrailPlugin {
    * checks — e.g. `"1.0.0"`.
    */
   version?: string;
+
+  /**
+   * Execution order for this plugin relative to others.
+   *
+   * Higher values run **first** during `start()` and all request-time hooks.
+   * `stop()` runs in the **reverse** order (lowest priority stops first),
+   * mirroring standard dependency teardown semantics.
+   *
+   * Defaults to `0`. Plugins with equal priority run in registration order.
+   *
+   * @example
+   * ```ts
+   * // Auth plugin must intercept before any feature plugin
+   * const authPlugin: AgentrailPlugin = { name: "auth", priority: 100, ... };
+   * const featurePlugin: AgentrailPlugin = { name: "feature", priority: 0, ... };
+   * ```
+   */
+  priority?: number;
+
+  /**
+   * When `true`, an error thrown by `interceptChatRequest` is treated as a
+   * deliberate denial and propagates to abort the request (after being reported
+   * to `onPluginError`).
+   *
+   * Use this for auth, rate-limit, or policy plugins where a throw means
+   * "deny this request". Non-critical plugin errors are isolated — the request
+   * continues as if the plugin returned `null`.
+   *
+   * Defaults to `false`.
+   */
+  critical?: boolean;
 
   /**
    * Initialise the plugin. Called once when the host application starts.

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -56,6 +56,8 @@ export type {
   AttachmentHandlerResult,
   ContextProvider,
   ContextProviderContext,
+  PluginErrorContext,
+  PluginErrorHandler,
 } from "@/host/types.js";
 
 // ============================================================================

--- a/packages/app/src/routes/attachment-pipeline.ts
+++ b/packages/app/src/routes/attachment-pipeline.ts
@@ -6,7 +6,12 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { runAttachmentHandlers } from "@/host/plugins.js";
-import type { AgentrailPlugin, AttachmentFile, AttachmentHandler } from "@/host/types.js";
+import type {
+  AgentrailPlugin,
+  AttachmentFile,
+  AttachmentHandler,
+  PluginErrorHandler,
+} from "@/host/types.js";
 import type { AttachmentInput } from "@/routes/stream-request.js";
 
 /**
@@ -60,13 +65,14 @@ export async function buildEffectiveMessage(
   uploadedFiles: AttachmentFile[],
   plugins: AgentrailPlugin[],
   fallbackHandler?: AttachmentHandler,
+  onPluginError?: PluginErrorHandler,
 ): Promise<string> {
   let effectiveMessage = message ?? "";
   if (uploadedFiles.length === 0) {
     return effectiveMessage;
   }
 
-  const result = await runAttachmentHandlers(uploadedFiles, plugins, fallbackHandler);
+  const result = await runAttachmentHandlers(uploadedFiles, plugins, fallbackHandler, onPluginError);
 
   if (result?.contextText) {
     effectiveMessage = effectiveMessage

--- a/packages/app/src/routes/chat-route.ts
+++ b/packages/app/src/routes/chat-route.ts
@@ -23,6 +23,7 @@ import type {
   AgentrailRequestLifecycleContext,
   AgentrailSessionStore,
   ContextProvider,
+  PluginErrorHandler,
 } from "@/host/types.js";
 
 /**
@@ -53,6 +54,12 @@ export interface AgentrailChatRouteOptions {
   ): Promise<AgentrailProfile | null>;
   /** Optional plugins that can intercept requests and observe lifecycle events. */
   plugins?: AgentrailPlugin[];
+  /**
+   * Called whenever a plugin hook throws an isolated error.
+   * Defaults to `console.warn`. May be async.
+   * @see {@link PluginErrorHandler}
+   */
+  onPluginError?: PluginErrorHandler;
   /** Static context providers prepended before conversation history. */
   contextProviders?: ContextProvider[];
   /** Dynamic context-provider resolver invoked per request. */
@@ -96,6 +103,7 @@ export interface AgentrailChatRouteOptions {
  */
 export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
   const plugins = options.plugins ?? [];
+  const onPluginError = options.onPluginError;
   const route = new Hono();
 
   route.post("/", async (c) => {
@@ -118,7 +126,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
       request,
       agentId,
       signal,
-    });
+    }, onPluginError);
     if (prehandled) {
       return respondHandledJson(c, prehandled);
     }
@@ -145,7 +153,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
       };
 
       await options.onRequestStart?.(requestContext);
-      await runPluginRequestHook(plugins, "onRequestStart", requestContext);
+      await runPluginRequestHook(plugins, "onRequestStart", requestContext, onPluginError);
       activityStarted = true;
 
       const handled = options.handleResolvedRequest
@@ -163,7 +171,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
 
       if (handled) {
         await options.onTurnPersisted?.(requestContext);
-        await runPluginRequestHook(plugins, "onTurnPersisted", requestContext);
+        await runPluginRequestHook(plugins, "onTurnPersisted", requestContext, onPluginError);
         return respondHandledJson(c, handled);
       }
 
@@ -224,7 +232,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
         options.sessionStore.recordTurn(request.tenantId, sessionId, result.usage),
       ]);
       await options.onTurnPersisted?.(requestContext);
-      await runPluginRequestHook(plugins, "onTurnPersisted", requestContext);
+      await runPluginRequestHook(plugins, "onTurnPersisted", requestContext, onPluginError);
 
       const body: AgentrailChatSuccessBody = {
         sessionId,
@@ -239,7 +247,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
     } finally {
       if (activityStarted && requestContext) {
         await options.onRequestEnd?.(requestContext);
-        await runPluginRequestHook(plugins, "onRequestEnd", requestContext);
+        await runPluginRequestHook(plugins, "onRequestEnd", requestContext, onPluginError);
       }
     }
   });

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -34,6 +34,7 @@ import type {
   AttachmentFile,
   AttachmentHandler,
   ContextProvider,
+  PluginErrorHandler,
 } from "@/host/types.js";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -103,6 +104,12 @@ export interface AgentrailStreamRouteOptions {
   onRequestEnd?: (context: AgentrailRequestLifecycleContext) => void | Promise<void>;
   /** Optional callback invoked after the turn has been persisted. */
   onTurnPersisted?: (context: AgentrailRequestLifecycleContext) => void | Promise<void>;
+  /**
+   * Called whenever a plugin hook throws an isolated error.
+   * Defaults to `console.warn`. May be async.
+   * @see {@link PluginErrorHandler}
+   */
+  onPluginError?: PluginErrorHandler;
   /** Connects this route to an orchestration manager for multi-agent event forwarding. */
   getOrchestrationManager?: (context: {
     tenantId: string;
@@ -148,6 +155,7 @@ export interface AgentrailResolvedStreamContext {
  */
 export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
   const plugins = options.plugins ?? [];
+  const onPluginError = options.onPluginError;
   const route = new Hono();
 
   route.post("/", async (c) => {
@@ -183,11 +191,12 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
       uploadedFiles,
       plugins,
       options.attachmentHandler,
+      onPluginError,
     );
 
     // ── 4. Lifecycle hooks + sandbox warmup (fire-and-forget) ────────────────
     await options.onRequestStart?.(requestContext);
-    await runPluginRequestHook(plugins, "onRequestStart", requestContext);
+    await runPluginRequestHook(plugins, "onRequestStart", requestContext, onPluginError);
     const sandboxReady = options.sandboxManager?.ensureSandbox(sid, tenantId, userId);
 
     // ── 5. Pre-resolve profile (skipped when a custom handler is registered) ─
@@ -233,7 +242,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
           options.sessionStore.recordTurn(tenantId, sid, usage),
         ]);
         await options.onTurnPersisted?.(requestContext);
-        await runPluginRequestHook(plugins, "onTurnPersisted", requestContext);
+        await runPluginRequestHook(plugins, "onTurnPersisted", requestContext, onPluginError);
       };
 
       try {
@@ -355,7 +364,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
       } finally {
         unsubscribeOrchestration?.();
         await options.onRequestEnd?.(requestContext);
-        await runPluginRequestHook(plugins, "onRequestEnd", requestContext);
+        await runPluginRequestHook(plugins, "onRequestEnd", requestContext, onPluginError);
       }
     });
   });

--- a/packages/app/test/plugins.test.ts
+++ b/packages/app/test/plugins.test.ts
@@ -1,0 +1,252 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  runPluginLifecycle,
+  runPluginRequestHook,
+  runPluginChatRequestInterceptors,
+  runAttachmentHandlers,
+  collectPluginContextProviders,
+} from "../src/host/plugins.js";
+import type { AgentrailPlugin, AgentrailRequestLifecycleContext, PluginErrorHandler } from "../src/host/types.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockRequestContext: AgentrailRequestLifecycleContext = {
+  kind: "chat",
+  tenantId: "t1",
+  userId: "u1",
+  sessionId: "s1",
+  agentId: "a1",
+};
+
+const mockChatContext = {
+  kind: "chat" as const,
+  request: { tenantId: "t1", userId: "u1", message: "hi" } as any,
+  agentId: "a1",
+  signal: new AbortController().signal,
+};
+
+function makePlugin(name: string, overrides: Partial<AgentrailPlugin> = {}): AgentrailPlugin {
+  return { name, ...overrides };
+}
+
+// ─── runPluginLifecycle ────────────────────────────────────────────────────────
+
+describe("runPluginLifecycle", () => {
+  it("calls start() on all plugins", async () => {
+    const start = vi.fn();
+    const plugin = makePlugin("p1", { start });
+    await runPluginLifecycle([plugin], "start");
+    expect(start).toHaveBeenCalledOnce();
+  });
+
+  it("calls stop() on all plugins", async () => {
+    const stop = vi.fn();
+    const plugin = makePlugin("p1", { stop });
+    await runPluginLifecycle([plugin], "stop");
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("start: notifies onPluginError then rethrows when a plugin throws", async () => {
+    const error = new Error("start failure");
+    const onError: PluginErrorHandler = vi.fn();
+    const plugin = makePlugin("bad", {
+      start: async () => { throw error; },
+    });
+    await expect(runPluginLifecycle([plugin], "start", onError)).rejects.toThrow("start failure");
+    expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "start", error });
+  });
+
+  it("stop: notifies onPluginError but continues when a plugin throws", async () => {
+    const onError: PluginErrorHandler = vi.fn();
+    const order: string[] = [];
+    const bad = makePlugin("bad", { stop: async () => { order.push("bad"); throw new Error("stop fail"); } });
+    const good = makePlugin("good", { stop: async () => { order.push("good"); } });
+    await runPluginLifecycle([bad, good], "stop", onError);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(order).toEqual(["bad", "good"]);
+  });
+
+  it("start: executes in descending priority order", async () => {
+    const order: string[] = [];
+    const low = makePlugin("low", { priority: 0, start: async () => { order.push("low"); } });
+    const high = makePlugin("high", { priority: 100, start: async () => { order.push("high"); } });
+    await runPluginLifecycle([low, high], "start");
+    expect(order).toEqual(["high", "low"]);
+  });
+
+  it("stop: executes in ascending priority order (reverse of start)", async () => {
+    const order: string[] = [];
+    const low = makePlugin("low", { priority: 0, stop: async () => { order.push("low"); } });
+    const high = makePlugin("high", { priority: 100, stop: async () => { order.push("high"); } });
+    await runPluginLifecycle([low, high], "stop");
+    expect(order).toEqual(["low", "high"]);
+  });
+
+  it("uses console.warn by default when no onPluginError is provided", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const plugin = makePlugin("bad", { stop: async () => { throw new Error("oops"); } });
+    await runPluginLifecycle([plugin], "stop");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('"bad"'),
+      expect.any(Error),
+    );
+    warn.mockRestore();
+  });
+
+  it("safeNotify: falls back to console.error when onPluginError itself throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onError: PluginErrorHandler = () => { throw new Error("handler failure"); };
+    const plugin = makePlugin("bad", { stop: async () => { throw new Error("original"); } });
+    // Must NOT throw even though both plugin and handler threw
+    await expect(runPluginLifecycle([plugin], "stop", onError)).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"bad"'),
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("onPluginError may be async: awaited before continuing (no fire-and-forget)", async () => {
+    const order: string[] = [];
+    const onError: PluginErrorHandler = async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("handler");
+    };
+    const bad = makePlugin("bad", { stop: async () => { order.push("throw"); throw new Error("err"); } });
+    const next = makePlugin("next", { stop: async () => { order.push("next"); } });
+    await runPluginLifecycle([bad, next], "stop", onError);
+    expect(order).toEqual(["throw", "handler", "next"]);
+  });
+});
+
+// ─── runPluginRequestHook ──────────────────────────────────────────────────────
+
+describe("runPluginRequestHook", () => {
+  it("calls hook on all plugins", async () => {
+    const onRequestStart = vi.fn();
+    await runPluginRequestHook([makePlugin("p1", { onRequestStart })], "onRequestStart", mockRequestContext);
+    expect(onRequestStart).toHaveBeenCalledWith(mockRequestContext);
+  });
+
+  it("isolates errors: other plugins still run", async () => {
+    const onError: PluginErrorHandler = vi.fn();
+    const order: string[] = [];
+    const bad = makePlugin("bad", { onRequestEnd: async () => { order.push("bad"); throw new Error("boom"); } });
+    const good = makePlugin("good", { onRequestEnd: async () => { order.push("good"); } });
+    await runPluginRequestHook([bad, good], "onRequestEnd", mockRequestContext, onError);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(order).toEqual(["bad", "good"]);
+  });
+
+  it("runs plugins in descending priority order", async () => {
+    const order: string[] = [];
+    const low = makePlugin("low", { priority: 0, onRequestStart: async () => { order.push("low"); } });
+    const high = makePlugin("high", { priority: 10, onRequestStart: async () => { order.push("high"); } });
+    await runPluginRequestHook([low, high], "onRequestStart", mockRequestContext);
+    expect(order).toEqual(["high", "low"]);
+  });
+});
+
+// ─── runPluginChatRequestInterceptors ─────────────────────────────────────────
+
+describe("runPluginChatRequestInterceptors", () => {
+  it("returns null when no plugin intercepts", async () => {
+    const result = await runPluginChatRequestInterceptors(
+      [makePlugin("p1")],
+      mockChatContext,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns the first non-null response", async () => {
+    const handled = { status: 200 as const, body: { text: "handled", usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } } };
+    const plugin = makePlugin("p1", { interceptChatRequest: async () => handled });
+    const result = await runPluginChatRequestInterceptors([plugin], mockChatContext);
+    expect(result).toBe(handled);
+  });
+
+  it("non-critical: isolates errors, notifies onPluginError, continues with null", async () => {
+    const onError: PluginErrorHandler = vi.fn();
+    const bad = makePlugin("bad", { interceptChatRequest: async () => { throw new Error("denied"); } });
+    const result = await runPluginChatRequestInterceptors([bad], mockChatContext, onError);
+    expect(result).toBeNull();
+    expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "interceptChatRequest", error: expect.any(Error) });
+  });
+
+  it("critical: notifies onPluginError then rethrows", async () => {
+    const onError: PluginErrorHandler = vi.fn();
+    const error = new Error("auth failure");
+    const bad = makePlugin("bad", {
+      critical: true,
+      interceptChatRequest: async () => { throw error; },
+    });
+    await expect(runPluginChatRequestInterceptors([bad], mockChatContext, onError)).rejects.toThrow("auth failure");
+    expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "interceptChatRequest", error });
+  });
+
+  it("runs plugins in descending priority order", async () => {
+    const order: string[] = [];
+    const low = makePlugin("low", { priority: 0, interceptChatRequest: async () => { order.push("low"); return null; } });
+    const high = makePlugin("high", { priority: 5, interceptChatRequest: async () => { order.push("high"); return null; } });
+    await runPluginChatRequestInterceptors([low, high], mockChatContext);
+    expect(order).toEqual(["high", "low"]);
+  });
+});
+
+// ─── runAttachmentHandlers ────────────────────────────────────────────────────
+
+describe("runAttachmentHandlers", () => {
+  const files = [{ name: "file.txt", mimeType: "text/plain", data: Buffer.from("data") }];
+
+  it("returns null when no handlers produce text", async () => {
+    const result = await runAttachmentHandlers(files, [makePlugin("p1")]);
+    expect(result).toBeNull();
+  });
+
+  it("merges contextText from multiple plugin handlers", async () => {
+    const p1 = makePlugin("p1", { attachmentHandler: async () => ({ contextText: "ctx1" }) });
+    const p2 = makePlugin("p2", { attachmentHandler: async () => ({ contextText: "ctx2" }) });
+    const result = await runAttachmentHandlers(files, [p1, p2]);
+    expect(result?.contextText).toBe("ctx1\n\nctx2");
+  });
+
+  it("isolates errors: skips failing handler, others still run", async () => {
+    const onError: PluginErrorHandler = vi.fn();
+    const bad = makePlugin("bad", { attachmentHandler: async () => { throw new Error("fail"); } });
+    const good = makePlugin("good", { attachmentHandler: async () => ({ contextText: "ok" }) });
+    const result = await runAttachmentHandlers(files, [bad, good], undefined, onError);
+    expect(result?.contextText).toBe("ok");
+    expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "attachmentHandler", error: expect.any(Error) });
+  });
+
+  it("includes fallbackHandler result", async () => {
+    const fallback = vi.fn(async () => ({ contextText: "fallback" }));
+    const result = await runAttachmentHandlers(files, [], fallback);
+    expect(result?.contextText).toBe("fallback");
+  });
+});
+
+// ─── collectPluginContextProviders ────────────────────────────────────────────
+
+describe("collectPluginContextProviders", () => {
+  it("returns base providers when plugins have none", () => {
+    const base = [vi.fn()];
+    const result = collectPluginContextProviders([makePlugin("p1")], base);
+    expect(result).toEqual(base);
+  });
+
+  it("appends plugin providers in priority order after base providers", () => {
+    const base = [vi.fn()];
+    const cp1 = vi.fn();
+    const cp2 = vi.fn();
+    const low = makePlugin("low", { priority: 0, contextProviders: [cp1] });
+    const high = makePlugin("high", { priority: 10, contextProviders: [cp2] });
+    const result = collectPluginContextProviders([low, high], base);
+    expect(result).toEqual([base[0], cp2, cp1]);
+  });
+});


### PR DESCRIPTION
Closes #28

## Summary

- **Error isolation**: every plugin hook (`start`, `stop`, `onRequestStart/End/onTurnPersisted`, `interceptChatRequest`, `attachmentHandler`) is now wrapped in an individual try/catch. A throwing plugin can never cascade to other plugins or fail the host request, unless `critical: true` is set on that plugin.
- **`priority` field**: controls execution order. Higher values run first during `start()` and all request-time hooks; `stop()` runs in reverse (lowest first), mirroring dependency teardown semantics.
- **`critical` field**: when `true`, an error thrown by `interceptChatRequest` propagates and aborts the request (after being reported). Designed for auth/rate-limit plugins where "throw" means "deny".
- **`onPluginError` callback**: injected into `createAgentApp()`, `createChatRoute()`, `createStreamRoute()`, and `runPluginLifecycle()`. Defaults to `console.warn`. The callback is `await`-ed, so async sinks (OTel, remote loggers) are supported. A `safeNotify` wrapper ensures a failing callback cannot break the main flow.

## Changed files

| File | Change |
|------|--------|
| `packages/app/src/host/types.ts` | Add `priority`, `critical`, `PluginErrorContext`, `PluginErrorHandler` |
| `packages/app/src/host/plugins.ts` | Full rewrite: `sortByPriority`, `safeNotify`, all run* functions updated |
| `packages/app/src/routes/chat-route.ts` | Thread `onPluginError` to all hook calls |
| `packages/app/src/routes/stream-route.ts` | Thread `onPluginError` to all hook calls |
| `packages/app/src/routes/attachment-pipeline.ts` | Thread `onPluginError` to `runAttachmentHandlers` |
| `packages/app/src/app/create-agent-app.ts` | Add `onPluginError` option |
| `packages/app/src/index.ts` | Export `PluginErrorContext`, `PluginErrorHandler` |
| `examples/playground-server/src/main.ts` | Pass `onPluginError` to `runPluginLifecycle` |
| `packages/app/test/plugins.test.ts` | 23 new tests |
| `docs/reference/plugin-contract.md` | Document new fields + error isolation model |
| `.changeset/plugin-error-isolation.md` | Minor changeset for `@agentrail/app` |

## Validation

```
pnpm --filter @agentrail/app test   # 34 tests, 0 failures
pnpm typecheck                       # all packages clean
```