### PR TITLE
feat: add onBeforeToolCall / onAfterToolCall plugin hooks (#56)

### DIFF
--- a/.changeset/tool-call-hooks.md
+++ b/.changeset/tool-call-hooks.md
@@ -1,0 +1,23 @@
+---
+"@agentrail/core": minor
+"@agentrail/app": minor
+---
+
+Add `onBeforeToolCall` / `onAfterToolCall` plugin hooks and `ToolInterceptor` core interface.
+
+**`@agentrail/core`**
+
+- New `ToolInterceptor` interface with `onBeforeToolCall` and `onAfterToolCall` methods, exported from the package root.
+- New related types: `BeforeToolCallResult`, `ToolInterceptorBeforeContext`, `ToolInterceptorAfterContext`.
+- `AgentRunOptions` gains an optional `toolInterceptor` field that threads the interceptor into every tool execution.
+- `tool.before` stream event gains a `rawArgs` field that always carries the original model-generated arguments. `args` now reflects the effective (post-interceptor) input that was actually passed to the tool.
+
+**`@agentrail/app`**
+
+- `AgentrailPlugin` gains two new optional hooks:
+  - `onBeforeToolCall(event)` — called before each tool executes; can allow, modify, or deny the call.
+  - `onAfterToolCall(event)` — called after each tool completes (success or error, not deny).
+- New exported types: `BeforeToolCallEvent`, `AfterToolCallEvent`, `AppBeforeToolCallResult`.
+- New `buildToolInterceptor(plugins, profileCtx, onError)` helper that composes plugin hooks in priority order with `safeNotify` error isolation.
+- Hooks are only dispatched for tools whose validated input is a plain object; array- and primitive-typed tools skip both hooks.
+- Corrected plugin lifecycle order in JSDoc: `onTurnPersisted` fires before `onRequestEnd`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changeset:
+    name: Changeset check
+    runs-on: ubuntu-latest
+    # Only check PRs, not direct pushes to master.
+    # Skip the automated "Version Packages" release PR created by changesets/action.
+    # Skip PRs labelled `skip-changeset` (for docs-only / CI-only / internal changes).
+    if: |
+      github.event_name == 'pull_request' &&
+      github.head_ref != 'changeset-release/master' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch base branch so we can diff against it.
+          fetch-depth: 0
+
+      - name: Check for changeset
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          FILES=$(git diff --name-only "$BASE"...HEAD -- '.changeset/' \
+            | grep -E '^\.changeset/.+\.md$' \
+            | grep -v '^\.changeset/README\.md$' \
+            || true)
+          if [ -z "$FILES" ]; then
+            echo "::error::No changeset found for this PR."
+            echo ""
+            echo "Run 'pnpm changeset' to generate one."
+            echo "If this PR intentionally needs no changeset (docs-only, CI-only,"
+            echo "internal refactor), add the 'skip-changeset' label to the PR."
+            exit 1
+          fi
+          echo "Changeset(s) found:"
+          echo "$FILES"
+
   verify:
     runs-on: ubuntu-latest
     permissions:

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -198,10 +198,37 @@ The most important ones for UI consumers:
 | `turn.complete`             | A turn finishes                              |
 | `compaction`                | In-loop reactive compaction rewrites history |
 | `message.update`            | Streaming text delta from the LLM            |
-| `tool.before`               | The agent is about to invoke a tool          |
+| `tool.before`               | A tool call is about to be dispatched (after any `onBeforeToolCall` plugin hooks have run) |
 | `tool.after`                | A tool invocation completes                  |
 | `waiting_for_user_input`    | The agent is paused waiting for user input   |
 | `skill_start` / `skill_end` | A skill sub-agent is invoked                 |
+
+### `tool.before` field reference
+
+```ts
+{
+  type: "tool.before";
+  toolCallId: string;
+  toolName: string;
+  /**
+   * Effective input passed to the tool.
+   * When a `onBeforeToolCall` plugin hook modifies the arguments, this field
+   * reflects the modified value rather than the raw model-generated arguments.
+   */
+  args: unknown;
+  /**
+   * Original model-generated arguments, always equal to the raw tool call
+   * payload from the model.  Identical to `args` when no plugin modified the
+   * input.  Use this field for audit logging and debugging.
+   */
+  rawArgs: unknown;
+}
+```
+
+> **Note for consumers that used `args` for audit purposes:** if you have a plugin
+> or tracing integration that reads `tool.before.args` and relies on it being the
+> unmodified model output, switch to `rawArgs`.  `args` now reflects the effective
+> (possibly plugin-modified) arguments that were actually executed.
 
 ---
 

--- a/docs/reference/plugin-contract.md
+++ b/docs/reference/plugin-contract.md
@@ -72,10 +72,18 @@ interface AgentrailPlugin {
   attachmentHandler?: AttachmentHandler;
   /** Runs at the start of every chat or stream request */
   onRequestStart?(ctx: AgentrailRequestLifecycleContext): void | Promise<void>;
-  /** Runs after the request lifecycle completes */
-  onRequestEnd?(ctx: AgentrailRequestLifecycleContext): void | Promise<void>;
+  /**
+   * Runs just before each individual tool call executes.
+   * Return `{ action: "deny", reason }` to block execution, or
+   * `{ action: "allow", input }` to replace the tool arguments.
+   */
+  onBeforeToolCall?(event: BeforeToolCallEvent): Promise<AppBeforeToolCallResult> | AppBeforeToolCallResult;
+  /** Runs after each tool call completes (success or execution error, not deny). */
+  onAfterToolCall?(event: AfterToolCallEvent): Promise<void> | void;
   /** Runs after the resulting turn has been persisted */
   onTurnPersisted?(ctx: AgentrailRequestLifecycleContext): void | Promise<void>;
+  /** Runs after the request lifecycle completes (last hook to fire per request) */
+  onRequestEnd?(ctx: AgentrailRequestLifecycleContext): void | Promise<void>;
 }
 ```
 
@@ -212,15 +220,88 @@ Typical uses:
 - liveness markers
 - request-scoped bookkeeping
 
-### `onRequestEnd`
-
-Runs after the host completes the request lifecycle.
-
 ### `onTurnPersisted`
 
-Runs after the host has persisted the resulting turn.
+Runs after the host has persisted the resulting turn — before `onRequestEnd`.
 
-Use it for behaviors that depend on the conversation state already being durable.
+Use it for behaviors that depend on the conversation state already being durable
+(e.g. triggering memory consolidation that reads the just-written messages).
+
+### `onRequestEnd`
+
+Runs last, after `onTurnPersisted`, once the response has been fully sent and the
+turn has been persisted. Use it for request teardown such as closing spans or
+recording final metrics.
+
+### `onBeforeToolCall`
+
+Runs just before each individual tool call is dispatched, after request-level
+hooks but before the tool's `execute()` function is called.
+
+> **Object-only constraint**: this hook is only called when the validated tool
+> input is a plain, non-array object (`typeof input === "object" && !Array.isArray(input)`).
+> Tools whose top-level schema is an array or a primitive (string, number, …) will
+> **not** trigger `onBeforeToolCall`.  This matches the `Record<string, unknown>` type
+> of `input` — the hook is not called for schemas that cannot be safely represented
+> as a record.
+
+```ts
+export interface BeforeToolCallEvent {
+  toolName: string;
+  input: Record<string, unknown>;   // fresh shallow copy per plugin call
+  context: AgentrailProfileContext; // tenantId, userId, sessionId, …
+}
+
+export type AppBeforeToolCallResult =
+  | { action: "allow" }
+  | { action: "deny"; reason: string }
+  | { action: "allow"; input: Record<string, unknown> };
+```
+
+Return values:
+
+| Result | Effect |
+|--------|--------|
+| `{ action: "allow" }` | Proceed with the original arguments |
+| `{ action: "allow", input }` | Replace the tool arguments with `input` |
+| `{ action: "deny", reason }` | Block the tool call; the model receives `reason` as an error |
+
+If a plugin throws, the error is reported via `onPluginError` and execution
+continues with the next plugin — **a throw is not treated as a deny**.
+
+Multiple plugins run in descending `priority` order. The first `deny` wins; a
+modified `input` is forwarded to subsequent plugins.
+
+Each plugin receives a **fresh shallow copy** of `input`.  In-place mutations do
+not affect other plugins; use the `{ action: "allow", input }` return value to
+propagate changes.
+
+Use cases: audit logging, compliance checks, input sanitization, credential
+stripping, path restriction enforcement.
+
+### `onAfterToolCall`
+
+Runs after a tool's `execute()` returns, whether the execution succeeded or
+raised an error.  **Not called** in two cases:
+
+1. When `onBeforeToolCall` returned `{ action: "deny" }`.
+2. When the tool's validated input is not a plain object (same constraint as
+   `onBeforeToolCall` — array- or primitive-typed tools skip this hook).
+
+```ts
+export interface AfterToolCallEvent {
+  toolName: string;
+  input: Record<string, unknown>; // fresh shallow copy; effective input after any before-hook changes
+  result: unknown;
+  durationMs: number;
+  context: AgentrailProfileContext;
+}
+```
+
+Errors thrown by this hook are reported via `onPluginError` and do not affect
+the tool result returned to the model.
+
+Use cases: execution auditing, latency metrics, result redaction.
 
 ## Complete Example Plugin
 
@@ -336,6 +417,8 @@ propagates to the calling request unless `critical: true` is set on that plugin.
 | `interceptChatRequest` (non-critical) | Report, skip plugin (treated as `null`) |
 | `interceptChatRequest` (critical) | Report, rethrow (request is aborted) |
 | `attachmentHandler` | Report, skip plugin result, merge others |
+| `onBeforeToolCall` | Report, continue to next plugin (not treated as deny) |
+| `onAfterToolCall` | Report, continue (tool result is unaffected) |
 
 ### `onPluginError` callback
 

--- a/packages/app/src/host/plugins.ts
+++ b/packages/app/src/host/plugins.ts
@@ -4,9 +4,15 @@
  */
 
 import type {
+  ToolInterceptor,
+  ToolInterceptorAfterContext,
+  ToolInterceptorBeforeContext,
+} from "@agentrail/core";
+import type {
   AgentrailChatHandledResponse,
   AgentrailChatRequestContext,
   AgentrailPlugin,
+  AgentrailProfileContext,
   AgentrailRequestLifecycleContext,
   AttachmentFile,
   AttachmentHandler,
@@ -41,6 +47,20 @@ async function safeNotify(
       notifyErr,
     );
   }
+}
+
+/**
+ * Returns true when `value` is a plain, non-array object.
+ *
+ * Used by `buildToolInterceptor` to guard the object-spread copy that is
+ * applied before each plugin hook call.  The app-layer `BeforeToolCallEvent`
+ * and `AfterToolCallEvent` contracts expose `input` as `Record<string, unknown>`,
+ * so hooks are only meaningful for object-shaped tool parameters.  For arrays,
+ * primitives, or `null`, the composed interceptor skips all plugin hooks rather
+ * than corrupting the value with an object spread.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /** Returns a new array sorted by descending priority (higher runs first). */
@@ -151,6 +171,116 @@ export async function runPluginChatRequestInterceptors(
   }
 
   return null;
+}
+
+/**
+ * Builds a `ToolInterceptor` that composes `onBeforeToolCall` and
+ * `onAfterToolCall` hooks from all registered plugins, in descending priority
+ * order (same ordering used for all other plugin hooks).
+ *
+ * Returns `undefined` when no plugin implements either hook so that the caller
+ * can skip interceptor overhead entirely.
+ *
+ * ### Error isolation
+ * - **`onBeforeToolCall`**: if a plugin hook throws, the error is reported via
+ *   `safeNotify(onError, ...)` and execution continues with the next plugin
+ *   (the throw is **not** treated as a deny). Only an explicit
+ *   `{ action: "deny" }` return blocks tool execution.
+ * - **`onAfterToolCall`**: each plugin hook is individually try/caught; errors
+ *   are reported via `safeNotify` and do not affect the tool result.
+ */
+export function buildToolInterceptor(
+  plugins: AgentrailPlugin[],
+  profileContext: AgentrailProfileContext,
+  onError: PluginErrorHandler = defaultErrorHandler,
+): ToolInterceptor | undefined {
+  const ordered = sortByPriority(plugins);
+  const beforePlugins = ordered.filter((p) => p.onBeforeToolCall != null);
+  const afterPlugins = ordered.filter((p) => p.onAfterToolCall != null);
+
+  if (beforePlugins.length === 0 && afterPlugins.length === 0) {
+    return undefined;
+  }
+
+  const interceptor: ToolInterceptor = {};
+
+  if (beforePlugins.length > 0) {
+    interceptor.onBeforeToolCall = async (ctx: ToolInterceptorBeforeContext) => {
+      // App-layer plugin hooks only support object-shaped tool parameters.
+      // Skip all hooks for arrays, primitives, and null so the value is never
+      // corrupted by an object spread.
+      if (!isPlainObject(ctx.input)) {
+        return { action: "allow" };
+      }
+
+      let currentInput: Record<string, unknown> = ctx.input;
+
+      for (const plugin of beforePlugins) {
+        try {
+          const result = await plugin.onBeforeToolCall!({
+            toolName: ctx.toolName,
+            // Fresh shallow copy per plugin so that in-place mutations by one
+            // plugin do not silently affect subsequent plugins.  Explicit
+            // `{ action: "allow", input }` is the declared API for passing
+            // modifications forward.
+            input: { ...currentInput },
+            context: profileContext,
+          });
+
+          if (result.action === "deny") {
+            return result;
+          }
+
+          if (result.action === "allow" && "input" in result) {
+            currentInput = result.input;
+          }
+        } catch (err) {
+          await safeNotify(onError, {
+            plugin: plugin.name,
+            hook: "onBeforeToolCall",
+            error: err,
+          });
+          // A throw is NOT a deny — continue to the next plugin.
+        }
+      }
+
+      return currentInput !== (ctx.input as Record<string, unknown>)
+        ? { action: "allow", input: currentInput }
+        : { action: "allow" };
+    };
+  }
+
+  if (afterPlugins.length > 0) {
+    interceptor.onAfterToolCall = async (ctx: ToolInterceptorAfterContext) => {
+      // Same guard as onBeforeToolCall — skip for non-object inputs.
+      if (!isPlainObject(ctx.input)) {
+        return;
+      }
+
+      const baseInput: Record<string, unknown> = ctx.input;
+
+      for (const plugin of afterPlugins) {
+        try {
+          await plugin.onAfterToolCall!({
+            toolName: ctx.toolName,
+            // Fresh shallow copy per plugin, consistent with onBeforeToolCall.
+            input: { ...baseInput },
+            result: ctx.result,
+            durationMs: ctx.durationMs,
+            context: profileContext,
+          });
+        } catch (err) {
+          await safeNotify(onError, {
+            plugin: plugin.name,
+            hook: "onAfterToolCall",
+            error: err,
+          });
+        }
+      }
+    };
+  }
+
+  return interceptor;
 }
 
 /**

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -156,6 +156,71 @@ export interface AgentrailRequestLifecycleContext {
   agentId: string;
 }
 
+// ============================================================================
+// Tool call hook types
+// ============================================================================
+
+/**
+ * App-layer result type for `onBeforeToolCall`.
+ *
+ * This is the **app-level** variant where a replacement `input` is typed as
+ * `Record<string, unknown>` (matching the structured tool parameter convention).
+ * It is a strict subtype of the core `BeforeToolCallResult` and is safely
+ * up-cast inside `buildToolInterceptor` without runtime validation.
+ */
+export type AppBeforeToolCallResult =
+  | { readonly action: "allow" }
+  | { readonly action: "deny"; readonly reason: string }
+  | { readonly action: "allow"; readonly input: Record<string, unknown> };
+
+/**
+ * Event passed to `AgentrailPlugin.onBeforeToolCall`.
+ *
+ * **Object-only contract**: the app layer only dispatches `onBeforeToolCall` when
+ * the validated tool input is a plain, non-array object.  Tools whose top-level
+ * schema is an array or primitive will silently skip all `onBeforeToolCall` hooks
+ * via `buildToolInterceptor`.  This matches the `Record<string, unknown>` type of
+ * `input` — hooks are not called for schemas that cannot safely be represented as
+ * a record.
+ */
+export interface BeforeToolCallEvent {
+  /** Name of the tool being invoked. */
+  readonly toolName: string;
+  /**
+   * Fresh shallow copy of the validated tool arguments for this plugin call.
+   * Returning `{ action: "allow", input: { ...modified } }` propagates the
+   * modified input to subsequent plugins and to the actual tool execution.
+   * In-place mutations to this object do **not** affect other plugins.
+   */
+  readonly input: Record<string, unknown>;
+  /** Identity and session information for the current request. */
+  readonly context: AgentrailProfileContext;
+}
+
+/**
+ * Event passed to `AgentrailPlugin.onAfterToolCall`.
+ *
+ * Like `BeforeToolCallEvent`, this event is only dispatched for tools whose
+ * validated input is a plain object.  Array- and primitive-typed tools skip
+ * `onAfterToolCall` hooks silently.
+ */
+export interface AfterToolCallEvent {
+  /** Name of the tool that was invoked. */
+  readonly toolName: string;
+  /**
+   * Fresh shallow copy of the effective input that was passed to the tool
+   * (after any `onBeforeToolCall` modifications).  In-place mutations do
+   * **not** affect other plugins.
+   */
+  readonly input: Record<string, unknown>;
+  /** The result produced by the tool. */
+  readonly result: unknown;
+  /** Wall-clock duration of the tool's `execute()` call in milliseconds. */
+  readonly durationMs: number;
+  /** Identity and session information for the current request. */
+  readonly context: AgentrailProfileContext;
+}
+
 /**
  * Lightweight host extension contract for request interception and lifecycle hooks.
  *
@@ -166,9 +231,10 @@ export interface AgentrailRequestLifecycleContext {
  * ### Lifecycle
  * 1. `start()` — called once when `createAgentApp` initialises. Use to open
  *    connections or warm up caches.
- * 2. Per-request hooks run in declaration order:
- *    `interceptChatRequest` → `onRequestStart` → _(agent runs)_ → `onRequestEnd`
- *    → `onTurnPersisted`
+ * 2. Per-request hooks run in priority order:
+ *    `interceptChatRequest` → `onRequestStart` → _(agent runs)_
+ *    → per tool: `onBeforeToolCall` → _(tool executes)_ → `onAfterToolCall`
+ *    → `onTurnPersisted` → `onRequestEnd`
  * 3. `stop()` — called on graceful shutdown. Use to flush buffers and close
  *    connections.
  *
@@ -266,6 +332,30 @@ export interface AgentrailPlugin {
    * Use for post-turn side effects such as triggering memory consolidation.
    */
   onTurnPersisted?(context: AgentrailRequestLifecycleContext): void | Promise<void>;
+
+  /**
+   * Called just before a tool's `execute()` is invoked.
+   *
+   * Return `{ action: "allow" }` to proceed unchanged, `{ action: "allow", input }` to
+   * replace the arguments passed to the tool, or `{ action: "deny", reason }` to abort
+   * the tool call and surface an error to the model.
+   *
+   * If this hook throws, the error is reported via `onPluginError` and execution
+   * continues as if the hook returned `{ action: "allow" }` (i.e. a throw is **not**
+   * treated as a deny).
+   */
+  onBeforeToolCall?(
+    event: BeforeToolCallEvent,
+  ): Promise<AppBeforeToolCallResult> | AppBeforeToolCallResult;
+
+  /**
+   * Called after a tool completes (both successful runs and execution errors).
+   * Not called when execution was blocked by a `deny` result.
+   *
+   * Errors thrown here are reported via `onPluginError` and do not affect the
+   * tool result returned to the model.
+   */
+  onAfterToolCall?(event: AfterToolCallEvent): Promise<void> | void;
 }
 
 /** Uploaded attachment metadata made available to attachment handlers. */

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -46,6 +46,7 @@ export { createFileSystemSessionTraceStore } from "@/session/trace-store.js";
 // ============================================================================
 
 export type {
+  AfterToolCallEvent,
   AgentrailChatHandledResponse,
   AgentrailChatRequest,
   AgentrailChatRequestContext,
@@ -56,9 +57,11 @@ export type {
   AgentrailRequestLifecycleContext,
   AgentrailResolvedChatContext,
   AgentrailSessionStore,
+  AppBeforeToolCallResult,
   AttachmentFile,
   AttachmentHandler,
   AttachmentHandlerResult,
+  BeforeToolCallEvent,
   ContextProvider,
   ContextProviderContext,
   PluginErrorContext,
@@ -69,7 +72,7 @@ export type {
 // Plugins
 // ============================================================================
 
-export { runPluginLifecycle } from "@/host/plugins.js";
+export { buildToolInterceptor, runPluginLifecycle } from "@/host/plugins.js";
 
 export {
   UserMemoryConsolidationService,

--- a/packages/app/src/routes/chat-route.ts
+++ b/packages/app/src/routes/chat-route.ts
@@ -15,7 +15,7 @@ import {
 import { TRACE_PERSISTED_EVENT_TYPES, wrapTraceEvent, type WorkflowTraceEventEnvelope } from "@/events/index.js";
 import { createReactiveCompactionController, type SummarizeMessagesFn } from "@/host/reactive-compaction.js";
 import { runCompactionStep } from "@/routes/compaction-runner.js";
-import { runPluginChatRequestInterceptors, runPluginRequestHook } from "@/host/plugins.js";
+import { buildToolInterceptor, runPluginChatRequestInterceptors, runPluginRequestHook } from "@/host/plugins.js";
 import type {
   AgentrailChatHandledResponse,
   AgentrailChatRequest,
@@ -286,6 +286,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
           signal,
           transformContext,
           reactiveCompaction,
+          toolInterceptor: buildToolInterceptor(plugins, profileCtx, onPluginError),
         });
       } catch (invokeError) {
         emitTraceEvent(

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -14,12 +14,12 @@ import {
 } from "@/events/index.js";
 import type { SessionRef } from "@agentrail/core";
 import type { OrchestrationManager } from "@agentrail/capabilities";
-import type { Agent, Message, RuntimeEvent, TransformContextFn, Usage } from "@agentrail/core";
+import type { Agent, Message, RuntimeEvent, ToolInterceptor, TransformContextFn, Usage } from "@agentrail/core";
 import { isRuntimeError } from "@agentrail/core";
 import type { SandboxManager } from "@agentrail/capabilities";
 import { Hono } from "hono";
 import { streamText } from "hono/streaming";
-import { runPluginRequestHook } from "@/host/plugins.js";
+import { buildToolInterceptor, runPluginRequestHook } from "@/host/plugins.js";
 import { createReactiveCompactionController, type SummarizeMessagesFn } from "@/host/reactive-compaction.js";
 import { runCompactionStep } from "@/routes/compaction-runner.js";
 import { awaitSandboxWarmup } from "@/routes/sandbox-warmup.js";
@@ -398,6 +398,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
             contextWindow: profile.contextWindow,
             writeEvent,
             onTraceEvent: maybeTraceEvent,
+            toolInterceptor: buildToolInterceptor(plugins, profileCtx, onPluginError),
             onTurnMessagesReady: async (msgs) => {
               await options.sessionStore.appendMessages(tenantId, sid, msgs);
             },
@@ -436,6 +437,7 @@ interface DrainAgentStreamOptions {
   contextWindow?: number;
   writeEvent: (event: RuntimeEvent | object) => Promise<void>;
   onTraceEvent: (event: RuntimeEvent | object) => void;
+  toolInterceptor?: ToolInterceptor;
   /**
    * Called after each internal reasoning turn (turn.complete) with the batch of new messages
    * produced during that turn. SSE is written first; this runs immediately after.
@@ -471,6 +473,7 @@ async function drainAgentStream(
     signal: opts.signal,
     transformContext: opts.transformContext,
     reactiveCompaction: opts.reactiveCompaction,
+    toolInterceptor: opts.toolInterceptor,
   });
 
   for await (const event of agentStream) {

--- a/packages/app/test/plugins.test.ts
+++ b/packages/app/test/plugins.test.ts
@@ -5,13 +5,22 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  buildToolInterceptor,
   runPluginLifecycle,
   runPluginRequestHook,
   runPluginChatRequestInterceptors,
   runAttachmentHandlers,
   collectPluginContextProviders,
 } from "../src/host/plugins.js";
-import type { AgentrailPlugin, AgentrailRequestLifecycleContext, PluginErrorHandler } from "../src/host/types.js";
+import type {
+  AfterToolCallEvent,
+  AgentrailPlugin,
+  AgentrailProfileContext,
+  AgentrailRequestLifecycleContext,
+  AppBeforeToolCallResult,
+  BeforeToolCallEvent,
+  PluginErrorHandler,
+} from "../src/host/types.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -228,6 +237,279 @@ describe("runAttachmentHandlers", () => {
     const fallback = vi.fn(async () => ({ contextText: "fallback" }));
     const result = await runAttachmentHandlers(files, [], fallback);
     expect(result?.contextText).toBe("fallback");
+  });
+});
+
+// ─── buildToolInterceptor ─────────────────────────────────────────────────────
+
+const mockProfileCtx: AgentrailProfileContext = {
+  tenantId: "t1",
+  userId: "u1",
+  sessionId: "s1",
+  sessionRef: { tenantId: "t1", userId: "u1", sessionId: "s1" } as AgentrailProfileContext["sessionRef"],
+  sessionStore: {} as AgentrailProfileContext["sessionStore"],
+};
+
+function makeToolPlugin(
+  name: string,
+  overrides: Pick<AgentrailPlugin, "priority" | "onBeforeToolCall" | "onAfterToolCall"> & { priority?: number },
+): AgentrailPlugin {
+  return { name, ...overrides };
+}
+
+function makeBeforeEvent(toolName = "test", input: Record<string, unknown> = { value: "x" }): BeforeToolCallEvent {
+  return { toolName, input, context: mockProfileCtx };
+}
+
+describe("buildToolInterceptor", () => {
+  // ── Non-object input guard ──────────────────────────────────────────────────
+
+  it("skips onBeforeToolCall hooks when input is an array (not a plain object)", async () => {
+    const hook = vi.fn().mockResolvedValue({ action: "allow" });
+    const plugin = makeToolPlugin("p1", { onBeforeToolCall: hook });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
+    const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: ["a", "b"] });
+    expect(hook).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ action: "allow" });
+  });
+
+  it("skips onBeforeToolCall hooks when input is a primitive", async () => {
+    const hook = vi.fn().mockResolvedValue({ action: "allow" });
+    const plugin = makeToolPlugin("p1", { onBeforeToolCall: hook });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
+    const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: 42 });
+    expect(hook).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ action: "allow" });
+  });
+
+  it("skips onAfterToolCall hooks when input is an array", async () => {
+    const hook = vi.fn();
+    const plugin = makeToolPlugin("p1", { onAfterToolCall: hook });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
+    await interceptor.onAfterToolCall!({ toolName: "t", input: ["a", "b"], result: {}, durationMs: 0 });
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it("skips onAfterToolCall hooks when input is null", async () => {
+    const hook = vi.fn();
+    const plugin = makeToolPlugin("p1", { onAfterToolCall: hook });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
+    await interceptor.onAfterToolCall!({ toolName: "t", input: null, result: {}, durationMs: 0 });
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it("still calls hooks normally for plain-object inputs", async () => {
+    const hook = vi.fn().mockResolvedValue({ action: "allow" });
+    const plugin = makeToolPlugin("p1", { onBeforeToolCall: hook });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
+    await interceptor.onBeforeToolCall!({ toolName: "t", input: { value: "x" } });
+    expect(hook).toHaveBeenCalledOnce();
+  });
+
+  // ── Other buildToolInterceptor tests ────────────────────────────────────────
+
+  it("returns undefined when no plugin implements either hook", () => {
+    const interceptor = buildToolInterceptor([makePlugin("p1"), makePlugin("p2")], mockProfileCtx);
+    expect(interceptor).toBeUndefined();
+  });
+
+  it("returns a ToolInterceptor when at least one plugin has a hook", () => {
+    const plugin = makeToolPlugin("p1", {
+      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow" }),
+    });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx);
+    expect(interceptor).toBeDefined();
+    expect(interceptor?.onBeforeToolCall).toBeDefined();
+  });
+
+  it("uses defaultErrorHandler when onError is omitted (no throw)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const plugin = makeToolPlugin("bad", {
+      onBeforeToolCall: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+    const interceptor = buildToolInterceptor([plugin], mockProfileCtx);
+    // Should not throw; error should be swallowed via defaultErrorHandler → console.warn
+    await expect(interceptor!.onBeforeToolCall!({ toolName: "t", input: {} })).resolves.toMatchObject({ action: "allow" });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  describe("onBeforeToolCall composition", () => {
+    it("runs plugins in descending priority order", async () => {
+      const order: string[] = [];
+      const low = makeToolPlugin("low", {
+        priority: 0,
+        onBeforeToolCall: vi.fn().mockImplementation(async () => { order.push("low"); return { action: "allow" }; }),
+      });
+      const high = makeToolPlugin("high", {
+        priority: 10,
+        onBeforeToolCall: vi.fn().mockImplementation(async () => { order.push("high"); return { action: "allow" }; }),
+      });
+      const interceptor = buildToolInterceptor([low, high], mockProfileCtx)!;
+      await interceptor.onBeforeToolCall!({ toolName: "t", input: {} });
+      expect(order).toEqual(["high", "low"]);
+    });
+
+    it("first-deny-wins: subsequent plugins are skipped", async () => {
+      const second = vi.fn().mockResolvedValue({ action: "allow" });
+      const first = makeToolPlugin("first", {
+        priority: 10,
+        onBeforeToolCall: vi.fn().mockResolvedValue({ action: "deny", reason: "no" }),
+      });
+      const secondPlugin = makeToolPlugin("second", {
+        priority: 0,
+        onBeforeToolCall: second,
+      });
+      const interceptor = buildToolInterceptor([first, secondPlugin], mockProfileCtx)!;
+      const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: {} });
+      expect(result).toMatchObject({ action: "deny", reason: "no" });
+      expect(second).not.toHaveBeenCalled();
+    });
+
+    it("modified input is forwarded to the next plugin and returned", async () => {
+      const received: Record<string, unknown>[] = [];
+      const first = makeToolPlugin("first", {
+        priority: 10,
+        onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow", input: { value: "modified" } }),
+      });
+      const second = makeToolPlugin("second", {
+        priority: 0,
+        onBeforeToolCall: vi.fn().mockImplementation(async (ev: BeforeToolCallEvent) => {
+          received.push(ev.input);
+          return { action: "allow" as const };
+        }),
+      });
+      const interceptor = buildToolInterceptor([first, second], mockProfileCtx)!;
+      const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: { value: "original" } }) as AppBeforeToolCallResult & { input?: Record<string, unknown> };
+      expect(received[0].value).toBe("modified");
+      expect(result).toMatchObject({ action: "allow", input: { value: "modified" } });
+    });
+
+    it("each plugin receives a fresh shallow copy of input, not the same reference", async () => {
+      const receivedRefs: Record<string, unknown>[] = [];
+      const mutatingPlugin = makeToolPlugin("mutator", {
+        priority: 10,
+        onBeforeToolCall: vi.fn().mockImplementation(async (ev: BeforeToolCallEvent) => {
+          receivedRefs.push(ev.input);
+          // In-place mutation — should NOT affect the next plugin's input.
+          (ev.input as Record<string, unknown>).injected = true;
+          return { action: "allow" as const };
+        }),
+      });
+      const observerPlugin = makeToolPlugin("observer", {
+        priority: 0,
+        onBeforeToolCall: vi.fn().mockImplementation(async (ev: BeforeToolCallEvent) => {
+          receivedRefs.push(ev.input);
+          return { action: "allow" as const };
+        }),
+      });
+      const interceptor = buildToolInterceptor([mutatingPlugin, observerPlugin], mockProfileCtx)!;
+      await interceptor.onBeforeToolCall!({ toolName: "t", input: { value: "x" } });
+
+      // Both plugins should have received distinct object references.
+      expect(receivedRefs[0]).not.toBe(receivedRefs[1]);
+      // The mutation by the first plugin should NOT appear in the second plugin's input.
+      expect(receivedRefs[1].injected).toBeUndefined();
+    });
+
+    it("plugin throw: safeNotify called, execution continues to next plugin (not deny)", async () => {
+      const onError: PluginErrorHandler = vi.fn();
+      const bad = makeToolPlugin("bad", {
+        priority: 10,
+        onBeforeToolCall: vi.fn().mockRejectedValue(new Error("boom")),
+      });
+      const good = makeToolPlugin("good", {
+        priority: 0,
+        onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow" }),
+      });
+      const interceptor = buildToolInterceptor([bad, good], mockProfileCtx, onError)!;
+      const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: {} });
+      expect(result).toMatchObject({ action: "allow" });
+      expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "onBeforeToolCall", error: expect.any(Error) });
+      expect(good.onBeforeToolCall).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("onAfterToolCall composition", () => {
+    it("runs plugins in descending priority order", async () => {
+      const order: string[] = [];
+      const low = makeToolPlugin("low", {
+        priority: 0,
+        onAfterToolCall: vi.fn().mockImplementation(async () => { order.push("low"); }),
+      });
+      const high = makeToolPlugin("high", {
+        priority: 10,
+        onAfterToolCall: vi.fn().mockImplementation(async () => { order.push("high"); }),
+      });
+      const interceptor = buildToolInterceptor([low, high], mockProfileCtx)!;
+      const ctx: Parameters<NonNullable<typeof interceptor.onAfterToolCall>>[0] = {
+        toolName: "t", input: {}, result: {}, durationMs: 0,
+      };
+      await interceptor.onAfterToolCall!(ctx);
+      expect(order).toEqual(["high", "low"]);
+    });
+
+    it("each plugin receives a fresh shallow copy of input", async () => {
+      const receivedRefs: Record<string, unknown>[] = [];
+      const plugin1 = makeToolPlugin("p1", {
+        priority: 10,
+        onAfterToolCall: vi.fn().mockImplementation(async (ev: AfterToolCallEvent) => {
+          receivedRefs.push(ev.input);
+          (ev.input as Record<string, unknown>).mutated = true;
+        }),
+      });
+      const plugin2 = makeToolPlugin("p2", {
+        priority: 0,
+        onAfterToolCall: vi.fn().mockImplementation(async (ev: AfterToolCallEvent) => {
+          receivedRefs.push(ev.input);
+        }),
+      });
+      const interceptor = buildToolInterceptor([plugin1, plugin2], mockProfileCtx)!;
+      await interceptor.onAfterToolCall!({ toolName: "t", input: { value: "x" }, result: {}, durationMs: 0 });
+
+      expect(receivedRefs[0]).not.toBe(receivedRefs[1]);
+      expect(receivedRefs[1].mutated).toBeUndefined();
+    });
+
+    it("plugin throw: safeNotify called, other plugins still run", async () => {
+      const onError: PluginErrorHandler = vi.fn();
+      const order: string[] = [];
+      const bad = makeToolPlugin("bad", {
+        priority: 10,
+        onAfterToolCall: vi.fn().mockRejectedValue(new Error("after fail")),
+      });
+      const good = makeToolPlugin("good", {
+        priority: 0,
+        onAfterToolCall: vi.fn().mockImplementation(async () => { order.push("good"); }),
+      });
+      const interceptor = buildToolInterceptor([bad, good], mockProfileCtx, onError)!;
+      const ctx: Parameters<NonNullable<typeof interceptor.onAfterToolCall>>[0] = {
+        toolName: "t", input: {}, result: {}, durationMs: 0,
+      };
+      await interceptor.onAfterToolCall!(ctx);
+      expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "onAfterToolCall", error: expect.any(Error) });
+      expect(order).toEqual(["good"]);
+    });
+
+    it("passes correct AfterToolCallEvent fields to plugin hooks", async () => {
+      const receivedEvents: AfterToolCallEvent[] = [];
+      const plugin = makeToolPlugin("p1", {
+        onAfterToolCall: vi.fn().mockImplementation(async (ev: AfterToolCallEvent) => {
+          receivedEvents.push(ev);
+        }),
+      });
+      const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
+      const ctx: Parameters<NonNullable<typeof interceptor.onAfterToolCall>>[0] = {
+        toolName: "myTool",
+        input: { key: "val" },
+        result: { content: [] },
+        durationMs: 42,
+      };
+      await interceptor.onAfterToolCall!(ctx);
+      expect(receivedEvents[0].toolName).toBe("myTool");
+      expect(receivedEvents[0].durationMs).toBe(42);
+      expect(receivedEvents[0].context).toBe(mockProfileCtx);
+    });
   });
 });
 

--- a/packages/core/src/agent/agent-impl.ts
+++ b/packages/core/src/agent/agent-impl.ts
@@ -113,6 +113,7 @@ export class AgentImpl implements Agent {
       transformContext: options?.transformContext,
       reactiveCompaction: options?.reactiveCompaction,
       getSteeringMessages: options?.getSteeringMessages,
+      toolInterceptor: options?.toolInterceptor,
     });
 
     return this.createAgentStream(eventStream);

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -13,7 +13,7 @@ import type {
 } from "@/types/agent.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
-import type { RuntimeTool } from "@/types/tool.types.js";
+import type { RuntimeTool, ToolInterceptor } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
 import type { ModelConfig } from "@/agent/define-agent.js";
 
@@ -55,6 +55,8 @@ export interface AgentLoopConfig {
   getFollowUpMessages?: () => Promise<Message[]>;
   transformContext?: TransformContextFn;
   reactiveCompaction?: ReactiveCompactionController;
+  /** Optional pre/post interceptor invoked around each tool execution. */
+  toolInterceptor?: ToolInterceptor;
 }
 
 /** Runs the core agent loop from the first user turn until completion. */
@@ -222,6 +224,7 @@ async function runLoop(
           signal,
           stream,
           config.getSteeringMessages,
+          config.toolInterceptor,
         );
         toolResults.push(...toolExecution.toolResults);
         steeringAfterTools = toolExecution.steeringMessages ?? null;

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -9,7 +9,7 @@ import { validateToolArguments } from "@/llm/utils/validation.js";
 import type { TextContent, ToolCall } from "@/types/content.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
-import type { RuntimeTool, ToolResult, ToolSignalEvent } from "@/types/tool.types.js";
+import type { RuntimeTool, ToolInterceptor, ToolResult, ToolSignalEvent } from "@/types/tool.types.js";
 
 /** Result produced by executing a single tool call against the runtime registry. */
 export interface ToolExecutionResult {
@@ -23,6 +23,7 @@ export async function executeToolCalls(
   signal: AbortSignal | undefined,
   stream: EventStream<RuntimeEvent, Message[]>,
   getSteeringMessages?: () => Promise<Message[]>,
+  toolInterceptor?: ToolInterceptor,
 ): Promise<ToolExecutionResult> {
   const toolCalls = assistantMessage.content.filter((c): c is ToolCall => c.type === "toolCall");
   const results: ToolResultMessage[] = [];
@@ -31,41 +32,121 @@ export async function executeToolCalls(
   for (let index = 0; index < toolCalls.length; index++) {
     const toolCall = toolCalls[index];
     const tool = tools?.find((t) => t.name === toolCall.name);
+    const rawArgs: unknown = toolCall.arguments;
 
+    // ── Tool not found — emit events and move on ──────────────────────────────
+    if (!tool) {
+      const errorText = new ToolNotFoundError(toolCall.name).message;
+      const errorResult: ToolResult = {
+        content: [{ type: "text", text: errorText } as TextContent],
+        details: {},
+      };
+      stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args: rawArgs, rawArgs });
+      stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: errorResult, isError: true });
+      const msg = buildToolResultMessage(toolCall, errorResult, true);
+      results.push(msg);
+      stream.push({ type: "message.start", message: msg });
+      stream.push({ type: "message.end", message: msg });
+      continue;
+    }
+
+    // ── Argument validation ───────────────────────────────────────────────────
+    // validateToolArguments may throw ToolValidationError (or in malformed tool
+    // fixtures, a TypeError). Guard it separately so validation errors become
+    // error ToolResults rather than unhandled exceptions.
+    let validatedArgs: unknown;
+    let validationError: unknown = null;
+    try {
+      validatedArgs = validateToolArguments(tool, toolCall);
+    } catch (e) {
+      validationError = e;
+    }
+
+    if (validationError !== null) {
+      const errorText = validationError instanceof Error ? validationError.message : String(validationError);
+      const errorResult: ToolResult = {
+        content: [{ type: "text", text: errorText } as TextContent],
+        details: {},
+      };
+      stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args: rawArgs, rawArgs });
+      stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: errorResult, isError: true });
+      const msg = buildToolResultMessage(toolCall, errorResult, true);
+      results.push(msg);
+      stream.push({ type: "message.start", message: msg });
+      stream.push({ type: "message.end", message: msg });
+      continue;
+    }
+
+    // ── Before-hook (NOT in try/catch — interceptor errors propagate uncaught) ──
+    // The host layer (buildToolInterceptor) is responsible for ensuring the
+    // composed interceptor never throws.
+    let effectiveArgs: unknown = validatedArgs;
+
+    if (toolInterceptor?.onBeforeToolCall) {
+      const beforeResult = await toolInterceptor.onBeforeToolCall({
+        toolName: toolCall.name,
+        // Pass validatedArgs as-is. The core layer does not assume the schema is
+        // an object, so no spread or clone is applied here. Defensive copying for
+        // cross-plugin mutation isolation is the app layer's responsibility
+        // (see buildToolInterceptor in @agentrail/app).
+        input: validatedArgs,
+      });
+
+      if (beforeResult.action === "deny") {
+        const denyResult: ToolResult = {
+          content: [{ type: "text", text: beforeResult.reason } as TextContent],
+          details: {},
+        };
+        // tool.before is emitted even for denied calls so stream consumers always
+        // see a matching before/after pair.
+        stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args: rawArgs, rawArgs });
+        stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: denyResult, isError: true });
+        const msg = buildToolResultMessage(toolCall, denyResult, true);
+        results.push(msg);
+        stream.push({ type: "message.start", message: msg });
+        stream.push({ type: "message.end", message: msg });
+        // onAfterToolCall is NOT called for denied executions.
+        continue;
+      }
+
+      if (beforeResult.action === "allow" && "input" in beforeResult) {
+        effectiveArgs = beforeResult.input;
+      }
+    }
+
+    // ── Emit tool.before with effective (post-hook) args ─────────────────────
     stream.push({
       type: "tool.before",
       toolCallId: toolCall.id,
       toolName: toolCall.name,
-      args: toolCall.arguments,
+      args: effectiveArgs,
+      rawArgs,
     });
 
+    // ── Execute ───────────────────────────────────────────────────────────────
     let result: ToolResult;
     let isError = false;
+    let durationMs = 0;
 
-    try {
-      if (!tool) {
-        throw new ToolNotFoundError(toolCall.name);
+    const onSignal = (event: ToolSignalEvent) => {
+      if (event.type === "waiting_for_input") {
+        stream.push({
+          type: "waiting_for_user_input",
+          toolCallId: toolCall.id,
+          question: event.question,
+          hint: event.hint,
+          options: event.options,
+          multiple: event.multiple,
+          custom: event.custom,
+        });
       }
+    };
 
-      const validatedArgs = validateToolArguments(tool, toolCall);
-
-      const onSignal = (event: ToolSignalEvent) => {
-        if (event.type === "waiting_for_input") {
-          stream.push({
-            type: "waiting_for_user_input",
-            toolCallId: toolCall.id,
-            question: event.question,
-            hint: event.hint,
-            options: event.options,
-            multiple: event.multiple,
-            custom: event.custom,
-          });
-        }
-      };
-
-        result = await tool.execute(
+    const startTime = Date.now();
+    try {
+      result = await tool.execute(
         toolCall.id,
-        validatedArgs,
+        effectiveArgs,
         signal,
         (partialResult) => {
           stream.push({
@@ -80,16 +161,15 @@ export async function executeToolCalls(
     } catch (e) {
       result = {
         content: [
-          {
-            type: "text",
-            text: e instanceof Error ? e.message : String(e),
-          } as TextContent,
+          { type: "text", text: e instanceof Error ? e.message : String(e) } as TextContent,
         ],
         details: {},
       };
       isError = true;
     }
+    durationMs = Date.now() - startTime;
 
+    // ── Emit tool.after ───────────────────────────────────────────────────────
     stream.push({
       type: "tool.after",
       toolCallId: toolCall.id,
@@ -98,16 +178,19 @@ export async function executeToolCalls(
       isError,
     });
 
-    const toolResultMessage: ToolResultMessage = {
-      role: "toolResult",
-      toolCallId: toolCall.id,
-      toolName: toolCall.name,
-      content: result.content,
-      details: result.details,
-      isError,
-      timestamp: Date.now(),
-    };
+    // ── After-hook (called for both success and execution errors, not for deny) ──
+    // NOT in try/catch — see note on onBeforeToolCall above.
+    if (toolInterceptor?.onAfterToolCall) {
+      await toolInterceptor.onAfterToolCall({
+        toolName: toolCall.name,
+        input: effectiveArgs,
+        result,
+        durationMs,
+      });
+    }
 
+    // ── Finalise ──────────────────────────────────────────────────────────────
+    const toolResultMessage = buildToolResultMessage(toolCall, result, isError);
     results.push(toolResultMessage);
     stream.push({ type: "message.start", message: toolResultMessage });
     stream.push({ type: "message.end", message: toolResultMessage });
@@ -128,6 +211,22 @@ export async function executeToolCalls(
   return { toolResults: results, steeringMessages };
 }
 
+function buildToolResultMessage(
+  toolCall: ToolCall,
+  result: ToolResult,
+  isError: boolean,
+): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    content: result.content,
+    details: result.details,
+    isError,
+    timestamp: Date.now(),
+  };
+}
+
 function skipToolCall(
   toolCall: ToolCall,
   stream: EventStream<RuntimeEvent, Message[]>,
@@ -142,6 +241,7 @@ function skipToolCall(
     toolCallId: toolCall.id,
     toolName: toolCall.name,
     args: toolCall.arguments,
+    rawArgs: toolCall.arguments,
   });
   stream.push({
     type: "tool.after",
@@ -151,16 +251,7 @@ function skipToolCall(
     isError: true,
   });
 
-  const toolResultMessage: ToolResultMessage = {
-    role: "toolResult",
-    toolCallId: toolCall.id,
-    toolName: toolCall.name,
-    content: result.content,
-    details: {},
-    isError: true,
-    timestamp: Date.now(),
-  };
-
+  const toolResultMessage = buildToolResultMessage(toolCall, result, true);
   stream.push({ type: "message.start", message: toolResultMessage });
   stream.push({ type: "message.end", message: toolResultMessage });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,10 +25,14 @@ export { Type } from "@sinclair/typebox";
 export type { Static, TSchema } from "@sinclair/typebox";
 
 export type {
+  BeforeToolCallResult,
   ExtractToolDetails,
   ExtractToolParams,
   RuntimeTool,
   ToolDefinition,
+  ToolInterceptor,
+  ToolInterceptorAfterContext,
+  ToolInterceptorBeforeContext,
   ToolResult,
   ToolSignalEvent,
   ToolUpdateCallback,

--- a/packages/core/src/types/agent.types.ts
+++ b/packages/core/src/types/agent.types.ts
@@ -6,6 +6,7 @@
 import type { ToolCall, UserContent } from "@/types/content.types.js";
 import type { AssistantMessage, Message, StopReason } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
+import type { ToolInterceptor } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
 
 // ============================================================================
@@ -86,6 +87,16 @@ export interface AgentRunOptions {
 
   /** Assistant-facing message used when the max-turn limit is reached. */
   readonly maxTurnsMessage?: string;
+
+  /**
+   * Optional pre/post hook interceptor for individual tool calls.
+   *
+   * The interceptor runs inside the core executor: `onBeforeToolCall` just
+   * before the tool's `execute()` is called and `onAfterToolCall` after the
+   * result is produced.  Multi-plugin composition is handled by the host layer
+   * (see `buildToolInterceptor` in `@agentrail/app`).
+   */
+  readonly toolInterceptor?: ToolInterceptor;
 }
 
 // ============================================================================

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -32,10 +32,14 @@ export { isAssistantMessage, isToolResultMessage, isUserMessage } from "@/types/
 
 /** Tool contract and helper types exported from the runtime core type surface. */
 export type {
+  BeforeToolCallResult,
   ExtractToolDetails,
   ExtractToolParams,
   RuntimeTool,
   ToolDefinition,
+  ToolInterceptor,
+  ToolInterceptorAfterContext,
+  ToolInterceptorBeforeContext,
   ToolResult,
   ToolUpdateCallback,
 } from "@/types/tool.types.js";

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -119,12 +119,26 @@ export type RuntimeEvent =
   /** Emitted once a message is fully assembled. */
   | { readonly type: "message.end"; readonly message: Message }
   // ── Tool execution ───────────────────────────────────────────────────────
-  /** Emitted just before a tool call is dispatched to the tool implementation. */
+  /**
+   * Emitted just before a tool call is dispatched to the tool implementation.
+   *
+   * When a `ToolInterceptor` is active, this event is emitted **after** the
+   * `onBeforeToolCall` hook has run so that `args` always reflects the effective
+   * (potentially modified) input that will be passed to the tool.
+   *
+   * - `args`    — effective input (after any interceptor modifications).
+   * - `rawArgs` — original model-generated arguments, always equal to
+   *               `toolCall.arguments`.  Identical to `args` when no interceptor
+   *               modifies the input.
+   */
   | {
       readonly type: "tool.before";
       readonly toolCallId: string;
       readonly toolName: string;
+      /** Effective input passed to the tool (may differ from raw model arguments). */
       readonly args: unknown;
+      /** Original model-generated arguments, preserved for audit and debugging. */
+      readonly rawArgs: unknown;
     }
   /** Emitted for each incremental update produced by a streaming tool. */
   | {

--- a/packages/core/src/types/tool.types.ts
+++ b/packages/core/src/types/tool.types.ts
@@ -66,3 +66,61 @@ export type ExtractToolParams<T> = T extends RuntimeTool<infer P, unknown> ? Sta
 
 /** Extracts the opaque `details` payload type from a runtime tool definition. */
 export type ExtractToolDetails<T> = T extends RuntimeTool<TSchema, infer D> ? D : never;
+
+// ============================================================================
+// ToolInterceptor — pre/post hook contract for the core agent loop
+// ============================================================================
+
+/**
+ * Result returned by `ToolInterceptor.onBeforeToolCall`.
+ *
+ * - `{ action: "allow" }` — proceed with the original (or previously modified) input.
+ * - `{ action: "allow"; input: unknown }` — proceed with a replacement input value.
+ * - `{ action: "deny"; reason: string }` — abort execution and surface an error to the model.
+ */
+export type BeforeToolCallResult =
+  | { readonly action: "allow" }
+  | { readonly action: "deny"; readonly reason: string }
+  | { readonly action: "allow"; readonly input: unknown };
+
+/** Context passed to `ToolInterceptor.onBeforeToolCall`. */
+export interface ToolInterceptorBeforeContext {
+  readonly toolName: string;
+  /**
+   * The validated arguments that will be passed to the tool.
+   *
+   * The core executor does not clone this value — it is passed by reference.
+   * Host-layer composers (e.g. `buildToolInterceptor`) are responsible for
+   * any defensive copying they wish to do between plugin calls.
+   */
+  readonly input: unknown;
+}
+
+/** Context passed to `ToolInterceptor.onAfterToolCall`. */
+export interface ToolInterceptorAfterContext {
+  readonly toolName: string;
+  /** The effective input that was passed to the tool (after any before-hook modifications). */
+  readonly input: unknown;
+  readonly result: unknown;
+  readonly durationMs: number;
+}
+
+/**
+ * Generic pre/post interception contract consumed by `executeToolCalls`.
+ *
+ * The core executor calls exactly one `onBeforeToolCall` and one `onAfterToolCall`
+ * per tool execution.  Multi-plugin composition, priority ordering, and error
+ * isolation (safeNotify) are the responsibility of the host layer that builds
+ * and supplies this object.
+ *
+ * Error semantics:
+ * - If either hook throws, the error propagates uncaught from the executor.
+ *   The host layer is responsible for ensuring the interceptor does not throw.
+ * - `onAfterToolCall` is not called when a before-hook returns `{ action: "deny" }`.
+ */
+export interface ToolInterceptor {
+  onBeforeToolCall?(
+    ctx: ToolInterceptorBeforeContext,
+  ): Promise<BeforeToolCallResult> | BeforeToolCallResult;
+  onAfterToolCall?(ctx: ToolInterceptorAfterContext): Promise<void> | void;
+}

--- a/packages/core/test/tool-executor.test.ts
+++ b/packages/core/test/tool-executor.test.ts
@@ -1,0 +1,254 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Type } from "@sinclair/typebox";
+import { executeToolCalls } from "../src/executor/tool-executor.js";
+import { EventStream } from "../src/llm/event-stream.js";
+import type { AssistantMessage, Message } from "../src/types/message.types.js";
+import type { RuntimeEvent } from "../src/types/result.types.js";
+import type { RuntimeTool, ToolInterceptor } from "../src/types/tool.types.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a real EventStream configured for RuntimeEvent/Message[] along with
+ * a mutable `events` array that accumulates every pushed event.
+ */
+function makeStream(): { stream: EventStream<RuntimeEvent, Message[]>; events: RuntimeEvent[] } {
+  const events: RuntimeEvent[] = [];
+  // EventStream<RuntimeEvent, Message[]> requires isComplete + extractResult.
+  // Use "session.end" as the completion sentinel (same as agent-loop.ts).
+  const stream = new EventStream<RuntimeEvent, Message[]>(
+    (e) => e.type === "session.end",
+    (e) => (e.type === "session.end" ? (e as Extract<RuntimeEvent, { type: "session.end" }>).messages : []),
+  );
+
+  // Tap into push by wrapping the stream in a Proxy so we can intercept events.
+  const originalPush = stream.push.bind(stream);
+  stream.push = (event: RuntimeEvent) => {
+    events.push(event);
+    originalPush(event);
+  };
+
+  return { stream, events };
+}
+
+function makeTool(name: string, result = "ok"): RuntimeTool {
+  return {
+    name,
+    label: name,
+    description: `Tool ${name}`,
+    parameters: Type.Object({ value: Type.String() }),
+    execute: vi.fn().mockResolvedValue({
+      content: [{ type: "text" as const, text: result }],
+      details: {},
+    }),
+  };
+}
+
+function makeAssistantMessage(toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>): AssistantMessage {
+  return {
+    role: "assistant",
+    content: toolCalls.map((tc) => ({
+      type: "toolCall" as const,
+      id: tc.id,
+      name: tc.name,
+      arguments: tc.arguments,
+    })),
+    provider: "test",
+    modelId: "test",
+    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: "toolUse",
+    timestamp: Date.now(),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("executeToolCalls — ToolInterceptor", () => {
+  let stream!: EventStream<RuntimeEvent, Message[]>;
+  let collectedEvents!: RuntimeEvent[];
+
+  beforeEach(() => {
+    ({ stream, events: collectedEvents } = makeStream());
+  });
+
+  it("allow: tool executes normally, tool.before args === rawArgs when no modification", async () => {
+    const tool = makeTool("echo");
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow" }),
+      onAfterToolCall: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "hello" } }]);
+    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    expect(beforeEvent).toBeDefined();
+    expect(beforeEvent.args).toEqual({ value: "hello" });
+    expect(beforeEvent.rawArgs).toEqual({ value: "hello" });
+    expect(beforeEvent.args).toEqual(beforeEvent.rawArgs);
+
+    expect(tool.execute).toHaveBeenCalledOnce();
+    expect(interceptor.onAfterToolCall).toHaveBeenCalledOnce();
+  });
+
+  it("allow + modified input: tool.before.args reflects modified value, rawArgs keeps original", async () => {
+    const tool = makeTool("echo");
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({
+        action: "allow",
+        input: { value: "SANITIZED" },
+      }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "sensitive" } }]);
+    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    expect((beforeEvent.args as Record<string, unknown>).value).toBe("SANITIZED");
+    expect((beforeEvent.rawArgs as Record<string, unknown>).value).toBe("sensitive");
+
+    // The tool received the modified input.
+    expect(tool.execute).toHaveBeenCalledOnce();
+    const callArgs = (tool.execute as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect((callArgs as Record<string, unknown>).value).toBe("SANITIZED");
+  });
+
+  it("deny: tool.execute is NOT called; onAfterToolCall is NOT called; result is error", async () => {
+    const tool = makeTool("echo");
+    const afterSpy = vi.fn();
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "deny", reason: "not allowed" }),
+      onAfterToolCall: afterSpy,
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(afterSpy).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(result.toolResults[0].content[0]).toMatchObject({ type: "text", text: "not allowed" });
+  });
+
+  it("deny: tool.before and tool.after stream events are still emitted", async () => {
+    const tool = makeTool("echo");
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "deny", reason: "blocked" }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
+    expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
+    const afterEvent = collectedEvents.find((e) => e.type === "tool.after") as Extract<RuntimeEvent, { type: "tool.after" }>;
+    expect(afterEvent.isError).toBe(true);
+  });
+
+  it("interceptor.onBeforeToolCall throws: error propagates uncaught from executor", async () => {
+    const tool = makeTool("echo");
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockRejectedValue(new Error("interceptor boom")),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    await expect(
+      executeToolCalls([tool], msg, undefined, stream, undefined, interceptor),
+    ).rejects.toThrow("interceptor boom");
+
+    // tool.execute was NOT called because the before hook threw.
+    expect(tool.execute).not.toHaveBeenCalled();
+  });
+
+  it("interceptor.onAfterToolCall throws: error propagates uncaught from executor", async () => {
+    const tool = makeTool("echo");
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow" }),
+      onAfterToolCall: vi.fn().mockRejectedValue(new Error("after boom")),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    await expect(
+      executeToolCalls([tool], msg, undefined, stream, undefined, interceptor),
+    ).rejects.toThrow("after boom");
+  });
+
+  it("onAfterToolCall receives correct durationMs (>= 0) and result", async () => {
+    const tool = makeTool("echo", "result-text");
+    const afterSpy = vi.fn().mockResolvedValue(undefined);
+    const interceptor: ToolInterceptor = {
+      onAfterToolCall: afterSpy,
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(afterSpy).toHaveBeenCalledOnce();
+    const ctx = afterSpy.mock.calls[0][0];
+    expect(ctx.toolName).toBe("echo");
+    expect(typeof ctx.durationMs).toBe("number");
+    expect(ctx.durationMs).toBeGreaterThanOrEqual(0);
+    expect((ctx.result as { content: unknown[] }).content[0]).toMatchObject({ type: "text", text: "result-text" });
+  });
+
+  it("tool not found: emits tool.before + tool.after error events, no interceptor calls", async () => {
+    const afterSpy = vi.fn();
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn(),
+      onAfterToolCall: afterSpy,
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "ghost", arguments: {} }]);
+    const result = await executeToolCalls([], msg, undefined, stream, undefined, interceptor);
+
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(interceptor.onBeforeToolCall).not.toHaveBeenCalled();
+    expect(afterSpy).not.toHaveBeenCalled();
+    expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
+    expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
+  });
+
+  it("non-object schema: interceptor receives the raw validated value, not a corrupted spread", async () => {
+    // Top-level array schema — spreading with { ... } would produce { 0: 'a', 1: 'b' }.
+    // The executor must pass the value as-is so non-object schemas are not corrupted.
+    const receivedInputs: unknown[] = [];
+    const arrayTool: RuntimeTool = {
+      name: "arr",
+      label: "arr",
+      description: "Array tool",
+      // Type.Array would normally be used; use an empty schema to keep the test lean.
+      parameters: Type.Array(Type.String()),
+      execute: vi.fn().mockResolvedValue({ content: [{ type: "text" as const, text: "ok" }], details: {} }),
+    };
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockImplementation(async (ctx) => {
+        receivedInputs.push(ctx.input);
+        return { action: "allow" as const };
+      }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "arr", arguments: ["a", "b"] as unknown as Record<string, unknown> }]);
+    await executeToolCalls([arrayTool], msg, undefined, stream, undefined, interceptor);
+
+    // The interceptor should receive exactly what came out of validateToolArguments,
+    // not an object-spread of an array.
+    expect(Array.isArray(receivedInputs[0])).toBe(true);
+    expect(receivedInputs[0]).toEqual(["a", "b"]);
+  });
+
+  it("no interceptor: behaves like original executor", async () => {
+    const tool = makeTool("echo");
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, undefined);
+
+    expect(tool.execute).toHaveBeenCalledOnce();
+    expect(result.toolResults[0].isError).toBe(false);
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    expect(beforeEvent.rawArgs).toEqual({ value: "x" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `onBeforeToolCall` and `onAfterToolCall` hooks to the `AgentrailPlugin` contract, enabling plugins to inspect, modify, or deny individual tool calls before/after execution
- Introduces a generic `ToolInterceptor` interface in `@agentrail/core` so the hook mechanism can be used directly without the app layer
- `tool.before` stream event gains a `rawArgs` field (original model-generated args); `args` now reflects the effective (post-hook) input

## What changed

**`@agentrail/core`**
- `ToolInterceptor`, `BeforeToolCallResult`, `ToolInterceptorBeforeContext`, `ToolInterceptorAfterContext` types
- `AgentRunOptions.toolInterceptor` optional field
- `tool.before` event: new `rawArgs` field; `args` = effective post-hook input
- `tool-executor`: validation error-isolated; before-hook runs before `tool.before` push; `onAfterToolCall` skipped on deny; interceptor errors propagate uncaught (app layer must not throw)

**`@agentrail/app`**
- `AgentrailPlugin.onBeforeToolCall` / `onAfterToolCall` hooks
- `buildToolInterceptor(plugins, profileCtx, onError)` — priority ordering, first-deny-wins, per-plugin fresh copy, `safeNotify` error isolation
- Non-plain-object tool inputs (arrays, primitives) skip app-layer hooks entirely to avoid corruption via object spread
- `stream-route` and `chat-route` wire `buildToolInterceptor()` into `agent.stream` / `agent.invoke`
- Corrected lifecycle order in `AgentrailPlugin` JSDoc: `onTurnPersisted` → `onRequestEnd`

## Tests

- `packages/core/test/tool-executor.test.ts` — 10 new cases (allow, deny, modified input, non-object schema safety, interceptor throw propagation, tool-not-found)
- `packages/app/test/plugins.test.ts` — 12 new cases (priority ordering, first-deny-wins, input forwarding, per-plugin copy isolation, `safeNotify` routing, non-object input skipping)

## Validation

```
pnpm test          # 106 tests, all pass
pnpm typecheck     # clean across all packages and examples
```

Closes #56