### PR TITLE
docs: refresh framework docs content

### DIFF
--- a/docs/.vitepress/theme/HomeLayout.vue
+++ b/docs/.vitepress/theme/HomeLayout.vue
@@ -23,6 +23,7 @@
           >
             View on GitHub
           </a>
+          <a href="/llms.txt" class="at-btn at-btn-secondary"> llms.txt </a>
         </div>
       </div>
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -56,6 +56,8 @@ Profiles, routes, UI, and business logic. This is the code you write. It uses `@
 | `@agentrail/core`                 | 1       | Agent loop, tool contracts, LLM providers, prompts, session types |
 | `@agentrail/capabilities`         | 2       | Sandbox, knowledge, skills, orchestration, built-in tools         |
 | `@agentrail/app`                  | 3       | `createAgentApp`, `defineProfile`, sessions, plugins, config      |
+| `@agentrail/cli`                  | tooling | Local developer CLI (`agentrail doctor`, config checks, helpers)  |
+| `@agentrail/testing`              | tooling | Test helpers for hosted apps and runtime behavior                 |
 | `@agentrail/deep-research`        | addon   | Multi-agent deep research workflow                                |
 | `@agentrail/create-agentrail-app` | tooling | Project scaffold CLI                                              |
 
@@ -82,10 +84,7 @@ Lower-level escape hatches from `@agentrail/app/advanced` (use when you need fin
 - `createStreamRoute(...)` — mount only the `/stream` primitive
 - `createOrchestrationRegistry(...)` — per-session orchestration manager
 
-Pre-Proposal-106 helpers available from `@agentrail/app/compat` for migration purposes:
-
-- `defineHostedProfile(...)` — use `defineProfile` instead
-- `createHostedProfileResolver(...)` — use `createStaticProfileResolver` or `ProfileResolver` instead
+Compatibility helpers still exist in `@agentrail/app/compat`, but they are migration-only APIs. Keep them out of new application code and refer to [Compatibility APIs](../reference/host-defaults.md) only when updating older hosts.
 
 Start with `createAgentApp` + `defineProfile`. They are not black boxes — they are a recommended assembly of primitives that you can unwrap and replace piece by piece as your app grows.
 

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -56,7 +56,7 @@ The `model` field accepts either a registered provider string or a `ModelConfig`
 
 ```ts
 // Short form — uses a registered provider alias
