### PR TITLE
feat: add optional validate() method to RuntimeTool (#59)

### DIFF
--- a/.changeset/tool-validate.md
+++ b/.changeset/tool-validate.md
@@ -1,0 +1,13 @@
+---
+"@agentrail/core": minor
+---
+
+Add optional `validate()` method to `RuntimeTool` for two-phase tool input validation.
+
+**`@agentrail/core`**
+
+- New `ToolValidationContext` interface (`{ toolCallId, signal? }`) and `ValidationResult` type (`{ valid: true } | { valid: false; reason: string }`), both exported from the package root.
+- `RuntimeTool` gains an optional `validate(params, ctx)` method. When present, it is called after TypeBox schema validation and after any `onBeforeToolCall` interceptor rewrites, but before `execute`. Returning `{ valid: false, reason }` or throwing surfaces a `"Tool precondition failed: <reason>"` error result to the model; `execute` and `onAfterToolCall` are not called.
+- `defineTool()` and the fluent `tool()` builder accept an optional `validate` field / `.validate()` method with the same signature.
+- `defineSimpleTool()` accepts an optional `validate` field (no `params` argument, only `ctx`) for parameter-less tools.
+- New `validateToolInput(tool, input)` helper in `validation.ts` that reuses the existing `Value.Check + Value.Errors + ToolValidationError` path. The executor uses it to re-validate arguments after an interceptor rewrites them, ensuring schema invariants hold before `validate()` or `execute()` run.

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -55,6 +55,67 @@ export const pingTool = defineSimpleTool({
 });
 ```
 
+## Business-Logic Validation
+
+Use the optional `validate` field to add precondition checks that run after schema validation but before `execute`. This is useful when the input is structurally valid but violates a business rule that cannot be expressed as a TypeBox schema.
+
+```ts
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@agentrail/core";
+import type { ValidationResult } from "@agentrail/core";
+
+export const transferTool = defineTool({
+  name: "transfer_funds",
+  description: "Transfer an amount between two accounts.",
+  parameters: Type.Object({
+    fromAccountId: Type.String(),
+    toAccountId: Type.String(),
+    amount: Type.Number({ minimum: 0.01 }),
+  }),
+  async validate(params, ctx): Promise<ValidationResult> {
+    const balance = await getBalance(params.fromAccountId);
+    if (balance < params.amount) {
+      return { valid: false, reason: "Insufficient funds" };
+    }
+    return { valid: true };
+  },
+  async execute(params, ctx) {
+    // Only runs when validate() returns { valid: true }
+    await doTransfer(params.fromAccountId, params.toAccountId, params.amount);
+    return { content: [{ type: "text", text: "Transfer complete." }], details: null };
+  },
+});
+```
+
+When `validate` returns `{ valid: false, reason }` or throws, the agent receives the error `"Tool precondition failed: <reason>"` and `execute` is not called. The same applies to `defineSimpleTool`:
+
+```ts
+import { defineSimpleTool } from "@agentrail/core";
+
+export const maintenanceTool = defineSimpleTool({
+  name: "run-maintenance",
+  description: "Run scheduled maintenance.",
+  async validate(ctx) {
+    if (isMaintenanceWindowOpen()) return { valid: true };
+    return { valid: false, reason: "Outside maintenance window" };
+  },
+  async execute(ctx) {
+    await runMaintenance();
+    return { content: [{ type: "text", text: "Done." }], details: null };
+  },
+});
+```
+
+### Execution order
+
+1. TypeBox schema validation (structural)
+2. `onBeforeToolCall` interceptor (plugin layer — may rewrite args)
+3. Schema re-validation on the rewritten args
+4. `validate()` (business logic — runs on final effective args)
+5. `execute()`
+
+`onAfterToolCall` is **not** called when `validate` fails.
+
 ## Tool Result Shape
 
 Every `execute` function must return a `ToolResult`:

--- a/docs/guides/add-tools.md
+++ b/docs/guides/add-tools.md
@@ -126,6 +126,41 @@ export const customerLookupTool = defineTool({
 
 The important part is not the exact helper name. The important part is that the tool stays framework/runtime-facing and does not depend on route glue.
 
+## Adding Business-Logic Validation
+
+Use the optional `validate` field to add precondition checks that run after schema validation and any plugin-level argument rewrites, but before `execute`. Return `{ valid: false, reason }` to abort execution with a model-visible error message:
+
+```ts
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@agentrail/core";
+
+export const transferTool = defineTool({
+  name: "transfer_funds",
+  description: "Transfer an amount between two accounts.",
+  parameters: Type.Object({
+    fromAccountId: Type.String(),
+    toAccountId: Type.String(),
+    amount: Type.Number({ minimum: 0.01 }),
+  }),
+  async validate(params) {
+    const balance = await getBalance(params.fromAccountId);
+    if (balance < params.amount) {
+      return { valid: false, reason: "Insufficient funds" };
+    }
+    return { valid: true };
+  },
+  async execute(params) {
+    await doTransfer(params.fromAccountId, params.toAccountId, params.amount);
+    return {
+      content: [{ type: "text", text: "Transfer complete." }],
+      details: null,
+    };
+  },
+});
+```
+
+When validation fails the agent receives `"Tool precondition failed: <reason>"`. If `validate` throws, the thrown message is used as the reason. `execute` and `onAfterToolCall` are not called in either case.
+
 ## Recommended Assembly Pattern
 
 Once you have one or more tools, assemble them in the host/profile layer rather than directly inside routes.

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -5,11 +5,18 @@
 
 import { ToolNotFoundError } from "@/errors.js";
 import { EventStream } from "@/llm/event-stream.js";
-import { validateToolArguments } from "@/llm/utils/validation.js";
+import { validateToolArguments, validateToolInput } from "@/llm/utils/validation.js";
 import type { TextContent, ToolCall } from "@/types/content.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
-import type { RuntimeTool, ToolInterceptor, ToolResult, ToolSignalEvent } from "@/types/tool.types.js";
+import type { Static, TSchema } from "@sinclair/typebox";
+import type {
+  RuntimeTool,
+  ToolInterceptor,
+  ToolResult,
+  ToolSignalEvent,
+  ValidationResult,
+} from "@/types/tool.types.js";
 
 /** Result produced by executing a single tool call against the runtime registry. */
 export interface ToolExecutionResult {
@@ -36,17 +43,14 @@ export async function executeToolCalls(
 
     // ── Tool not found — emit events and move on ──────────────────────────────
     if (!tool) {
-      const errorText = new ToolNotFoundError(toolCall.name).message;
-      const errorResult: ToolResult = {
-        content: [{ type: "text", text: errorText } as TextContent],
-        details: {},
-      };
-      stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args: rawArgs, rawArgs });
-      stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: errorResult, isError: true });
-      const msg = buildToolResultMessage(toolCall, errorResult, true);
-      results.push(msg);
-      stream.push({ type: "message.start", message: msg });
-      stream.push({ type: "message.end", message: msg });
+      rejectToolCall(
+        toolCall,
+        new ToolNotFoundError(toolCall.name).message,
+        rawArgs,
+        rawArgs,
+        stream,
+        results,
+      );
       continue;
     }
 
@@ -63,17 +67,14 @@ export async function executeToolCalls(
     }
 
     if (validationError !== null) {
-      const errorText = validationError instanceof Error ? validationError.message : String(validationError);
-      const errorResult: ToolResult = {
-        content: [{ type: "text", text: errorText } as TextContent],
-        details: {},
-      };
-      stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args: rawArgs, rawArgs });
-      stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: errorResult, isError: true });
-      const msg = buildToolResultMessage(toolCall, errorResult, true);
-      results.push(msg);
-      stream.push({ type: "message.start", message: msg });
-      stream.push({ type: "message.end", message: msg });
+      rejectToolCall(
+        toolCall,
+        validationError instanceof Error ? validationError.message : String(validationError),
+        rawArgs,
+        rawArgs,
+        stream,
+        results,
+      );
       continue;
     }
 
@@ -93,24 +94,65 @@ export async function executeToolCalls(
       });
 
       if (beforeResult.action === "deny") {
-        const denyResult: ToolResult = {
-          content: [{ type: "text", text: beforeResult.reason } as TextContent],
-          details: {},
-        };
         // tool.before is emitted even for denied calls so stream consumers always
         // see a matching before/after pair.
-        stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args: rawArgs, rawArgs });
-        stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: denyResult, isError: true });
-        const msg = buildToolResultMessage(toolCall, denyResult, true);
-        results.push(msg);
-        stream.push({ type: "message.start", message: msg });
-        stream.push({ type: "message.end", message: msg });
+        rejectToolCall(toolCall, beforeResult.reason, rawArgs, rawArgs, stream, results);
         // onAfterToolCall is NOT called for denied executions.
         continue;
       }
 
       if (beforeResult.action === "allow" && "input" in beforeResult) {
         effectiveArgs = beforeResult.input;
+        // Re-validate schema after interceptor rewrite: the before-hook contract
+        // allows returning an arbitrary unknown, so the shape may no longer match
+        // the tool's TypeBox schema. Uses the same ToolValidationError format as
+        // the initial validation above.
+        let rewriteValidationError: unknown = null;
+        try {
+          validateToolInput(tool, effectiveArgs);
+        } catch (e) {
+          rewriteValidationError = e;
+        }
+        if (rewriteValidationError !== null) {
+          // Use effectiveArgs (rewritten value) as args so the event reflects
+          // the actual input that failed re-validation.
+          rejectToolCall(
+            toolCall,
+            rewriteValidationError instanceof Error
+              ? rewriteValidationError.message
+              : String(rewriteValidationError),
+            effectiveArgs,
+            rawArgs,
+            stream,
+            results,
+          );
+          // onAfterToolCall is NOT called for schema re-validation failures.
+          continue;
+        }
+      }
+    }
+
+    // ── Business-logic validation (tool.validate) ─────────────────────────────
+    // Runs on the final effectiveArgs (post-interceptor) so tool-level
+    // preconditions cannot be bypassed by a before-hook rewrite.
+    if (tool.validate) {
+      let vr: ValidationResult;
+      try {
+        vr = await tool.validate(effectiveArgs as Static<TSchema>, { toolCallId: toolCall.id, signal });
+      } catch (e) {
+        vr = { valid: false, reason: e instanceof Error ? e.message : String(e) };
+      }
+      if (!vr.valid) {
+        rejectToolCall(
+          toolCall,
+          `Tool precondition failed: ${vr.reason}`,
+          effectiveArgs,
+          rawArgs,
+          stream,
+          results,
+        );
+        // onAfterToolCall is NOT called for validate() failures.
+        continue;
       }
     }
 
@@ -209,6 +251,34 @@ export async function executeToolCalls(
   }
 
   return { toolResults: results, steeringMessages };
+}
+
+/**
+ * Emits a tool.before/tool.after error pair, pushes a ToolResultMessage, and
+ * appends it to `results`. Used for all early-exit failure paths (tool not
+ * found, schema validation, deny, re-validation, validate()).
+ *
+ * Callers must `continue` (or `return`) after calling this to skip execution.
+ * `onAfterToolCall` is intentionally NOT called here.
+ */
+function rejectToolCall(
+  toolCall: ToolCall,
+  errorText: string,
+  args: unknown,
+  rawArgs: unknown,
+  stream: EventStream<RuntimeEvent, Message[]>,
+  results: ToolResultMessage[],
+): void {
+  const errorResult: ToolResult = {
+    content: [{ type: "text", text: errorText } as TextContent],
+    details: {},
+  };
+  stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args, rawArgs });
+  stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: errorResult, isError: true });
+  const msg = buildToolResultMessage(toolCall, errorResult, true);
+  results.push(msg);
+  stream.push({ type: "message.start", message: msg });
+  stream.push({ type: "message.end", message: msg });
 }
 
 function buildToolResultMessage(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,8 @@ export type {
   ToolResult,
   ToolSignalEvent,
   ToolUpdateCallback,
+  ToolValidationContext,
+  ValidationResult,
 } from "@/types/tool.types.js";
 
 // ============================================================================

--- a/packages/core/src/llm/utils/validation.ts
+++ b/packages/core/src/llm/utils/validation.ts
@@ -9,23 +9,33 @@ import { ToolValidationError } from "@/errors.js";
 import type { ToolCall } from "@/types/content.types.js";
 import type { ToolDefinition } from "@/types/tool.types.js";
 
+/**
+ * Validates a raw value against a tool's TypeBox schema and returns typed data.
+ *
+ * Unlike `validateToolArguments`, this accepts a bare `unknown` value rather
+ * than a `ToolCall` object. It is used by the executor to re-validate arguments
+ * after an `onBeforeToolCall` interceptor may have rewritten them.
+ */
+export function validateToolInput<T extends TSchema>(
+  tool: ToolDefinition<T>,
+  input: unknown,
+): Static<T> {
+  if (!Value.Check(tool.parameters, input)) {
+    const errors = [...Value.Errors(tool.parameters, input)].map((error) => ({
+      path: error.path,
+      message: error.message,
+    }));
+    throw new ToolValidationError(`Invalid arguments for tool "${tool.name}"`, tool.name, errors);
+  }
+  return input as Static<T>;
+}
+
 /** Validates raw tool-call arguments against a TypeBox schema and returns typed data. */
 export function validateToolArguments<T extends TSchema>(
   tool: ToolDefinition<T>,
   toolCall: ToolCall,
 ): Static<T> {
-  if (!Value.Check(tool.parameters, toolCall.arguments)) {
-    const errors = [...Value.Errors(tool.parameters, toolCall.arguments)].map((error) => ({
-      path: error.path,
-      message: error.message,
-    }));
-    throw new ToolValidationError(
-      `Invalid arguments for tool "${toolCall.name}"`,
-      toolCall.name,
-      errors,
-    );
-  }
-  return toolCall.arguments as Static<T>;
+  return validateToolInput(tool, toolCall.arguments);
 }
 
 /** Validates a model-emitted tool call against a declared runtime tool. */

--- a/packages/core/src/tools/define-tool.ts
+++ b/packages/core/src/tools/define-tool.ts
@@ -4,7 +4,7 @@
  */
 
 import { Type, type Static, type TSchema } from "@sinclair/typebox";
-import type { RuntimeTool, ToolResult } from "@/types/tool.types.js";
+import type { RuntimeTool, ToolResult, ToolValidationContext, ValidationResult } from "@/types/tool.types.js";
 import { type ToolExecutionContext, tool } from "@/tools/tool-builder.js";
 
 /**
@@ -39,15 +39,39 @@ export function defineTool<TSchema_ extends TSchema, TDetails>(options: {
   description: string;
   /** TypeBox schema describing the accepted parameters. */
   parameters?: TSchema_;
+  /**
+   * Optional business-logic precondition check.
+   *
+   * Called after schema validation and after any `onBeforeToolCall` interceptor
+   * has rewritten the arguments, but before `execute`. Returning
+   * `{ valid: false }` or throwing prevents execution.
+   */
+  validate?: (
+    params: Static<TSchema_>,
+    ctx: ToolValidationContext,
+  ) => Promise<ValidationResult> | ValidationResult;
   /** Async implementation invoked when the tool is called. */
   execute: (params: Static<TSchema_>, ctx: ToolExecutionContext) => Promise<ToolResult<TDetails>>;
 }): RuntimeTool {
   const schema = options.parameters ?? Type.Object({});
-  return tool()
+  let builder = tool()
     .name(options.name)
     .label(options.label ?? options.name)
     .description(options.description)
     .parameters(schema)
-    .execute(options.execute as (params: Static<typeof schema>, ctx: ToolExecutionContext) => Promise<ToolResult<TDetails>>)
-    .build();
+    .execute(
+      options.execute as (
+        params: Static<typeof schema>,
+        ctx: ToolExecutionContext,
+      ) => Promise<ToolResult<TDetails>>,
+    );
+
+  if (options.validate) {
+    const validateFn = options.validate;
+    builder = builder.validate(
+      validateFn as (params: Static<typeof schema>, ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult,
+    );
+  }
+
+  return builder.build();
 }

--- a/packages/core/src/tools/tool-builder.ts
+++ b/packages/core/src/tools/tool-builder.ts
@@ -4,7 +4,13 @@
  */
 
 import { Type, type Static, type TSchema } from "@sinclair/typebox";
-import type { RuntimeTool, ToolResult, ToolSignalEvent } from "@/types/tool.types.js";
+import type {
+  RuntimeTool,
+  ToolResult,
+  ToolSignalEvent,
+  ToolValidationContext,
+  ValidationResult,
+} from "@/types/tool.types.js";
 
 // ============================================================================
 // ============================================================================
@@ -37,6 +43,7 @@ interface ToolConfig<TParams, TDetails> {
   label?: string;
   description?: string;
   parameters?: TSchema;
+  validate?: (params: TParams, ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult;
   execute?: (params: TParams, ctx: ToolExecutionContext) => Promise<ToolResult<TDetails>>;
 }
 
@@ -76,6 +83,20 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
     return builder;
   }
 
+  /**
+   * Registers an optional business-logic precondition check.
+   *
+   * The function is called after schema validation and after any
+   * `onBeforeToolCall` interceptor has rewritten the arguments, but before
+   * `execute`. Returning `{ valid: false }` or throwing prevents execution.
+   */
+  validate(
+    fn: (params: TParams, ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult,
+  ): this {
+    this.config.validate = fn;
+    return this;
+  }
+
   /** Registers the async implementation invoked when the tool is executed. */
   execute(fn: (params: TParams, ctx: ToolExecutionContext) => Promise<ToolResult<TDetails>>): this {
     this.config.execute = fn;
@@ -96,8 +117,9 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
 
     const parameters = this.config.parameters ?? Type.Object({});
     const executeFn = this.config.execute;
+    const validateFn = this.config.validate;
 
-    return {
+    const runtimeTool: RuntimeTool<TSchema, TDetails> = {
       name: this.config.name,
       label: this.config.label ?? this.config.name,
       description: this.config.description,
@@ -118,6 +140,15 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
         return executeFn(params as TParams, ctx);
       },
     };
+
+    if (validateFn) {
+      runtimeTool.validate = (
+        params: Static<typeof parameters>,
+        ctx: ToolValidationContext,
+      ): Promise<ValidationResult> | ValidationResult => validateFn(params as TParams, ctx);
+    }
+
+    return runtimeTool;
   }
 }
 
@@ -169,14 +200,25 @@ export function defineSimpleTool<TDetails = unknown>(options: {
   label?: string;
   /** Description shown to the model for tool selection. */
   description: string;
+  /**
+   * Optional business-logic precondition check.
+   * Receives only context (no parameters) because this tool has no schema.
+   */
+  validate?: (ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult;
   /** Async implementation invoked when the tool is called. */
   execute: (ctx: ToolExecutionContext) => Promise<ToolResult<TDetails>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }): RuntimeTool<TSchema, any> {
-  return tool()
+  let builder = tool()
     .name(options.name)
     .label(options.label ?? options.name)
     .description(options.description)
-    .execute(async (_params, ctx) => options.execute(ctx))
-    .build();
+    .execute(async (_params, ctx) => options.execute(ctx));
+
+  if (options.validate) {
+    const validateFn = options.validate;
+    builder = builder.validate((_params, ctx) => validateFn(ctx));
+  }
+
+  return builder.build();
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -42,6 +42,8 @@ export type {
   ToolInterceptorBeforeContext,
   ToolResult,
   ToolUpdateCallback,
+  ToolValidationContext,
+  ValidationResult,
 } from "@/types/tool.types.js";
 
 /** Agent invocation input/output types exported from the runtime core type surface. */

--- a/packages/core/src/types/tool.types.ts
+++ b/packages/core/src/types/tool.types.ts
@@ -51,6 +51,20 @@ export interface RuntimeTool<
   /** Human-readable label used in logs and developer tooling. */
   label: string;
 
+  /**
+   * Optional business-logic precondition check.
+   *
+   * Called after TypeBox schema validation and after any `onBeforeToolCall`
+   * interceptor has potentially rewritten the arguments, but before `execute`.
+   * If this method returns `{ valid: false }` or throws, `execute` is not
+   * called and the model receives a `"Tool precondition failed: <reason>"`
+   * error result. `onAfterToolCall` is also not called in that case.
+   */
+  validate?(
+    params: Static<TParameters>,
+    ctx: ToolValidationContext,
+  ): Promise<ValidationResult> | ValidationResult;
+
   /** Executes the tool for a single model-generated tool call. */
   execute(
     toolCallId: string,
@@ -60,6 +74,32 @@ export interface RuntimeTool<
     onSignal?: (event: ToolSignalEvent) => void,
   ): Promise<ToolResult<TDetails>>;
 }
+
+// ============================================================================
+// Validation types — two-phase validation support
+// ============================================================================
+
+/**
+ * Minimal context available to a tool's `validate` method.
+ *
+ * Intentionally narrower than `ToolExecutionContext`: validation is a pure
+ * precondition check and does not need streaming callbacks.
+ */
+export interface ToolValidationContext {
+  readonly toolCallId: string;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Return value of a `validate` method.
+ *
+ * - `{ valid: true }` — precondition satisfied, proceed to execution.
+ * - `{ valid: false; reason: string }` — precondition failed; the executor
+ *   surfaces the reason as a `"Tool precondition failed: <reason>"` error result.
+ */
+export type ValidationResult =
+  | { readonly valid: true }
+  | { readonly valid: false; readonly reason: string };
 
 /** Extracts the static parameter type from a runtime tool definition. */
 export type ExtractToolParams<T> = T extends RuntimeTool<infer P, unknown> ? Static<P> : never;

--- a/packages/core/test/define-tool.test.ts
+++ b/packages/core/test/define-tool.test.ts
@@ -3,9 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Type } from "@sinclair/typebox";
 import { defineTool } from "../src/tools/define-tool.js";
+import { defineSimpleTool } from "../src/tools/tool-builder.js";
+import type { ToolValidationContext } from "../src/types/tool.types.js";
 
 describe("defineTool", () => {
   it("creates a RuntimeTool with the correct name and description", () => {
@@ -82,5 +84,78 @@ describe("defineTool", () => {
     const result = await t.execute("test-call-id", { msg: "hello" }, undefined, () => {});
     expect(result.content[0]).toMatchObject({ type: "text", text: "hello" });
     expect((result as { details: { msg: string } }).details.msg).toBe("hello");
+  });
+
+  it("validate option is wired to RuntimeTool.validate", async () => {
+    const validateFn = vi.fn().mockResolvedValue({ valid: true });
+    const t = defineTool({
+      name: "checked",
+      description: "Checked tool",
+      parameters: Type.Object({ value: Type.String() }),
+      validate: validateFn,
+      async execute() {
+        return { content: [] };
+      },
+    });
+
+    expect(typeof t.validate).toBe("function");
+    const ctx: ToolValidationContext = { toolCallId: "id-1" };
+    await t.validate!({ value: "x" }, ctx);
+    expect(validateFn).toHaveBeenCalledOnce();
+    expect(validateFn).toHaveBeenCalledWith({ value: "x" }, ctx);
+  });
+
+  it("validate option absent: RuntimeTool.validate is undefined", () => {
+    const t = defineTool({
+      name: "plain",
+      description: "Plain tool",
+      async execute() {
+        return { content: [] };
+      },
+    });
+    expect(t.validate).toBeUndefined();
+  });
+});
+
+describe("defineSimpleTool", () => {
+  it("creates a RuntimeTool with the correct name and description", () => {
+    const t = defineSimpleTool({
+      name: "ping",
+      description: "Pings",
+      async execute() {
+        return { content: [{ type: "text" as const, text: "pong" }], details: null };
+      },
+    });
+    expect(t.name).toBe("ping");
+    expect(t.description).toBe("Pings");
+  });
+
+  it("validate option is wired to RuntimeTool.validate", async () => {
+    const validateFn = vi.fn().mockResolvedValue({ valid: true });
+    const t = defineSimpleTool({
+      name: "safe-ping",
+      description: "Safe ping",
+      validate: validateFn,
+      async execute() {
+        return { content: [], details: null };
+      },
+    });
+
+    expect(typeof t.validate).toBe("function");
+    const ctx: ToolValidationContext = { toolCallId: "id-2" };
+    await t.validate!({}, ctx);
+    expect(validateFn).toHaveBeenCalledOnce();
+    expect(validateFn).toHaveBeenCalledWith(ctx);
+  });
+
+  it("validate option absent: RuntimeTool.validate is undefined", () => {
+    const t = defineSimpleTool({
+      name: "simple",
+      description: "Simple",
+      async execute() {
+        return { content: [], details: null };
+      },
+    });
+    expect(t.validate).toBeUndefined();
   });
 });

--- a/packages/core/test/tool-executor.test.ts
+++ b/packages/core/test/tool-executor.test.ts
@@ -9,7 +9,7 @@ import { executeToolCalls } from "../src/executor/tool-executor.js";
 import { EventStream } from "../src/llm/event-stream.js";
 import type { AssistantMessage, Message } from "../src/types/message.types.js";
 import type { RuntimeEvent } from "../src/types/result.types.js";
-import type { RuntimeTool, ToolInterceptor } from "../src/types/tool.types.js";
+import type { RuntimeTool, ToolInterceptor, ToolValidationContext } from "../src/types/tool.types.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -250,5 +250,138 @@ describe("executeToolCalls — ToolInterceptor", () => {
     expect(result.toolResults[0].isError).toBe(false);
     const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
     expect(beforeEvent.rawArgs).toEqual({ value: "x" });
+  });
+
+  it("interceptor rewrites args to schema-invalid shape: re-validation fails, execute and onAfterToolCall NOT called", async () => {
+    const tool = makeTool("echo");
+    const afterSpy = vi.fn();
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({
+        action: "allow",
+        input: { value: 42 }, // number instead of required string
+      }),
+      onAfterToolCall: afterSpy,
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "ok" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(afterSpy).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(result.toolResults[0].content[0]).toMatchObject({ type: "text", text: expect.stringContaining('Invalid arguments for tool') });
+    // tool.before.args should reflect the interceptor-rewritten value
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    expect((beforeEvent.args as Record<string, unknown>).value).toBe(42);
+  });
+});
+
+describe("executeToolCalls — tool.validate()", () => {
+  let stream!: EventStream<RuntimeEvent, Message[]>;
+  let collectedEvents!: RuntimeEvent[];
+
+  beforeEach(() => {
+    ({ stream, events: collectedEvents } = makeStream());
+  });
+
+  it("validate returns { valid: true }: execute is called, onAfterToolCall is called", async () => {
+    const tool = makeTool("echo");
+    const validateFn = vi.fn().mockResolvedValue({ valid: true });
+    (tool as RuntimeTool & { validate: unknown }).validate = validateFn;
+    const afterSpy = vi.fn().mockResolvedValue(undefined);
+    const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(validateFn).toHaveBeenCalledOnce();
+    expect(tool.execute).toHaveBeenCalledOnce();
+    expect(afterSpy).toHaveBeenCalledOnce();
+    expect(result.toolResults[0].isError).toBe(false);
+  });
+
+  it("validate returns { valid: false, reason }: error result with prefix, execute NOT called, onAfterToolCall NOT called", async () => {
+    const tool = makeTool("echo");
+    (tool as RuntimeTool & { validate: unknown }).validate = vi
+      .fn()
+      .mockResolvedValue({ valid: false, reason: "quota exceeded" });
+    const afterSpy = vi.fn();
+    const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(afterSpy).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(result.toolResults[0].content[0]).toMatchObject({
+      type: "text",
+      text: "Tool precondition failed: quota exceeded",
+    });
+  });
+
+  it("validate throws: error is caught and surfaced as precondition failure, execute NOT called", async () => {
+    const tool = makeTool("echo");
+    (tool as RuntimeTool & { validate: unknown }).validate = vi
+      .fn()
+      .mockRejectedValue(new Error("unexpected boom"));
+    const afterSpy = vi.fn();
+    const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(afterSpy).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(result.toolResults[0].content[0]).toMatchObject({
+      type: "text",
+      text: "Tool precondition failed: unexpected boom",
+    });
+  });
+
+  it("validate failure: tool.before and tool.after are still emitted as a pair", async () => {
+    const tool = makeTool("echo");
+    (tool as RuntimeTool & { validate: unknown }).validate = vi
+      .fn()
+      .mockResolvedValue({ valid: false, reason: "blocked" });
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    await executeToolCalls([tool], msg, undefined, stream);
+
+    expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
+    expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
+    const afterEvent = collectedEvents.find((e) => e.type === "tool.after") as Extract<RuntimeEvent, { type: "tool.after" }>;
+    expect(afterEvent.isError).toBe(true);
+  });
+
+  it("validate is undefined: behavior unchanged — execute is called normally", async () => {
+    const tool = makeTool("echo");
+    expect(tool.validate).toBeUndefined();
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
+    const result = await executeToolCalls([tool], msg, undefined, stream);
+
+    expect(tool.execute).toHaveBeenCalledOnce();
+    expect(result.toolResults[0].isError).toBe(false);
+  });
+
+  it("validate runs on effectiveArgs (post-interceptor), not original args", async () => {
+    const tool = makeTool("echo");
+    const receivedParams: unknown[] = [];
+    (tool as RuntimeTool & { validate: (p: unknown, ctx: ToolValidationContext) => { valid: true } }).validate = vi
+      .fn()
+      .mockImplementation((params: unknown) => {
+        receivedParams.push(params);
+        return { valid: true as const };
+      });
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow", input: { value: "MODIFIED" } }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "original" } }]);
+    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+
+    expect(receivedParams[0]).toEqual({ value: "MODIFIED" });
   });
 });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import { describe, it, expect } from "vitest";
+import { Type } from "@sinclair/typebox";
+import { validateToolInput } from "../src/llm/utils/validation.js";
+import { ToolValidationError } from "../src/errors.js";
+
+const schema = Type.Object({
+  name: Type.String(),
+  age: Type.Number({ minimum: 0 }),
+});
+
+const tool = { name: "profile", description: "", parameters: schema };
+
+describe("validateToolInput", () => {
+  it("returns the input unchanged when it matches the schema", () => {
+    const input = { name: "Alice", age: 30 };
+    expect(validateToolInput(tool, input)).toBe(input);
+  });
+
+  it("throws ToolValidationError when required field is missing", () => {
+    expect(() => validateToolInput(tool, { age: 25 })).toThrow(ToolValidationError);
+  });
+
+  it("throws ToolValidationError when field type is wrong", () => {
+    expect(() => validateToolInput(tool, { name: "Bob", age: "old" })).toThrow(ToolValidationError);
+  });
+
+  it("error message includes the tool name", () => {
+    expect(() => validateToolInput(tool, { age: 1 })).toThrow(ToolValidationError);
+    let caught: ToolValidationError | undefined;
+    try {
+      validateToolInput(tool, { age: 1 });
+    } catch (e) {
+      caught = e as ToolValidationError;
+    }
+    expect(caught!.message).toContain("profile");
+  });
+
+  it("errors array contains path and message for each violation", () => {
+    // Two violations: missing name (undefined fails string check) and age is a string.
+    expect(() => validateToolInput(tool, { age: "not-a-number" })).toThrow(ToolValidationError);
+    let caught: ToolValidationError | undefined;
+    try {
+      validateToolInput(tool, { age: "not-a-number" });
+    } catch (e) {
+      caught = e as ToolValidationError;
+    }
+    const errors = caught!.errors!;
+    expect(Array.isArray(errors)).toBe(true);
+    expect(errors.length).toBeGreaterThan(0);
+    for (const error of errors) {
+      expect(typeof error.path).toBe("string");
+      expect(typeof error.message).toBe("string");
+      expect(error.message.length).toBeGreaterThan(0);
+    }
+    expect(errors.some((e) => e.path.includes("age"))).toBe(true);
+  });
+
+  it("violating minimum constraint produces an error with the correct path", () => {
+    expect(() => validateToolInput(tool, { name: "Charlie", age: -1 })).toThrow(ToolValidationError);
+    let caught: ToolValidationError | undefined;
+    try {
+      validateToolInput(tool, { name: "Charlie", age: -1 });
+    } catch (e) {
+      caught = e as ToolValidationError;
+    }
+    expect(caught!.errors!.some((e) => e.path.includes("age"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `RuntimeTool.validate?(params, ctx: ToolValidationContext)` — an optional two-phase precondition check that runs after TypeBox schema validation and after any `onBeforeToolCall` interceptor rewrites, but before `execute`
- All authoring APIs updated: `defineTool()`, `tool()` builder, and `defineSimpleTool()` all accept a `validate` field/method
- New `validateToolInput(tool, input)` helper in `validation.ts` enables re-validation of interceptor-rewritten args with the same `ToolValidationError` format as the initial schema check
- New public types `ToolValidationContext` and `ValidationResult` exported from `@agentrail/core`

## Execution order

1. TypeBox schema validation (structural)
2. `onBeforeToolCall` interceptor (may rewrite args)
3. Schema re-validation on rewritten args (`validateToolInput`)
4. `validate()` — business-logic precondition on final effective args
5. `execute()`

`onAfterToolCall` is **not** called when `validate` fails.

## Test plan

- [x] `pnpm --filter @agentrail/core test` — 41 tests pass (17 executor, 11 define-tool, 6 validation util, 3 agent-loop, 3 session, 1 reactive-compaction)
- [x] `pnpm --filter @agentrail/core typecheck` — no errors
- New test cases cover: validate pass/fail/throw, validate runs on post-interceptor args, interceptor schema-breaking rewrite triggers re-validation error, `defineSimpleTool.validate` wiring, `validateToolInput` error structure (path + message)

Closes #59