### PR TITLE
chore: add DCO file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,28 @@ This file controls non-sensitive runtime settings such as:
 
 Store secrets in environment variables only. Do not add real credentials to `config/agentrail.yaml`.
 
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify that you have the right to submit the contribution under this project's license (see [`DCO`](./DCO)).
+
+Sign off every commit with `-s` / `--signoff`:
+
+```bash
+git commit -s -m "feat: my change"
+```
+
+This appends a `Signed-off-by: Your Name <email@example.com>` line to the commit message using your Git `user.name` and `user.email`. The DCO check runs automatically on every PR and will block merging if any commit is missing the sign-off.
+
+If you forgot to sign off on previous commits, amend or rebase them:
+
+```bash
+# Single commit
+git commit --amend --signoff
+
+# Multiple commits (last N)
+git rebase HEAD~N --signoff
+```
+
 ## Daily Development Flow
 
 1. Create a feature branch from `master`.
@@ -47,7 +69,7 @@ Store secrets in environment variables only. Do not add real credentials to `con
 3. Make your code changes.
 4. Run the local checks relevant to your changes.
 5. Add a changeset if your change affects any published package.
-6. Open a pull request.
+6. Open a pull request (all commits must be signed off — see DCO section above).
 7. After merge, let the release workflow create or update the Release PR.
 8. Merge the Release PR to publish packages and, when applicable, the sandbox image.
 
@@ -133,6 +155,7 @@ The sandbox container image is published to `ghcr.io/yai-dev/agentrail-sandbox`.
 
 Every PR runs GitHub Actions CI:
 
+- DCO sign-off check (all commits must have `Signed-off-by`)
 - install dependencies
 - build published packages
 - run package tests
@@ -200,6 +223,7 @@ AI tools are welcome for writing code, tests, and documentation. Contributors ar
 
 Before requesting review:
 
+- all commits are signed off (`git commit -s`)
 - `pnpm format` has been run and any formatting-only changes were reviewed
 - local configuration is represented in `config/agentrail.yaml`
 - code builds locally

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is allowed to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Adds the Developer Certificate of Origin (DCO 1.1) text file to the repository root.

This is a prerequisite for enabling the [DCO GitHub App](https://github.com/apps/dco) which will require all PR commits to carry a `Signed-off-by` line (`git commit -s`).