-model: "anthropic/claude-sonnet-4-5"
+model: "anthropic:claude-sonnet-4-5"
 
 // Full form — explicit credentials
 model: {

--- a/docs/concepts/context-and-compaction.md
+++ b/docs/concepts/context-and-compaction.md
@@ -44,10 +44,10 @@ Context providers are **not** the right place for:
 
 When a request arrives, the host runs all registered context providers in order and assembles their output into a list of messages. This list is prepended to the session history before the agent sees it.
 
-The pipeline is built with `createTransformContext` from `@agentrail/app`:
+The pipeline is built with `createTransformContext` from `@agentrail/app/advanced`:
 
 ```ts
-import { createTransformContext } from "@agentrail/app";
+import { createTransformContext } from "@agentrail/app/advanced";
 
 const transformContext = createTransformContext([
   identityProvider,
@@ -61,10 +61,10 @@ Order matters. Identity and date headers should come first; memory and knowledge
 
 ## Defaults Layer
 
-Use `createDefaultCapabilityContextProviders` from `@agentrail/app` to assemble the standard capability context stack:
+Use `createDefaultCapabilityContextProviders` from `@agentrail/capabilities` to assemble the standard capability context stack:
 
 ```ts
-import { createDefaultCapabilityContextProviders } from "@agentrail/app";
+import { createDefaultCapabilityContextProviders } from "@agentrail/capabilities";
 
 const contextProviders = createDefaultCapabilityContextProviders({
   memory: memoryManager,
@@ -78,21 +78,12 @@ This covers the typical provider set — memory summaries, knowledge summaries, 
 
 ## Context Window Budget
 
-Each profile declares a `contextWindow` — the maximum number of tokens the model can handle in a single call. The host uses this value to:
+The low-level profile contract supports a `contextWindow` field — the maximum number of tokens the model can handle in a single call. The host uses this value to:
 
 - trim session history via `loadMessagesWithBudget` (keeping the most recent messages that fit)
 - compute `budgetUsedPct` in SSE events so the client can show a context usage indicator
 
-```ts
-defineProfile({
-  id: "default",
-  model: "anthropic/claude-sonnet-4-5",
-  contextWindow: 200_000, // actual limit of the model used by this profile
-  system: "You are a helpful assistant.",
-});
-```
-
-If `contextWindow` is not set, it defaults to `200_000`. Set it accurately so the token budget percentage shown to clients is correct.
+If you do not set it through a lower-level custom profile, the host defaults to `200_000`. Set it accurately when you implement `AgentrailProfile` directly so the token budget percentage shown to clients is correct.
 
 ## Compaction
 

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -68,8 +68,8 @@ The mapping is done by `mapOrchestrationEvent` in `@agentrail/app`, so UIs do no
 ## Event Flow
 
 ```
-runtime-core          host             SSE stream             UI
-────────────          ────             ──────────             ──
+@agentrail/core      host             SSE stream             UI
+───────────────      ────             ──────────             ──
 session.start    ──►  forward     ──►  JSON line         ──►  start indicator
 turn.start       ──►  forward     ──►                    ──►
 message.update   ──►  forward     ──►                    ──►  text delta

--- a/docs/concepts/host.md
+++ b/docs/concepts/host.md
@@ -99,15 +99,9 @@ Available from `@agentrail/app/advanced` when you need direct control:
 
 Use these when you need a custom request lifecycle or are integrating into an existing server architecture.
 
-### Compatibility Layer — `@agentrail/app/compat`
+### Migration Helpers
 
-Pre-Proposal-106 helpers remain available from `@agentrail/app/compat` for migration purposes:
-
-- `defineHostedProfile`
-- `createHostedProfileResolver`
-- `buildDefaultCapabilityTools`
-
-These are retained for backward compatibility only. Prefer `defineProfile` from `@agentrail/app`.
+Compatibility helpers still exist in `@agentrail/app/compat`, but they are migration-only APIs. Keep new applications on `createAgentApp` + `defineProfile` and only reach for compat helpers when upgrading an older codebase. See [Compatibility APIs](../reference/host-defaults.md) for the legacy surface.
 
 ## Choosing a Path
 

--- a/docs/concepts/profiles.md
+++ b/docs/concepts/profiles.md
@@ -69,11 +69,12 @@ export const tenantProfile = defineProfile({
 | --------------- | ----------------------------------------------------------------------------------------- |
 | `id`            | Stable identifier used by the host to resolve this profile                                |
 | `name`          | Human-readable label for logs and diagnostics                                             |
-| `contextWindow` | LLM context window size in tokens (used for token budget calculations, default `200_000`) |
 | `agent`         | Static agent config (static shape only)                                                   |
 | `createAgent`   | Per-request factory function (dynamic shape only)                                         |
 | `capabilities`  | Capability descriptors to compose into the agent                                          |
 | `modelConfig`   | Model metadata for capabilities that spawn sub-agents (e.g. `skills()`)                  |
+
+The low-level `AgentrailProfile` contract also supports `contextWindow` for token-budget calculations, but `defineProfile` does not currently expose it as a first-class helper field. If you do not provide it through a lower-level custom profile, the host defaults to `200_000`.
 
 ## Profile Registration
 

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -4,7 +4,7 @@ Tools are functions that an agent can invoke during its execution loop. They bri
 
 ## What a Tool Is
 
-A `RuntimeTool` from `@agentrail/core` has four required parts:
+A `RuntimeTool` from `@agentrail/core` has five core parts:
 
 | Part          | Purpose                                                                   |
 | ------------- | ------------------------------------------------------------------------- |
@@ -18,29 +18,27 @@ The LLM does not execute tools directly. It produces a structured tool call requ
 
 ## Defining a Tool
 
-Use the `defineTool()` builder from `@agentrail/core`:
+Use object-style `defineTool()` from `@agentrail/core` for most tools:
 
 ```ts
 import { Type } from "@sinclair/typebox";
 import { defineTool } from "@agentrail/core";
 
-export const customerLookupTool = defineTool()
-  .name("customer-lookup")
-  .label("Customer Lookup")
-  .description("Look up a customer by account ID.")
-  .parameters(
-    Type.Object({
-      accountId: Type.String({ description: "The account identifier" }),
-    }),
-  )
-  .execute(async (params, ctx) => {
+export const customerLookupTool = defineTool({
+  name: "customer-lookup",
+  label: "Customer Lookup",
+  description: "Look up a customer by account ID.",
+  parameters: Type.Object({
+    accountId: Type.String({ description: "The account identifier" }),
+  }),
+  async execute(params, ctx) {
     const record = await db.customers.findById(params.accountId);
     return {
       content: [{ type: "text", text: JSON.stringify(record) }],
       details: record,
     };
-  })
-  .build();
+  },
+});
 ```
 
 For tools with no parameters, use `defineSimpleTool`:
@@ -75,11 +73,18 @@ Every `execute` function must return a `ToolResult`:
 For long-running tools, use `ctx.onUpdate` to emit intermediate results while the tool is still executing. The host forwards these as `tool.update` events over SSE:
 
 ```ts
-.execute(async (params, ctx) => {
+const searchTool = defineTool({
+  name: "search_docs",
+  description: "Search the internal docs index.",
+  parameters: Type.Object({
+    query: Type.String(),
+  }),
+  async execute(params, ctx) {
   ctx.onUpdate({ content: [{ type: "text", text: "Starting..." }], details: null });
   const result = await longRunningTask(params.query);
   return { content: [{ type: "text", text: result }], details: result };
-})
+  },
+});
 ```
 
 ## Waiting for User Input
@@ -87,14 +92,19 @@ For long-running tools, use `ctx.onUpdate` to emit intermediate results while th
 A tool can pause the agent loop and request input from the user:
 
 ```ts
-.execute(async (params, ctx) => {
+const approvalTool = defineTool({
+  name: "request_approval",
+  description: "Ask the user to confirm a choice before continuing.",
+  async execute(params, ctx) {
   ctx.onSignal?.({
     type: "waiting_for_input",
     question: "Which option do you prefer?",
     options: ["Option A", "Option B"],
   });
   // ...
-})
+    return { content: [{ type: "text", text: "Waiting for input." }], details: null };
+  },
+});
 ```
 
 The host emits a `waiting_for_user_input` event and the UI can surface the question to the user.
@@ -105,7 +115,7 @@ Tools in a hosted Agentrail app come from several sources:
 
 ### 1. Custom runtime tools
 
-Domain-specific tools you define yourself using `tool()` or `defineSimpleTool`. These live in your app's packages or source files and are passed to a profile's `createAgent`.
+Domain-specific tools you define yourself using `defineTool`, `tool()`, or `defineSimpleTool`. These live in your app's packages or source files and are passed to a profile's `agent.tools` or `createAgent`.
 
 ### 2. `@agentrail/capabilities` built-in tools
 
@@ -120,12 +130,12 @@ Capability tools are added to a profile via `defineProfile({ capabilities: [...]
 
 | Capability         | Example tools                                    |
 | ------------------ | ------------------------------------------------ |
-| `knowledge(km)`    | knowledge-search, knowledge-index                |
-| `filesystem(sbm)`  | bash, read, write, edit, glob, grep, sleep, todo-write |
+| `knowledge(km)`    | kb-list, kb-read, kb-search                      |
+| `filesystem(...)`  | bash, read, write, edit, glob, grep, sleep, todo-write |
 | `skills(sm)`       | skill-list, skill-invoke                         |
 | `orchestration(r)` | spawn-agent, send-input, wait-agent, close-agent |
 
-### 4. Orchestration tools
+### 3. Orchestration tools
 
 When a hosted profile uses the orchestration layer, the parent agent gets `spawn-agent`, `send-input`, `wait-agent`, and `close-agent` tools. These let it delegate work to sub-agents and wait for results.
 
@@ -139,10 +149,13 @@ import { filesystem } from "@agentrail/capabilities";
 
 export const defaultProfile = defineProfile({
   id: "default",
-  model: "anthropic/claude-sonnet-4-5",
-  system: systemPrompt,
-  tools: [customerLookupTool, pingTool],
-  capabilities: [filesystem(sandboxManager)],
+  name: "Default Assistant",
+  agent: {
+    model: "anthropic:claude-sonnet-4-5",
+    prompt: systemPrompt,
+    tools: [customerLookupTool, pingTool],
+  },
+  capabilities: [filesystem({ sandboxManager })],
 });
 ```
 

--- a/docs/examples/playground-server.md
+++ b/docs/examples/playground-server.md
@@ -62,9 +62,12 @@ The default profile lives in `profiles/default-profile.ts`. It shows the recomme
 
 ```ts
 // examples/playground-server/src/profiles/default-profile.ts (simplified)
-import { defineProfile, createStaticProfileResolver } from "@agentrail/app";
-import { filesystem, browser, knowledge, skills, orchestration, memoryContext } from "@agentrail/capabilities";
+import { compactToolResults, createStaticProfileResolver, defineProfile } from "@agentrail/app";
+import { askUser, browser, createSubAgentProcess, filesystem, knowledge, memoryContext, orchestration, skills } from "@agentrail/capabilities";
+import { config } from "../config.js";
 import { knowledgeManager, sandboxManager, skillManager, orchestrationRegistry, sessionManager } from "../context/index.js";
+import { waitHandleRegistry } from "../wait-handle-registry.js";
+import { getWorkerPath } from "../agents/worker-path.js";
 
 export const defaultProfile = defineProfile({
   id: "agentrail-default-agent",
@@ -78,9 +81,38 @@ export const defaultProfile = defineProfile({
     filesystem({ sandboxManager }),
     browser({ sandboxManager }),
     knowledge(knowledgeManager),
-    skills(skillManager, { mode: "delegate" }),
-    orchestration(orchestrationRegistry, subAgentFactory),
-    memoryContext({ buildMemoryIndex, listKnowledgeMetadatas, listSkills }, { cacheTtlMs: 5_000 }),
+    skills(skillManager, {
+      mode: config.skillDelegateToSubAgent ? "delegate" : "inline",
+    }),
+    askUser(waitHandleRegistry),
+    orchestration(orchestrationRegistry, (input, ctx) =>
+      createSubAgentProcess({
+        tenantId: ctx.tenantId,
+        userId: ctx.userId,
+        sessionId: ctx.sessionId,
+        sessionRef: ctx.sessionRef,
+        dataDir: config.dataDir,
+        input,
+        workerPath: getWorkerPath(),
+        runtimeConfig: { input },
+        workerConfig: config.orchestration.subagent,
+      }),
+    ),
+    memoryContext(
+      {
+        buildMemoryIndex: (ctx) =>
+          sessionManager.buildMemoryIndex(ctx.tenantId, ctx.userId, ctx.sessionId),
+        listKnowledgeMetadatas: async (ctx) => {
+          const kbList = await knowledgeManager.listKbs(ctx.tenantId);
+          return Promise.all(kbList.map((id) => knowledgeManager.getMetadata(ctx.tenantId, id)));
+        },
+        listSkills: () => skillManager.listSkills(),
+        listWorkspaceSnapshot: (ctx) => sandboxManager.listWorkspace(ctx.sessionId),
+        compactMessages: compactToolResults,
+        delegateSkillsToSubAgent: config.skillDelegateToSubAgent,
+      },
+      { cacheTtlMs: 5_000 },
+    ),
   ],
 });
 
@@ -93,19 +125,19 @@ Plugins live in `plugins/index.ts`. Each plugin owns one horizontal concern:
 
 ```ts
 // examples/playground-server/src/plugins/index.ts (simplified)
-import type { AgentrailPlugin } from "@agentrail/app";
-import { slashCommandsPlugin } from "./slash-commands.js";
-import { attachmentHintsPlugin } from "./attachment-hints.js";
-import { userMemoryPlugin } from "./user-memory.js";
+import { createUserMemoryPlugin } from "@agentrail/app";
+import { userMemoryConsolidationService } from "../context/index.js";
+import { createAttachmentHintsPlugin } from "./attachment-hints.js";
+import { createSlashCommandsPlugin } from "./slash-commands.js";
 
-export const plugins: AgentrailPlugin[] = [
-  slashCommandsPlugin, // intercepts /commands before the agent runs
-  attachmentHintsPlugin, // injects file context for uploaded attachments
-  userMemoryPlugin, // adds user memory notes to context
+export const playgroundPlugins = [
+  createUserMemoryPlugin(userMemoryConsolidationService),
+  createAttachmentHintsPlugin(),
+  createSlashCommandsPlugin(),
 ];
 ```
 
-The `slashCommandsPlugin` uses `interceptChatRequest` to handle `/help`, `/reset`, and similar commands without invoking the LLM.
+The slash-commands plugin uses `interceptChatRequest` to handle `/help`, `/reset`, and similar commands without invoking the LLM. The user-memory plugin runs as a host concern rather than a profile concern.
 
 ---
 

--- a/docs/guides/add-context.md
+++ b/docs/guides/add-context.md
@@ -76,7 +76,7 @@ That path is especially useful when you want to compose:
 
 The current implementation lives in:
 
-- [packages/app/src/host/capability-context.ts](../../packages/app/src/host/capability-context.ts)
+- [packages/capabilities/src/memory/context.ts](../../packages/capabilities/src/memory/context.ts)
 
 ## Repository Example
 
@@ -134,7 +134,7 @@ If the defaults layer is too opinionated, use these primitives directly:
 - `createTransformContext`
 - `createContextProviderFromTransform`
 
-These live in `@agentrail/app` and let you build a custom context pipeline without adopting the default capability stack.
+These live in `@agentrail/app/advanced` and `@agentrail/capabilities` and let you build a custom context pipeline without adopting the default capability stack.
 
 ## Related Docs
 

--- a/docs/guides/add-tools.md
+++ b/docs/guides/add-tools.md
@@ -38,19 +38,22 @@ Examples include:
 
 - ask-user style interactions
 - todo/task progress writing
-- filesystem, browser, and knowledge tools
+- filesystem, browser, knowledge, and orchestration tools
 
 This is the lowest-friction path when you want a working host quickly. Add capabilities to a profile via:
 
 ```ts
 import { defineProfile } from "@agentrail/app";
-import { filesystem, webSearch } from "@agentrail/capabilities";
+import { filesystem } from "@agentrail/capabilities";
 
 export const defaultProfile = defineProfile({
   id: "default",
-  model: "anthropic/claude-sonnet-4-5",
-  system: "You are a helpful assistant.",
-  capabilities: [filesystem(), webSearch()],
+  name: "Default Assistant",
+  agent: {
+    model: "anthropic:claude-sonnet-4-5",
+    prompt: "You are a helpful assistant.",
+  },
+  capabilities: [filesystem({ sandboxManager })],
 });
 ```
 
@@ -79,10 +82,13 @@ import { customerLookupTool } from "./tools/customer-lookup.js";
 
 export const supportProfile = defineProfile({
   id: "support",
-  model: "anthropic/claude-sonnet-4-5",
-  system: "You are a support assistant.",
-  tools: [customerLookupTool],
-  capabilities: [filesystem()],
+  name: "Support Assistant",
+  agent: {
+    model: "anthropic:claude-sonnet-4-5",
+    prompt: "You are a support assistant.",
+    tools: [customerLookupTool],
+  },
+  capabilities: [filesystem({ sandboxManager })],
 });
 ```
 
@@ -99,13 +105,12 @@ import { Type } from "@sinclair/typebox";
 import { defineTool } from "@agentrail/core";
 
 export const customerLookupTool = defineTool({
-  name: "CustomerLookup",
-  label: "Customer Lookup",
+  name: "customer_lookup",
   description: "Look up customer details by account id.",
   parameters: Type.Object({
     accountId: Type.String(),
   }),
-  async execute(_toolCallId, params) {
+  async execute(params) {
     return {
       content: [
         {
@@ -129,7 +134,7 @@ A common pattern is:
 
 1. define reusable tools in a package or app-local runtime module
 2. build a tool list in one place
-3. pass that list into your profile’s `createAgent`
+3. pass that list into your profile’s `agent.tools` or dynamic `createAgent`
 
 This keeps route files small and avoids duplicated tool lists.
 

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -119,9 +119,12 @@ import { orchestration } from "@agentrail/capabilities";
 
 export const orchestratorProfile = defineProfile({
   id: "orchestrator",
-  model: "anthropic/claude-sonnet-4-5",
-  system: "You are an orchestrator that coordinates sub-agents.",
-  capabilities: [orchestration(waitHandleRegistry)],
+  name: "Orchestrator",
+  agent: {
+    model: "anthropic:claude-sonnet-4-5",
+    prompt: "You are an orchestrator that coordinates sub-agents.",
+  },
+  capabilities: [orchestration(orchestrationRegistry, subAgentFactory)],
 });
 ```
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -91,6 +91,8 @@ const agentApp = createAgentApp({
 app.route("/api", agentApp);
 ```
 
+`src/main.ts` also imports `@agentrail/core/providers` once at startup so the built-in Anthropic and OpenAI providers are registered before requests arrive.
+
 `createAgentApp` handles the full request lifecycle: session lookup or creation, context assembly, LLM streaming, tool dispatch, compaction, and SSE event forwarding. It returns a Hono app with both `/chat` (JSON) and `/stream` (SSE) endpoints.
 
 ## Manual Setup (Without Scaffold)

--- a/docs/guides/use-capability-packages.md
+++ b/docs/guides/use-capability-packages.md
@@ -58,7 +58,7 @@ export const researchProfile = defineProfile({
 });
 ```
 
-At request time, the agent receives KB metadata summaries as context and gains access to `knowledge-search` and `knowledge-index` tools.
+At request time, the agent receives KB metadata summaries as context and gains access to `kb-list`, `kb-read`, and `kb-search`.
 
 ---
 
@@ -116,7 +116,7 @@ export const coderProfile = defineProfile({
     model: "anthropic:claude-sonnet-4-5",
     prompt: "You are a coding assistant. You can run code in a sandbox.",
   },
-  capabilities: [filesystem(sandboxManager)],
+  capabilities: [filesystem({ sandboxManager })],
 });
 ```
 
@@ -170,7 +170,7 @@ export const assistantProfile = defineProfile({
 });
 ```
 
-When `delegateToSubAgent` is `true`, skill execution is isolated inside a sub-agent. This is the recommended setting for production use.
+When `mode: "delegate"` is enabled, skill execution is isolated inside a sub-agent. This is the recommended setting for production use.
 
 ---
 
@@ -188,7 +188,7 @@ export const powerProfile = defineProfile({
     prompt: "You are a powerful assistant.",
   },
   capabilities: [
-    filesystem(sandboxManager),
+    filesystem({ sandboxManager }),
     knowledge(knowledgeManager),
     skills(skillManager, { mode: "delegate" }),
   ],

--- a/docs/public/arch-diagram.svg
+++ b/docs/public/arch-diagram.svg
@@ -53,7 +53,7 @@
 
   <text x="73" y="203" dominant-baseline="middle"
         font-family="'Courier New',Courier,monospace" font-size="11"
-        fill="rgba(196,255,46,0.28)" letter-spacing="0.01em">createChatRoute  &#183;  createStreamRoute  &#183;  createOrchestrationRegistry  &#183;  defineHostedProfile</text>
+        fill="rgba(196,255,46,0.28)" letter-spacing="0.01em">createChatRoute  &#183;  createStreamRoute  &#183;  createOrchestrationRegistry  &#183;  compat migration helpers</text>
 
   <!-- arrow -->
   <line x1="450" y1="236" x2="450" y2="256"
@@ -104,7 +104,7 @@
 
   <text x="54" y="440" dominant-baseline="middle"
         font-family="'Courier New',Courier,monospace" font-size="10.5"
-        fill="rgba(196,255,46,0.28)" letter-spacing="0.01em">via defineProfile&#40;&#123; capabilities: [filesystem(), knowledge(), orchestration(), ...]  &#125;&#41;</text>
+        fill="rgba(196,255,46,0.28)" letter-spacing="0.01em">via defineProfile&#40;&#123; capabilities: [filesystem&#40;&#123; sandboxManager &#125;&#41;, knowledge&#40;km&#41;, orchestration&#40;registry, factory&#41;, ...]  &#125;&#41;</text>
 
   <!-- arrow -->
   <line x1="450" y1="464" x2="450" y2="484"

--- a/docs/public/lifecycle-diagram.svg
+++ b/docs/public/lifecycle-diagram.svg
@@ -16,7 +16,7 @@
   <circle cx="52" cy="110" r="14" fill="#1a1a18" stroke="#2e2e2c" stroke-width="1.5"/>
   <text x="52" y="110" text-anchor="middle" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="10" fill="#888880">1</text>
   <text x="82" y="105" dominant-baseline="middle" font-family="Georgia,'Times New Roman',serif" font-size="14" fill="#c8c6c0">getOrCreate session</text>
-  <text x="82" y="123" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="11" fill="#555550">creates or resumes session, returns sessionId &#8212; @agentrail/memo</text>
+  <text x="82" y="123" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="11" fill="#555550">creates or resumes session through the configured session store</text>
   <circle cx="52" cy="166" r="14" fill="#1a1a18" stroke="#2e2e2c" stroke-width="1.5"/>
   <text x="52" y="166" text-anchor="middle" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="10" fill="#888880">2</text>
   <text x="82" y="161" dominant-baseline="middle" font-family="Georgia,'Times New Roman',serif" font-size="14" fill="#c8c6c0">resolveProfile &#8594; profile.createAgent()</text>
@@ -32,7 +32,7 @@
   <circle cx="52" cy="334" r="14" fill="#1a1a18" stroke="#2e2e2c" stroke-width="1.5"/>
   <text x="52" y="334" text-anchor="middle" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="10" fill="#888880">5</text>
   <text x="82" y="329" dominant-baseline="middle" font-family="Georgia,'Times New Roman',serif" font-size="14" fill="#c8c6c0">assemble context messages</text>
-  <text x="82" y="347" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="11" fill="#555550">capability messages, workspace snapshot, knowledge results</text>
+  <text x="82" y="347" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="11" fill="#555550">context providers inject memory, knowledge, skills, and workspace state</text>
   <circle cx="52" cy="390" r="14" fill="rgba(196,255,46,0.12)" stroke="rgba(196,255,46,0.5)" stroke-width="1.5"/>
   <text x="52" y="390" text-anchor="middle" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="10" fill="#c4ff2e">6</text>
   <text x="82" y="385" dominant-baseline="middle" font-family="Georgia,'Times New Roman',serif" font-size="14" fill="#c4ff2e">agent.stream(message, context)</text>
@@ -40,7 +40,7 @@
   <circle cx="52" cy="446" r="14" fill="#1a1a18" stroke="#2e2e2c" stroke-width="1.5"/>
   <text x="52" y="446" text-anchor="middle" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="10" fill="#888880">7</text>
   <text x="82" y="441" dominant-baseline="middle" font-family="Georgia,'Times New Roman',serif" font-size="14" fill="#c8c6c0">appendMessages + recordTurn</text>
-  <text x="82" y="459" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="11" fill="#555550">persists new messages and token usage to session store</text>
+  <text x="82" y="459" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="11" fill="#555550">persists new messages, turn usage, and session metadata updates</text>
   <circle cx="52" cy="490" r="14" fill="#1a1a18" stroke="#2e2e2c" stroke-width="1.5"/>
   <text x="52" y="490" text-anchor="middle" dominant-baseline="middle" font-family="'Courier New',Courier,monospace" font-size="10" fill="#888880">8</text>
   <text x="82" y="485" dominant-baseline="middle" font-family="Georgia,'Times New Roman',serif" font-size="14" fill="#c8c6c0">SSE done event</text>

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -40,7 +40,7 @@
 
 - [createAgentApp](https://agentrail.run/reference/create-agent-app): High-level hosted app entrypoint
 - [Host Primitives](https://agentrail.run/reference/host-primitives): Lower-level chat/stream/orchestration building blocks
-- [Host Defaults](https://agentrail.run/reference/host-defaults): Recommended app-layer defaults and helpers
+- [Compatibility APIs](https://agentrail.run/reference/host-defaults): Migration-only compat helpers retained for older hosts
 - [Profile Contract](https://agentrail.run/reference/profile-contract): `AgentrailProfile` and profile context types
 - [Plugin Contract](https://agentrail.run/reference/plugin-contract): `AgentrailPlugin` lifecycle hook contract
 - [Session Store](https://agentrail.run/reference/session-store): `AgentrailSessionStore` interface

--- a/docs/reference/profile-contract.md
+++ b/docs/reference/profile-contract.md
@@ -38,7 +38,6 @@ import { defineAgent } from "@agentrail/core";
 export const analyticsProfile = defineProfile({
   id: "analytics",
   name: "Analytics Agent",
-  contextWindow: 128_000,
   agent: {
     model: "openai:gpt-4o",
     prompt: async (ctx) => loadSystemPrompt(ctx.tenantId),
@@ -103,6 +102,8 @@ At the primitive level, a profile must provide `id`, `name`, and `createAgent`. 
 Optional. The model's context window size in tokens. Defaults to `200_000`.
 
 The stream route uses this value to compute `budgetUsedPct` in SSE events. Set it to the actual limit of the model used by this profile.
+
+This field belongs to the low-level `AgentrailProfile` contract. `defineProfile` does not currently expose `contextWindow` as a helper option, so you only set it when implementing a custom profile object directly.
 
 ## `ProfileDefinition`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,10 +42,10 @@ onMounted(() => {
   <div class="rm-group">
     <p class="rm-group-title">Core Stability</p>
     <div class="rm-items">
-      <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Finalize public API surface for <code>runtime-core</code>, <code>host</code>, and <code>orchestration</code></span></div>
+      <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Finalize public API surface for <code>@agentrail/core</code>, <code>@agentrail/app</code>, and orchestration capabilities</span></div>
       <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Lock the <code>AgentrailPlugin</code> contract</span></div>
       <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Lock the <code>AgentrailSessionStore</code> interface</span></div>
-      <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Lock the <code>AgentrailProfile</code> / <code>HostedProfileDefinition</code> contracts</span></div>
+      <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Lock the <code>AgentrailProfile</code> / <code>ProfileDefinition</code> contracts</span></div>
       <div class="rm-item"><span class="rm-icon rm-icon-todo">○</span><span>Stabilize the event type taxonomy (<code>RuntimeEvent</code>, <code>AgentrailHostEvent</code>)</span></div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- refresh the main docs narrative so the recommended path consistently matches the current public API
- update stale code snippets across quickstart, concepts, guides, and the playground server example
- align `llms.txt`, the home page entry, and the public architecture/lifecycle SVGs with the current docs structure

## Why
A number of high-traffic docs pages had drifted from the actual package layout and API surface. The main problems were:
- compat APIs showing up too prominently in mainline docs
- `defineProfile` examples still using outdated fields or old capability wiring
- public diagrams and `llms.txt` descriptions lagging behind the current framework terminology

## Impact
- new users now land on `createAgentApp + defineProfile` consistently across quickstart, architecture, and concept pages
- code examples better match the current repo and published packages
- `llms.txt` and the docs homepage now expose a more accurate docs index for both humans and AI tooling

## Validation
- `cd docs && npm run build`
- `git diff --check`