### PR TITLE
feat: add toolCalls field to sub-agent job results

### DIFF
--- a/.changeset/capabilities-v0.3.0.md
+++ b/.changeset/capabilities-v0.3.0.md
@@ -1,0 +1,7 @@
+---
+"@agentrail/capabilities": minor
+---
+
+Add toolCalls field to sub-agent job results
+
+ManagedAgentDeliveryResult and OrchestrationAgentJob now carry a toolCalls array with every tool call the sub-agent made during a job, including the tool name, input arguments, and the full output (content and structured details). The wait_agent tool result now includes the resolution object so the parent LLM can see outputText and toolCalls.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Detect sandbox changes
+        id: sandbox
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - 'docker/sandbox/**'
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -78,4 +86,5 @@ jobs:
         run: pnpm typecheck
 
       - name: Build sandbox image
+        if: steps.sandbox.outputs.changed == 'true'
         run: docker build -t agentrail-sandbox:ci docker/sandbox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 This repository is a `pnpm` workspace. Core publishable packages live in `packages/*`, each with `src/`, `test/`, and usually `dist/`. End-to-end examples live in `examples/*`, including `examples/playground-server`, `examples/playground-ui`, and `examples/deep-research`. Documentation lives in `docs/`, shared local config in `config/agentrail.yaml`, static assets in `assets/`, and sandbox image sources in `docker/sandbox`.
 
 ## Build, Test, and Development Commands
+
 Install once with `pnpm install` on Node.js 22.
 
 - `pnpm build`: build all packages and examples.
@@ -15,13 +17,17 @@ Install once with `pnpm install` on Node.js 22.
 - `docker build -t agentrail-sandbox:latest docker/sandbox`: rebuild the sandbox image when touching sandbox code.
 
 ## Coding Style & Naming Conventions
+
 The codebase is TypeScript ESM. Prettier is the formatting authority: 2-space indentation, semicolons, double quotes, trailing commas, and 100-column width. Imports are organized by `prettier-plugin-organize-imports`. Keep source under `src/` and name tests with `.test.ts` under `test/`. Use descriptive file names such as `agentLoop.test.ts` or `session-store.test.ts`; prefer `camelCase` for variables/functions and `PascalCase` for exported types and classes.
 
 ## Testing Guidelines
+
 Vitest is the standard test runner. Package configs such as `packages/runtime-core/vitest.config.ts` use Node environments and V8 coverage reporting. Add or update tests alongside behavior changes, especially in published packages. Before opening a PR, run the smallest relevant scoped command first, then `pnpm test` and `pnpm typecheck` for full verification.
 
 ## Commit & Pull Request Guidelines
+
 Recent history uses Conventional Commits such as `fix: ...`, `chore: ...`, and `feat: ...`; keep subjects short and imperative. PRs should describe the behavioral change, list validation commands run, and link the related issue when applicable. Add a changeset with `pnpm changeset` for user-visible changes to published packages; docs-only and internal-only updates usually do not need one.
 
 ## Security & Configuration Tips
+
 Keep secrets in environment variables like `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`, never in `config/agentrail.yaml`. If you change published sandbox behavior, update `@agentrail/sandbox` and rebuild the Docker image locally.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -81,7 +81,10 @@ export default defineConfig({
             text: "Use Capability Packages",
             link: "/guides/use-capability-packages",
           },
-          { text: "Use OpenAI-Compatible Providers", link: "/guides/use-openai-compatible-providers" },
+          {
+            text: "Use OpenAI-Compatible Providers",
+            link: "/guides/use-openai-compatible-providers",
+          },
           { text: "Deployment", link: "/guides/deployment" },
           { text: "Troubleshooting", link: "/guides/troubleshooting" },
         ],

--- a/docs/concepts/orchestration.md
+++ b/docs/concepts/orchestration.md
@@ -57,14 +57,12 @@ Each sub-agent has a **mailbox** — a persisted event queue for inputs and clos
 
 From the parent agent's perspective, orchestration is accessed through four runtime tools. These are injected by the host layer:
 
-
 | Tool          | Purpose                                  |
 | ------------- | ---------------------------------------- |
 | `spawn-agent` | Create a sub-agent and assign it a role  |
 | `send-input`  | Send a work item to a sub-agent          |
 | `wait-agent`  | Block until agents reach a desired state |
 | `close-agent` | Terminate a sub-agent                    |
-
 
 The parent agent calls these tools like any other tool. The orchestration manager handles the actual coordination.
 
@@ -202,3 +200,4 @@ Orchestration is for **multi-agent work distribution**. Plugins are for **cross-
 - [Deep Research Example](../examples/deep-research.md)
 - [Host Primitives Reference](../reference/host-primitives.md)
 
+```

--- a/docs/concepts/profiles.md
+++ b/docs/concepts/profiles.md
@@ -65,14 +65,14 @@ export const tenantProfile = defineProfile({
 
 ## Key Fields
 
-| Field           | Purpose                                                                                   |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| `id`            | Stable identifier used by the host to resolve this profile                                |
-| `name`          | Human-readable label for logs and diagnostics                                             |
-| `agent`         | Static agent config (static shape only)                                                   |
-| `createAgent`   | Per-request factory function (dynamic shape only)                                         |
-| `capabilities`  | Capability descriptors to compose into the agent                                          |
-| `modelConfig`   | Model metadata for capabilities that spawn sub-agents (e.g. `skills()`)                  |
+| Field          | Purpose                                                                 |
+| -------------- | ----------------------------------------------------------------------- |
+| `id`           | Stable identifier used by the host to resolve this profile              |
+| `name`         | Human-readable label for logs and diagnostics                           |
+| `agent`        | Static agent config (static shape only)                                 |
+| `createAgent`  | Per-request factory function (dynamic shape only)                       |
+| `capabilities` | Capability descriptors to compose into the agent                        |
+| `modelConfig`  | Model metadata for capabilities that spawn sub-agents (e.g. `skills()`) |
 
 The low-level `AgentrailProfile` contract also supports `contextWindow` for token-budget calculations, but `defineProfile` does not currently expose it as a first-class helper field. If you do not provide it through a lower-level custom profile, the host defaults to `200_000`.
 
@@ -120,11 +120,11 @@ Most apps start with a single profile and add more over time. Each profile is in
 
 These three concepts often get confused:
 
-| Concern                                              | Belongs in                           |
-| ---------------------------------------------------- | ------------------------------------ |
-| Agent execution loop, model, tools                   | Agent (`defineAgent`)                |
-| How an agent is assembled for a request              | Profile (`defineProfile`)            |
-| Cross-cutting host behavior (memory, slash commands) | Plugin (`AgentrailPlugin`)           |
+| Concern                                              | Belongs in                             |
+| ---------------------------------------------------- | -------------------------------------- |
+| Agent execution loop, model, tools                   | Agent (`defineAgent`)                  |
+| How an agent is assembled for a request              | Profile (`defineProfile`)              |
+| Cross-cutting host behavior (memory, slash commands) | Plugin (`AgentrailPlugin`)             |
 | Prompt content and fragments                         | Prompt builder (`createPromptBuilder`) |
 
 ## Related Concepts

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -141,9 +141,9 @@ const searchTool = defineTool({
     query: Type.String(),
   }),
   async execute(params, ctx) {
-  ctx.onUpdate({ content: [{ type: "text", text: "Starting..." }], details: null });
-  const result = await longRunningTask(params.query);
-  return { content: [{ type: "text", text: result }], details: result };
+    ctx.onUpdate({ content: [{ type: "text", text: "Starting..." }], details: null });
+    const result = await longRunningTask(params.query);
+    return { content: [{ type: "text", text: result }], details: result };
   },
 });
 ```
@@ -157,12 +157,12 @@ const approvalTool = defineTool({
   name: "request_approval",
   description: "Ask the user to confirm a choice before continuing.",
   async execute(params, ctx) {
-  ctx.onSignal?.({
-    type: "waiting_for_input",
-    question: "Which option do you prefer?",
-    options: ["Option A", "Option B"],
-  });
-  // ...
+    ctx.onSignal?.({
+      type: "waiting_for_input",
+      question: "Which option do you prefer?",
+      options: ["Option A", "Option B"],
+    });
+    // ...
     return { content: [{ type: "text", text: "Waiting for input." }], details: null };
   },
 });
@@ -189,12 +189,12 @@ The capabilities package exposes tools for common patterns:
 
 Capability tools are added to a profile via `defineProfile({ capabilities: [...] })`:
 
-| Capability         | Example tools                                    |
-| ------------------ | ------------------------------------------------ |
-| `knowledge(km)`    | kb-list, kb-read, kb-search                      |
+| Capability         | Example tools                                          |
+| ------------------ | ------------------------------------------------------ |
+| `knowledge(km)`    | kb-list, kb-read, kb-search                            |
 | `filesystem(...)`  | bash, read, write, edit, glob, grep, sleep, todo-write |
-| `skills(sm)`       | skill-list, skill-invoke                         |
-| `orchestration(r)` | spawn-agent, send-input, wait-agent, close-agent |
+| `skills(sm)`       | skill-list, skill-invoke                               |
+| `orchestration(r)` | spawn-agent, send-input, wait-agent, close-agent       |
 
 ### 3. Orchestration tools
 

--- a/docs/guides/use-capability-packages.md
+++ b/docs/guides/use-capability-packages.md
@@ -197,12 +197,12 @@ export const powerProfile = defineProfile({
 
 ## What Belongs Where
 
-| Concern                           | Import from                |
-| --------------------------------- | -------------------------- |
-| Document search and retrieval     | `@agentrail/capabilities`  |
-| Code execution, file I/O, browser | `@agentrail/capabilities`  |
-| Reusable named agent capabilities | `@agentrail/capabilities`  |
-| Session history and compaction    | `@agentrail/app`           |
+| Concern                           | Import from               |
+| --------------------------------- | ------------------------- |
+| Document search and retrieval     | `@agentrail/capabilities` |
+| Code execution, file I/O, browser | `@agentrail/capabilities` |
+| Reusable named agent capabilities | `@agentrail/capabilities` |
+| Session history and compaction    | `@agentrail/app`          |
 
 ## Related Concepts
 

--- a/docs/guides/use-openai-compatible-providers.md
+++ b/docs/guides/use-openai-compatible-providers.md
@@ -25,12 +25,12 @@ No additional packages or registration calls are needed — the standard `import
 
 ## Supported Providers
 
-| Provider | `baseUrl` | API key env var |
-|----------|-----------|-----------------|
-| DeepSeek | `https://api.deepseek.com/v1` | `DEEPSEEK_API_KEY` |
-| Ollama (local) | `http://localhost:11434/v1` | not required |
-| OpenRouter | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
-| Together AI | `https://api.together.xyz/v1` | `TOGETHER_API_KEY` |
+| Provider       | `baseUrl`                      | API key env var      |
+| -------------- | ------------------------------ | -------------------- |
+| DeepSeek       | `https://api.deepseek.com/v1`  | `DEEPSEEK_API_KEY`   |
+| Ollama (local) | `http://localhost:11434/v1`    | not required         |
+| OpenRouter     | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
+| Together AI    | `https://api.together.xyz/v1`  | `TOGETHER_API_KEY`   |
 
 ## Provider Examples
 
@@ -58,7 +58,7 @@ const agent = defineAgent({
   id: "ollama-agent",
   model: {
     provider: "openai",
-    modelId: "llama3.2",  // must match a model pulled with `ollama pull`
+    modelId: "llama3.2", // must match a model pulled with `ollama pull`
     baseUrl: "http://localhost:11434/v1",
   },
   system: "You are a helpful assistant.",
@@ -134,13 +134,13 @@ The `modelConfig` fields are merged on top of the model string at agent construc
 
 Not all providers fully implement the OpenAI chat completions specification. Check the provider's documentation before relying on these features:
 
-| Feature | Notes |
-|---------|-------|
-| Tool calling (function calling) | Supported by DeepSeek, OpenRouter, Together AI for capable models; not supported by all Ollama models |
-| Streaming | Generally supported; verify with your specific model |
-| Structured output (`response_format`) | Varies by provider and model |
-| Extended thinking | Only available on Anthropic models via the `anthropic` provider — not available through `baseUrl` overrides |
-| Vision / image inputs | Varies by provider and model |
+| Feature                               | Notes                                                                                                       |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Tool calling (function calling)       | Supported by DeepSeek, OpenRouter, Together AI for capable models; not supported by all Ollama models       |
+| Streaming                             | Generally supported; verify with your specific model                                                        |
+| Structured output (`response_format`) | Varies by provider and model                                                                                |
+| Extended thinking                     | Only available on Anthropic models via the `anthropic` provider — not available through `baseUrl` overrides |
+| Vision / image inputs                 | Varies by provider and model                                                                                |
 
 When a provider does not support tool calling, the agent loop will fail if any tools are registered. For tool-free use cases (pure text generation, summarization, classification), most providers work without issue.
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -190,18 +190,18 @@ Runtime events come from `@agentrail/core` and are emitted during agent executio
 Types use a dotted-namespace convention (`session.*`, `turn.*`, `message.*`, `tool.*`).
 The most important ones for UI consumers:
 
-| Event type                  | When emitted                                 |
-| --------------------------- | -------------------------------------------- |
-| `session.start`             | Agent begins processing a request            |
-| `session.end`               | Agent finishes (all turns complete)          |
-| `turn.start`                | A new LLM turn starts                        |
-| `turn.complete`             | A turn finishes                              |
-| `compaction`                | In-loop reactive compaction rewrites history |
-| `message.update`            | Streaming text delta from the LLM            |
+| Event type                  | When emitted                                                                               |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `session.start`             | Agent begins processing a request                                                          |
+| `session.end`               | Agent finishes (all turns complete)                                                        |
+| `turn.start`                | A new LLM turn starts                                                                      |
+| `turn.complete`             | A turn finishes                                                                            |
+| `compaction`                | In-loop reactive compaction rewrites history                                               |
+| `message.update`            | Streaming text delta from the LLM                                                          |
 | `tool.before`               | A tool call is about to be dispatched (after any `onBeforeToolCall` plugin hooks have run) |
-| `tool.after`                | A tool invocation completes                  |
-| `waiting_for_user_input`    | The agent is paused waiting for user input   |
-| `skill_start` / `skill_end` | A skill sub-agent is invoked                 |
+| `tool.after`                | A tool invocation completes                                                                |
+| `waiting_for_user_input`    | The agent is paused waiting for user input                                                 |
+| `skill_start` / `skill_end` | A skill sub-agent is invoked                                                               |
 
 ### `tool.before` field reference
 
@@ -227,7 +227,7 @@ The most important ones for UI consumers:
 
 > **Note for consumers that used `args` for audit purposes:** if you have a plugin
 > or tracing integration that reads `tool.before.args` and relies on it being the
-> unmodified model output, switch to `rawArgs`.  `args` now reflects the effective
+> unmodified model output, switch to `rawArgs`. `args` now reflects the effective
 > (possibly plugin-modified) arguments that were actually executed.
 
 ---

--- a/docs/reference/host-defaults.md
+++ b/docs/reference/host-defaults.md
@@ -4,14 +4,14 @@
 
 ## Migration
 
-| Old API                                 | Replacement                                      |
-| --------------------------------------- | ------------------------------------------------ |
-| `defineHostedProfile`                   | `defineProfile` from `@agentrail/app`            |
-| `createHostedProfileResolver`           | `createStaticProfileResolver` from `@agentrail/app` |
-| `buildDefaultCapabilityTools`           | `capabilities: [...]` in `defineProfile`         |
-| `createDefaultCapabilityContextProviders` | `capabilities: [...]` in `defineProfile`       |
-| `@agentrail/host`                       | `@agentrail/app/advanced`                        |
-| `@agentrail/host/defaults`              | `@agentrail/app/compat`                          |
+| Old API                                   | Replacement                                         |
+| ----------------------------------------- | --------------------------------------------------- |
+| `defineHostedProfile`                     | `defineProfile` from `@agentrail/app`               |
+| `createHostedProfileResolver`             | `createStaticProfileResolver` from `@agentrail/app` |
+| `buildDefaultCapabilityTools`             | `capabilities: [...]` in `defineProfile`            |
+| `createDefaultCapabilityContextProviders` | `capabilities: [...]` in `defineProfile`            |
+| `@agentrail/host`                         | `@agentrail/app/advanced`                           |
+| `@agentrail/host/defaults`                | `@agentrail/app/compat`                             |
 
 ## Import Path
 
@@ -60,7 +60,8 @@ export const supportProfile = defineProfile({
   name: "Support Agent",
   agent: {
     model: "anthropic:claude-sonnet-4-5",
-    prompt: async (ctx) => createPromptBuilder(myBundle).render({ vars: { sessionId: ctx.sessionId } }),
+    prompt: async (ctx) =>
+      createPromptBuilder(myBundle).render({ vars: { sessionId: ctx.sessionId } }),
     maxTurns: 30,
   },
 });

--- a/docs/reference/inspector-route.md
+++ b/docs/reference/inspector-route.md
@@ -10,7 +10,7 @@ Pass `inspector: true` to `createAgentApp`:
 import { createAgentApp } from "@agentrail/app";
 
 const app = createAgentApp({
-  dataDir: "./data",   // required when inspector is enabled
+  dataDir: "./data", // required when inspector is enabled
   profiles: [myProfile],
   inspector: true,
 });
@@ -19,6 +19,7 @@ const app = createAgentApp({
 The route is mounted at the fixed path `/__inspector`. The Agentrail Inspector Docker image's nginx proxy hardcodes this prefix, so the mount path is not configurable in v1.
 
 **Requirements:**
+
 - `dataDir` must be set. A custom `sessionStore` is not supported.
 - An error is thrown at startup if `inspector: true` is set without `dataDir`.
 
@@ -47,6 +48,7 @@ All endpoints are relative to `/__inspector`.
 Returns a list of all sessions across all tenants with enriched metadata.
 
 **Response:**
+
 ```json
 {
   "sessions": [
@@ -73,11 +75,12 @@ Returns the merged trace for a session: runtime events (agent loop, tools, compa
 
 **Query parameters:**
 
-| Parameter | Default | Description |
-|---|---|---|
+| Parameter  | Default     | Description                  |
+| ---------- | ----------- | ---------------------------- |
 | `tenantId` | `"default"` | Tenant that owns the session |
 
 **Response:**
+
 ```json
 {
   "envelopes": [
@@ -105,11 +108,12 @@ Returns the current orchestration state snapshot for a session: all agents that 
 
 **Query parameters:**
 
-| Parameter | Default | Description |
-|---|---|---|
+| Parameter  | Default     | Description                  |
+| ---------- | ----------- | ---------------------------- |
 | `tenantId` | `"default"` | Tenant that owns the session |
 
 **Response:**
+
 ```json
 {
   "agents": [
@@ -134,14 +138,17 @@ Returns the raw message history for a session. Used by the Context Diff view in 
 
 **Query parameters:**
 
-| Parameter | Default | Description |
-|---|---|---|
+| Parameter  | Default     | Description                  |
+| ---------- | ----------- | ---------------------------- |
 | `tenantId` | `"default"` | Tenant that owns the session |
 
 **Response:**
+
 ```json
 {
-  "messages": [ /* Anthropic-format Message objects */ ]
+  "messages": [
+    /* Anthropic-format Message objects */
+  ]
 }
 ```
 
@@ -152,6 +159,7 @@ Returns the raw message history for a session. Used by the Context Diff view in 
 Lightweight liveness check. Always returns 200 while the process is alive.
 
 **Response:**
+
 ```json
 { "status": "ok" }
 ```

--- a/docs/reference/plugin-contract.md
+++ b/docs/reference/plugin-contract.md
@@ -77,7 +77,9 @@ interface AgentrailPlugin {
    * Return `{ action: "deny", reason }` to block execution, or
    * `{ action: "allow", input }` to replace the tool arguments.
    */
-  onBeforeToolCall?(event: BeforeToolCallEvent): Promise<AppBeforeToolCallResult> | AppBeforeToolCallResult;
+  onBeforeToolCall?(
+    event: BeforeToolCallEvent,
+  ): Promise<AppBeforeToolCallResult> | AppBeforeToolCallResult;
   /** Runs after each tool call completes (success or execution error, not deny). */
   onAfterToolCall?(event: AfterToolCallEvent): Promise<void> | void;
   /** Runs after the resulting turn has been persisted */
@@ -153,12 +155,12 @@ const authPlugin: AgentrailPlugin = { name: "auth", priority: 100, ... };
 const featurePlugin: AgentrailPlugin = { name: "feature", priority: 0, ... };
 ```
 
-| Phase | Order | Rationale |
-|-------|-------|-----------|
-| `start()` | Descending (high first) | High-priority plugins may be dependencies of others |
-| `stop()` | Ascending (low first) | Teardown mirrors initialisation |
-| Request hooks | Descending (high first) | Auth/policy plugins run before feature plugins |
-| Context providers | Descending (high first) | High-priority context is injected first |
+| Phase             | Order                   | Rationale                                           |
+| ----------------- | ----------------------- | --------------------------------------------------- |
+| `start()`         | Descending (high first) | High-priority plugins may be dependencies of others |
+| `stop()`          | Ascending (low first)   | Teardown mirrors initialisation                     |
+| Request hooks     | Descending (high first) | Auth/policy plugins run before feature plugins      |
+| Context providers | Descending (high first) | High-priority context is injected first             |
 
 ### `critical`
 
@@ -241,14 +243,14 @@ hooks but before the tool's `execute()` function is called.
 > **Object-only constraint**: this hook is only called when the validated tool
 > input is a plain, non-array object (`typeof input === "object" && !Array.isArray(input)`).
 > Tools whose top-level schema is an array or a primitive (string, number, …) will
-> **not** trigger `onBeforeToolCall`.  This matches the `Record<string, unknown>` type
+> **not** trigger `onBeforeToolCall`. This matches the `Record<string, unknown>` type
 > of `input` — the hook is not called for schemas that cannot be safely represented
 > as a record.
 
 ```ts
 export interface BeforeToolCallEvent {
   toolName: string;
-  input: Record<string, unknown>;   // fresh shallow copy per plugin call
+  input: Record<string, unknown>; // fresh shallow copy per plugin call
   context: AgentrailProfileContext; // tenantId, userId, sessionId, …
 }
 
@@ -260,10 +262,10 @@ export type AppBeforeToolCallResult =
 
 Return values:
 
-| Result | Effect |
-|--------|--------|
-| `{ action: "allow" }` | Proceed with the original arguments |
-| `{ action: "allow", input }` | Replace the tool arguments with `input` |
+| Result                       | Effect                                                       |
+| ---------------------------- | ------------------------------------------------------------ |
+| `{ action: "allow" }`        | Proceed with the original arguments                          |
+| `{ action: "allow", input }` | Replace the tool arguments with `input`                      |
 | `{ action: "deny", reason }` | Block the tool call; the model receives `reason` as an error |
 
 If a plugin throws, the error is reported via `onPluginError` and execution
@@ -272,7 +274,7 @@ continues with the next plugin — **a throw is not treated as a deny**.
 Multiple plugins run in descending `priority` order. The first `deny` wins; a
 modified `input` is forwarded to subsequent plugins.
 
-Each plugin receives a **fresh shallow copy** of `input`.  In-place mutations do
+Each plugin receives a **fresh shallow copy** of `input`. In-place mutations do
 not affect other plugins; use the `{ action: "allow", input }` return value to
 propagate changes.
 
@@ -282,7 +284,7 @@ stripping, path restriction enforcement.
 ### `onAfterToolCall`
 
 Runs after a tool's `execute()` returns, whether the execution succeeded or
-raised an error.  **Not called** in two cases:
+raised an error. **Not called** in two cases:
 
 1. When `onBeforeToolCall` returned `{ action: "deny" }`.
 2. When the tool's validated input is not a plain object (same constraint as
@@ -409,16 +411,16 @@ propagates to the calling request unless `critical: true` is set on that plugin.
 
 ### Error strategy per hook
 
-| Hook | On error |
-|------|----------|
-| `start()` | Report to `onPluginError`, then rethrow (startup is aborted) |
-| `stop()` | Report to `onPluginError`, continue (all plugins always get to stop) |
-| `onRequestStart/End/onTurnPersisted` | Report, continue |
-| `interceptChatRequest` (non-critical) | Report, skip plugin (treated as `null`) |
-| `interceptChatRequest` (critical) | Report, rethrow (request is aborted) |
-| `attachmentHandler` | Report, skip plugin result, merge others |
-| `onBeforeToolCall` | Report, continue to next plugin (not treated as deny) |
-| `onAfterToolCall` | Report, continue (tool result is unaffected) |
+| Hook                                  | On error                                                             |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `start()`                             | Report to `onPluginError`, then rethrow (startup is aborted)         |
+| `stop()`                              | Report to `onPluginError`, continue (all plugins always get to stop) |
+| `onRequestStart/End/onTurnPersisted`  | Report, continue                                                     |
+| `interceptChatRequest` (non-critical) | Report, skip plugin (treated as `null`)                              |
+| `interceptChatRequest` (critical)     | Report, rethrow (request is aborted)                                 |
+| `attachmentHandler`                   | Report, skip plugin result, merge others                             |
+| `onBeforeToolCall`                    | Report, continue to next plugin (not treated as deny)                |
+| `onAfterToolCall`                     | Report, continue (tool result is unaffected)                         |
 
 ### `onPluginError` callback
 

--- a/docs/reference/telemetry-sink.md
+++ b/docs/reference/telemetry-sink.md
@@ -49,30 +49,30 @@ interface TelemetrySinkEvent {
   traceId: string;
   sessionId: string;
   tenantId: string;
-  timestamp: string;   // ISO-8601
-  sequence: number;    // monotonically increasing within a request
+  timestamp: string; // ISO-8601
+  sequence: number; // monotonically increasing within a request
   source: "runtime" | "orchestration" | "host";
   event: Record<string, unknown>;
 }
 ```
 
-| Field | Description |
-|---|---|
-| `traceId` | Unique identifier for the originating request chain |
-| `sessionId` | Session this event belongs to |
-| `tenantId` | Tenant this event belongs to |
-| `timestamp` | ISO-8601 timestamp |
-| `sequence` | Monotonically increasing counter within a single request |
-| `source` | Where the event originated (see below) |
-| `event` | Raw event payload matching the corresponding `AgentrailEvent` subtype |
+| Field       | Description                                                           |
+| ----------- | --------------------------------------------------------------------- |
+| `traceId`   | Unique identifier for the originating request chain                   |
+| `sessionId` | Session this event belongs to                                         |
+| `tenantId`  | Tenant this event belongs to                                          |
+| `timestamp` | ISO-8601 timestamp                                                    |
+| `sequence`  | Monotonically increasing counter within a single request              |
+| `source`    | Where the event originated (see below)                                |
+| `event`     | Raw event payload matching the corresponding `AgentrailEvent` subtype |
 
 ### Event sources
 
-| Source | Description |
-|---|---|
-| `"runtime"` | Agent loop events: turn start/end, tool calls, compaction, errors |
+| Source            | Description                                                             |
+| ----------------- | ----------------------------------------------------------------------- |
+| `"runtime"`       | Agent loop events: turn start/end, tool calls, compaction, errors       |
 | `"orchestration"` | Multi-agent coordination events: agent spawn, job dispatch, agent close |
-| `"host"` | Framework-level events emitted by the `/chat` or `/stream` route |
+| `"host"`          | Framework-level events emitted by the `/chat` or `/stream` route        |
 
 ## Built-in sinks
 
@@ -103,7 +103,7 @@ const app = createAgentApp({
   dataDir: "./data",
   profiles: [myProfile],
   telemetrySink: createFileTelemetrySink("./data"),
-  inspector: true,   // Inspector reads the same files
+  inspector: true, // Inspector reads the same files
 });
 ```
 
@@ -138,9 +138,9 @@ function createOpenTelemetrySink(): TelemetrySink {
 
 Events emitted via `/chat` are coarser than `/stream`:
 
-| Route | Events emitted |
-|---|---|
-| `/stream` | Full granularity: `session.start`, `turn.start`, `tool.before`, `tool.after`, `turn.end`, `session.end`, compaction events |
-| `/chat` | Synthetic only: `agent_start`, `agent_end`, and `error` — because `agent.invoke()` does not expose granular turn/tool events |
+| Route     | Events emitted                                                                                                               |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `/stream` | Full granularity: `session.start`, `turn.start`, `tool.before`, `tool.after`, `turn.end`, `session.end`, compaction events   |
+| `/chat`   | Synthetic only: `agent_start`, `agent_end`, and `error` — because `agent.invoke()` does not expose granular turn/tool events |
 
 For complete observability traces, use the `/stream` route.

--- a/examples/deep-research/src/context/index.ts
+++ b/examples/deep-research/src/context/index.ts
@@ -3,10 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { KnowledgeManager } from "@agentrail/capabilities";
-import { SessionManager } from "@agentrail/app";
-import { SandboxManager } from "@agentrail/capabilities";
 import { config } from "@/config.js";
+import { SessionManager } from "@agentrail/app";
+import { KnowledgeManager, SandboxManager } from "@agentrail/capabilities";
 
 export const sessionManager = new SessionManager(config.dataDir);
 export const knowledgeManager = new KnowledgeManager(config.dataDir);

--- a/examples/deep-research/src/main.ts
+++ b/examples/deep-research/src/main.ts
@@ -5,14 +5,14 @@
 
 import "@agentrail/core/providers";
 
-import { serve } from "@hono/node-server";
-import { Hono } from "hono";
-import { logger } from "hono/logger";
 import { config } from "@/config.js";
 import { sandboxManager } from "@/context/index.js";
 import { deepResearch } from "@/routes/deep-research.js";
 import { health } from "@/routes/health.js";
 import { run } from "@/routes/run.js";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { logger } from "hono/logger";
 
 const app = new Hono();
 

--- a/examples/deep-research/src/routes/deep-research.ts
+++ b/examples/deep-research/src/routes/deep-research.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createDeepResearchRoute } from "@agentrail/deep-research";
 import { config } from "@/config.js";
+import { createDeepResearchRoute } from "@agentrail/deep-research";
 
 const deepResearch = createDeepResearchRoute({
   dataDir: config.dataDir,

--- a/examples/deep-research/src/routes/run.ts
+++ b/examples/deep-research/src/routes/run.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createDeepResearchRunRoute } from "@agentrail/deep-research";
 import { config } from "@/config.js";
 import { sessionManager } from "@/context/index.js";
+import { createDeepResearchRunRoute } from "@agentrail/deep-research";
 
 const run = createDeepResearchRunRoute({
   sessionStore: sessionManager,

--- a/examples/playground-server/src/agents/default-subagent-runtime.ts
+++ b/examples/playground-server/src/agents/default-subagent-runtime.ts
@@ -4,8 +4,6 @@
  */
 
 import { SessionManager } from "@agentrail/app";
-import type { SessionRef } from "@agentrail/core";
-import type { ModelConfig } from "@agentrail/core";
 import {
   askUser,
   browser,
@@ -15,7 +13,7 @@ import {
   type CreateManagedAgentInput,
   type SubAgentRuntime,
 } from "@agentrail/capabilities";
-import type { RuntimeTool, TransformContextFn } from "@agentrail/core";
+import type { ModelConfig, RuntimeTool, SessionRef, TransformContextFn } from "@agentrail/core";
 
 import { config } from "@/config.js";
 import { knowledgeManager, sandboxManager } from "@/context/index.js";

--- a/examples/playground-server/src/agents/default-subagent-worker-entry.ts
+++ b/examples/playground-server/src/agents/default-subagent-worker-entry.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import { initializeWorker } from "@agentrail/capabilities/orchestration/worker";
-import "@agentrail/core/providers";
 import { DefaultSubAgentRuntime } from "@/agents/default-subagent-runtime.js";
+import { initializeWorker } from "@agentrail/capabilities/orchestration/worker";
+import type { SessionRef } from "@agentrail/core";
+import "@agentrail/core/providers";
 
 interface WorkerInitPayload {
   type: "init";

--- a/examples/playground-server/src/agents/ingestion-agent.ts
+++ b/examples/playground-server/src/agents/ingestion-agent.ts
@@ -9,10 +9,9 @@ import type {
   KnowledgeManager,
   Taxonomy,
 } from "@agentrail/capabilities";
-import { createKbReadTool } from "@agentrail/capabilities";
+import { createKbReadTool, writeTool } from "@agentrail/capabilities";
 import type { ModelConfig } from "@agentrail/core";
 import { defineAgent, isRuntimeError } from "@agentrail/core";
-import { writeTool } from "@agentrail/capabilities";
 import fs from "node:fs/promises";
 import path from "node:path";
 

--- a/examples/playground-server/src/agents/user-preference-summarizer.ts
+++ b/examples/playground-server/src/agents/user-preference-summarizer.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { config } from "@/config.js";
+import { sessionManager } from "@/context/index.js";
 import type { Message } from "@agentrail/core";
 import { defineAgent, isRuntimeError } from "@agentrail/core";
 import "@agentrail/core/providers";
 import { appendFile, readFile, writeFile } from "node:fs/promises";
-import { config } from "@/config.js";
-import { sessionManager } from "@/context/index.js";
 
 const LAST_SUMMARY_AT_FILE = ".last_preference_summary_at";
 const COOLDOWN_MS = (config.userPreferenceSummary.cooldownHours || 24) * 60 * 60 * 1000;

--- a/examples/playground-server/src/chat/deep-research.ts
+++ b/examples/playground-server/src/chat/deep-research.ts
@@ -3,18 +3,15 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { config } from "@/config.js";
+import type { AgentrailChatHandledResponse, AgentrailResolvedChatContext } from "@agentrail/app";
+import type { AgentrailResolvedStreamContext } from "@agentrail/app/advanced";
+import type { Message, Usage } from "@agentrail/core";
 import {
   runDeepResearchBlocking,
   runDeepResearchStreaming,
   type DeepResearchStreamingRunInput,
 } from "@agentrail/deep-research";
-import type {
-  AgentrailChatHandledResponse,
-  AgentrailResolvedChatContext,
-} from "@agentrail/app";
-import type { AgentrailResolvedStreamContext } from "@agentrail/app/advanced";
-import type { Message, Usage } from "@agentrail/core";
-import { config } from "@/config.js";
 
 function buildDeepResearchRuntime() {
   return {

--- a/examples/playground-server/src/commands/handlers/compact.ts
+++ b/examples/playground-server/src/commands/handlers/compact.ts
@@ -3,13 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type {
-  ParsedSlashCommand,
-  SlashCommandContext,
-  SlashCommandResult,
-} from "@agentrail/app";
 import { buildSummarizeFn } from "@/agents/summarizer.js";
 import { sandboxManager, sessionManager } from "@/context/index.js";
+import type { ParsedSlashCommand, SlashCommandContext, SlashCommandResult } from "@agentrail/app";
 
 export async function handleCompactCommand(
   parsed: ParsedSlashCommand,

--- a/examples/playground-server/src/commands/handlers/memory-consolidate.ts
+++ b/examples/playground-server/src/commands/handlers/memory-consolidate.ts
@@ -3,12 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type {
-  ParsedSlashCommand,
-  SlashCommandContext,
-  SlashCommandResult,
-} from "@agentrail/app";
 import { userMemoryConsolidationService } from "@/context/index.js";
+import type { ParsedSlashCommand, SlashCommandContext, SlashCommandResult } from "@agentrail/app";
 
 export async function handleMemoryConsolidateCommand(
   parsed: ParsedSlashCommand,

--- a/examples/playground-server/src/commands/registry.ts
+++ b/examples/playground-server/src/commands/registry.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { handleCompactCommand } from "@/commands/handlers/compact.js";
+import { handleMemoryConsolidateCommand } from "@/commands/handlers/memory-consolidate.js";
 import {
   createSlashCommandRegistry,
   type ParsedSlashCommand,
@@ -10,8 +12,6 @@ import {
   type SlashCommandDefinition,
   type SlashCommandResult,
 } from "@agentrail/app";
-import { handleCompactCommand } from "@/commands/handlers/compact.js";
-import { handleMemoryConsolidateCommand } from "@/commands/handlers/memory-consolidate.js";
 
 const commandDefinitions: SlashCommandDefinition[] = [
   {

--- a/examples/playground-server/src/context/index.ts
+++ b/examples/playground-server/src/context/index.ts
@@ -3,11 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { SessionManager, compactToolResults } from "@agentrail/app";
+import { config } from "@/config.js";
+import { SessionManager, UserMemoryConsolidationService, compactToolResults } from "@agentrail/app";
 import { createOrchestrationRegistry } from "@agentrail/app/advanced";
 import { KnowledgeManager, SandboxManager, SkillManager } from "@agentrail/capabilities";
-import { UserMemoryConsolidationService } from "@agentrail/app";
-import { config } from "@/config.js";
 
 // Module-level singletons — one instance per process, shared across all
 // request handlers. State is per-tenant/session, not per-instance.
@@ -35,7 +34,9 @@ export const orchestrationRegistry = createOrchestrationRegistry({
 });
 
 /** @deprecated Use orchestrationRegistry.getManager() directly */
-export function getOrchestrationManager(request: Parameters<typeof orchestrationRegistry.getManager>[0]) {
+export function getOrchestrationManager(
+  request: Parameters<typeof orchestrationRegistry.getManager>[0],
+) {
   return orchestrationRegistry.getManager(request);
 }
 
@@ -46,11 +47,7 @@ export function invalidateOrchestrationManager(tenantId: string, sessionId: stri
 // Context-building helpers (legacy helpers kept for compatibility with other
 // parts of the server; the default profile now uses self-contained builders).
 
-export function buildMemoryIndex(
-  tenantId: string,
-  userId: string,
-  sessionId: string,
-) {
+export function buildMemoryIndex(tenantId: string, userId: string, sessionId: string) {
   return () => sessionManager.buildMemoryIndex(tenantId, userId, sessionId);
 }
 
@@ -60,7 +57,8 @@ export async function listKnowledgeMetadatas(tenantId: string) {
 }
 
 export const listSkills = () => skillManager.listSkills();
-export const listWorkspaceSnapshot = (sessionId: string) => () => sandboxManager.listWorkspace(sessionId);
+export const listWorkspaceSnapshot = (sessionId: string) => () =>
+  sandboxManager.listWorkspace(sessionId);
 export const compactMessages = (
   messages: Parameters<typeof compactToolResults>[0],
   ctx?: { sessionDir?: string },

--- a/examples/playground-server/src/main.ts
+++ b/examples/playground-server/src/main.ts
@@ -6,11 +6,6 @@
 // Register built-in LLM providers (Anthropic, OpenAI) as side effects
 import "@agentrail/core/providers";
 
-import { runPluginLifecycle, type PluginErrorHandler } from "@agentrail/app";
-import { createInspectorRoute } from "@agentrail/app/advanced";
-import { serve } from "@hono/node-server";
-import { Hono } from "hono";
-import { logger } from "hono/logger";
 import { config } from "@/config.js";
 import { sandboxManager } from "@/context/index.js";
 import { playgroundPlugins } from "@/plugins/index.js";
@@ -23,6 +18,11 @@ import { orchestration } from "@/routes/orchestration.js";
 import { sessions } from "@/routes/sessions.js";
 import { stream } from "@/routes/stream.js";
 import { trace } from "@/routes/trace.js";
+import { runPluginLifecycle, type PluginErrorHandler } from "@agentrail/app";
+import { createInspectorRoute } from "@agentrail/app/advanced";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { logger } from "hono/logger";
 
 const app = new Hono();
 

--- a/examples/playground-server/src/plugins/index.ts
+++ b/examples/playground-server/src/plugins/index.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createUserMemoryPlugin } from "@agentrail/app";
 import { userMemoryConsolidationService } from "@/context/index.js";
 import { createAttachmentHintsPlugin } from "@/plugins/attachment-hints.js";
 import { createSlashCommandsPlugin } from "@/plugins/slash-commands.js";
+import { createUserMemoryPlugin } from "@agentrail/app";
 
 export const playgroundPlugins = [
   createUserMemoryPlugin(userMemoryConsolidationService),

--- a/examples/playground-server/src/plugins/slash-commands.ts
+++ b/examples/playground-server/src/plugins/slash-commands.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { AgentrailPlugin } from "@agentrail/app";
 import { executeSlashCommand, parseRegisteredSlashCommand } from "@/commands/registry.js";
+import type { AgentrailPlugin } from "@agentrail/app";
 
 export function createSlashCommandsPlugin(): AgentrailPlugin {
   return {

--- a/examples/playground-server/src/profiles/default-profile.ts
+++ b/examples/playground-server/src/profiles/default-profile.ts
@@ -3,6 +3,17 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { getWorkerPath } from "@/agents/worker-path.js";
+import { config } from "@/config.js";
+import {
+  knowledgeManager,
+  orchestrationRegistry,
+  sandboxManager,
+  sessionManager,
+  skillManager,
+} from "@/context/index.js";
+import { buildSystemPrompt } from "@/prompts/index.js";
+import { waitHandleRegistry } from "@/wait-handle-registry.js";
 import { compactToolResults, createStaticProfileResolver, defineProfile } from "@agentrail/app";
 import {
   askUser,
@@ -14,17 +25,6 @@ import {
   orchestration,
   skills,
 } from "@agentrail/capabilities";
-import { config } from "@/config.js";
-import {
-  knowledgeManager,
-  orchestrationRegistry,
-  sandboxManager,
-  sessionManager,
-  skillManager,
-} from "@/context/index.js";
-import { waitHandleRegistry } from "@/wait-handle-registry.js";
-import { buildSystemPrompt } from "@/prompts/index.js";
-import { getWorkerPath } from "@/agents/worker-path.js";
 
 export const DEFAULT_HOSTED_AGENT_ID = "agentrail-default-agent";
 
@@ -67,8 +67,7 @@ export const defaultProfile = defineProfile({
         },
         listSkills: () => skillManager.listSkills(),
         listWorkspaceSnapshot: (ctx) => sandboxManager.listWorkspace(ctx.sessionId),
-        compactMessages: (msgs, ctx) =>
-          compactToolResults(msgs, { sessionDir: ctx?.sessionDir }),
+        compactMessages: (msgs, ctx) => compactToolResults(msgs, { sessionDir: ctx?.sessionDir }),
         delegateSkillsToSubAgent: config.skillDelegateToSubAgent,
       },
       { cacheTtlMs: 5_000 },

--- a/examples/playground-server/src/routes/chat.ts
+++ b/examples/playground-server/src/routes/chat.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createChatRoute } from "@agentrail/app/advanced";
 import { DEFAULT_AGENT_ID } from "@/agents/index.js";
 import { buildSummarizeFn } from "@/agents/summarizer.js";
 import { handlePlaygroundDeepResearchMode } from "@/chat/deep-research.js";
@@ -11,6 +10,7 @@ import { config } from "@/config.js";
 import { sessionManager } from "@/context/index.js";
 import { playgroundPlugins } from "@/plugins/index.js";
 import { resolvePlaygroundProfile } from "@/profiles/default-profile.js";
+import { createChatRoute } from "@agentrail/app/advanced";
 
 const summarize = buildSummarizeFn();
 

--- a/examples/playground-server/src/routes/commands.ts
+++ b/examples/playground-server/src/routes/commands.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createCommandsRoute, createSlashCommandRegistry } from "@agentrail/app";
 import { getSlashCommandDefinitions } from "@/commands/registry.js";
+import { createCommandsRoute, createSlashCommandRegistry } from "@agentrail/app";
 
 const commands = createCommandsRoute(createSlashCommandRegistry(getSlashCommandDefinitions()));
 

--- a/examples/playground-server/src/routes/deep-research.ts
+++ b/examples/playground-server/src/routes/deep-research.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createDeepResearchRoute } from "@agentrail/deep-research";
 import { config } from "@/config.js";
+import { createDeepResearchRoute } from "@agentrail/deep-research";
 
 const deepResearch = createDeepResearchRoute({
   dataDir: config.dataDir,

--- a/examples/playground-server/src/routes/knowledge.ts
+++ b/examples/playground-server/src/routes/knowledge.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { runIngestionAgent } from "@/agents/ingestion-agent.js";
+import { config } from "@/config.js";
 import type { IngestionEvent } from "@agentrail/capabilities";
 import { KnowledgeManager } from "@agentrail/capabilities";
 import { Hono } from "hono";
 import { streamText } from "hono/streaming";
-import { runIngestionAgent } from "@/agents/ingestion-agent.js";
-import { config } from "@/config.js";
 
 const km = new KnowledgeManager(config.dataDir);
 

--- a/examples/playground-server/src/routes/orchestration.ts
+++ b/examples/playground-server/src/routes/orchestration.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createSessionRef } from "@agentrail/core";
+import { config } from "@/config.js";
 import type { OrchestrationAgent, OrchestrationEvent } from "@agentrail/capabilities";
 import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
+import { createSessionRef } from "@agentrail/core";
 import { Hono } from "hono";
-import { config } from "@/config.js";
 
 const orchestration = new Hono();
 

--- a/examples/playground-server/src/routes/sessions.ts
+++ b/examples/playground-server/src/routes/sessions.ts
@@ -3,14 +3,14 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { config } from "@/config.js";
+import { invalidateOrchestrationManager, sandboxManager } from "@/context/index.js";
+import { waitHandleRegistry } from "@/wait-handle-registry.js";
 import { isCompactionMessage, parseCompactionMetadata, SessionManager } from "@agentrail/app";
 import type { Message } from "@agentrail/core";
 import { Hono } from "hono";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
-import { config } from "@/config.js";
-import { invalidateOrchestrationManager, sandboxManager } from "@/context/index.js";
-import { waitHandleRegistry } from "@/wait-handle-registry.js";
 
 const sessionManager = new SessionManager(config.dataDir);
 

--- a/examples/playground-server/src/routes/stream.ts
+++ b/examples/playground-server/src/routes/stream.ts
@@ -3,20 +3,16 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { WorkflowTraceEventEnvelope } from "@agentrail/app";
-import { createFileSystemSessionTraceStore } from "@agentrail/app";
-import { createStreamRoute } from "@agentrail/app/advanced";
 import { DEFAULT_AGENT_ID } from "@/agents/index.js";
 import { buildSummarizeFn } from "@/agents/summarizer.js";
 import { handlePlaygroundDeepResearchModeStream } from "@/chat/deep-research.js";
 import { config } from "@/config.js";
-import {
-  orchestrationRegistry,
-  sandboxManager,
-  sessionManager,
-} from "@/context/index.js";
+import { orchestrationRegistry, sandboxManager, sessionManager } from "@/context/index.js";
 import { playgroundPlugins } from "@/plugins/index.js";
 import { resolvePlaygroundProfile } from "@/profiles/default-profile.js";
+import type { WorkflowTraceEventEnvelope } from "@agentrail/app";
+import { createFileSystemSessionTraceStore } from "@agentrail/app";
+import { createStreamRoute } from "@agentrail/app/advanced";
 
 const summarize = buildSummarizeFn();
 

--- a/examples/playground-server/src/routes/trace.ts
+++ b/examples/playground-server/src/routes/trace.ts
@@ -3,12 +3,15 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { mapOrchestrationEvent, type WorkflowTraceEventEnvelope } from "@agentrail/app";
-import { createFileSystemSessionTraceStore } from "@agentrail/app";
-import { createSessionRef } from "@agentrail/core";
-import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
-import { Hono } from "hono";
 import { config } from "@/config.js";
+import {
+  createFileSystemSessionTraceStore,
+  mapOrchestrationEvent,
+  type WorkflowTraceEventEnvelope,
+} from "@agentrail/app";
+import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
+import { createSessionRef } from "@agentrail/core";
+import { Hono } from "hono";
 
 const trace = new Hono();
 

--- a/examples/playground-server/test/deep-research-route.test.ts
+++ b/examples/playground-server/test/deep-research-route.test.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { createSessionRef } from "@agentrail/core";
 import {
   createFileSystemDeepResearchStore,
   type DeepResearchState,
 } from "@agentrail/deep-research";
-import { createSessionRef } from "@agentrail/core";
 import { Hono } from "hono";
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";

--- a/examples/playground-server/test/deep-research-stream-handler.test.ts
+++ b/examples/playground-server/test/deep-research-stream-handler.test.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createSessionRef } from "@agentrail/core";
 import type { Message, Usage } from "@agentrail/core";
+import { createSessionRef } from "@agentrail/core";
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/examples/playground-server/test/default-subagent-process.test.ts
+++ b/examples/playground-server/test/default-subagent-process.test.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createSessionRef } from "@agentrail/core";
 import type {
   AgentInputEnvelope,
   CreateManagedAgentInput,
@@ -16,6 +15,7 @@ import {
   resolveWorkerCwd,
   resolveWorkerExecArgv,
 } from "@agentrail/capabilities/orchestration/worker";
+import { createSessionRef } from "@agentrail/core";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";

--- a/examples/playground-server/test/default-subagent-worker.test.ts
+++ b/examples/playground-server/test/default-subagent-worker.test.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createSessionRef } from "@agentrail/core";
 import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
+import { createSessionRef } from "@agentrail/core";
 import assert from "node:assert/strict";
 import { fork } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";

--- a/examples/playground-server/test/orchestration-route.test.ts
+++ b/examples/playground-server/test/orchestration-route.test.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createSessionRef } from "@agentrail/core";
 import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
+import { createSessionRef } from "@agentrail/core";
 import { Hono } from "hono";
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";

--- a/examples/playground-server/test/trace-route.test.ts
+++ b/examples/playground-server/test/trace-route.test.ts
@@ -5,8 +5,8 @@
 
 import type { WorkflowTraceEventEnvelope } from "@agentrail/app";
 import { createFileSystemSessionTraceStore } from "@agentrail/app";
-import { createSessionRef } from "@agentrail/core";
 import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
+import { createSessionRef } from "@agentrail/core";
 import { Hono } from "hono";
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";

--- a/examples/playground-ui/src/App.tsx
+++ b/examples/playground-ui/src/App.tsx
@@ -141,10 +141,7 @@ export default function App() {
   const skipHistoryLoadRef = useRef(false);
 
   const { sessions, upsert, remove } = useSessions();
-  const {
-    feedEvent: feedTraceEvent,
-    clearTrace,
-  } = useWorkflowTrace(currentSessionId);
+  const { feedEvent: feedTraceEvent, clearTrace } = useWorkflowTrace(currentSessionId);
   const {
     state: orchestrationState,
     isLoading: orchestrationLoading,

--- a/examples/playground-ui/src/components/AgentTracePanel.tsx
+++ b/examples/playground-ui/src/components/AgentTracePanel.tsx
@@ -96,7 +96,9 @@ export function AgentTracePanel({ state }: AgentTracePanelProps) {
         <div className="agent-trace-empty">
           <div className="agent-trace-empty-icon">📋</div>
           <p>No events recorded</p>
-          <p className="agent-trace-empty-hint">Orchestration events will appear here as detailed logs.</p>
+          <p className="agent-trace-empty-hint">
+            Orchestration events will appear here as detailed logs.
+          </p>
         </div>
       </div>
     );

--- a/examples/playground-ui/src/components/AgentWorkspace.tsx
+++ b/examples/playground-ui/src/components/AgentWorkspace.tsx
@@ -23,12 +23,7 @@ import { WorkspaceEmptyState } from "./WorkspaceEmptyState";
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type WorkspaceTab =
-  | "activity"
-  | "workspace"
-  | "browser"
-  | "agent_team"
-  | "deep_research";
+export type WorkspaceTab = "activity" | "workspace" | "browser" | "agent_team" | "deep_research";
 
 interface ActiveFileView {
   path: string;
@@ -60,7 +55,8 @@ function humanizeAction(toolName: string, args: unknown): string {
     case "Bash": {
       const cmd = String(a.command ?? "");
       if (cmd.includes("run_pipeline.sh")) return "Query database";
-      if (cmd.includes("pip install") || cmd.includes("pip3 install")) return "Install dependencies";
+      if (cmd.includes("pip install") || cmd.includes("pip3 install"))
+        return "Install dependencies";
       if (cmd.includes("python") || cmd.includes("python3")) return "Run script";
       if (cmd.includes("npm") || cmd.includes("pnpm")) return "Run build command";
       if (cmd.includes("git")) return "Run git operation";
@@ -843,7 +839,11 @@ function WorkspaceFilesTab({ sessionId, turns }: { sessionId?: string; turns: Tu
       <div className="ws-file-tree">
         <div className="ws-tree-header">
           <span className="ws-tree-title">/workspace</span>
-          <button className="ws-tree-refresh" onClick={() => fetchFiles()} title="Refresh file list">
+          <button
+            className="ws-tree-refresh"
+            onClick={() => fetchFiles()}
+            title="Refresh file list"
+          >
             {loading ? "⟳" : "↻"}
           </button>
         </div>

--- a/examples/playground-ui/src/components/DeepResearchPanel.tsx
+++ b/examples/playground-ui/src/components/DeepResearchPanel.tsx
@@ -662,7 +662,10 @@ export function DeepResearchPanel({ state, isLoading, sessionId }: Props) {
             </div>
             <div className="deep-research-entity-row">
               <span className="deep-research-stat-pill">
-                Mode: {entityProfile.mode === "entity_disambiguation" ? "Entity Disambiguation" : "Topic Scope"}
+                Mode:{" "}
+                {entityProfile.mode === "entity_disambiguation"
+                  ? "Entity Disambiguation"
+                  : "Topic Scope"}
               </span>
               {state.entityProfile?.confidence && (
                 <span className="deep-research-stat-pill">
@@ -670,7 +673,9 @@ export function DeepResearchPanel({ state, isLoading, sessionId }: Props) {
                 </span>
               )}
               {state.entityProfile?.source && (
-                <span className="deep-research-stat-pill">Source: {state.entityProfile?.source}</span>
+                <span className="deep-research-stat-pill">
+                  Source: {state.entityProfile?.source}
+                </span>
               )}
             </div>
             <TagGroup title="Aliases" items={entityProfile.aliases} />
@@ -791,7 +796,11 @@ export function DeepResearchPanel({ state, isLoading, sessionId }: Props) {
       <section className="deep-research-card">
         <h4>Sources</h4>
         <div className="deep-research-source-groups">
-          <SourceSection title="Primary Sources" sources={primarySources} emptyText="No primary sources yet." />
+          <SourceSection
+            title="Primary Sources"
+            sources={primarySources}
+            emptyText="No primary sources yet."
+          />
           <SourceSection
             title="Supporting Sources"
             sources={supportingSources}
@@ -813,9 +822,13 @@ export function DeepResearchPanel({ state, isLoading, sessionId }: Props) {
         <div className="deep-research-artifacts-layout">
           <div className="deep-research-artifact-list">
             <div className="deep-research-artifact-list-header">
-              <span className="deep-research-artifact-count">{state.artifacts.length} artifacts</span>
+              <span className="deep-research-artifact-count">
+                {state.artifacts.length} artifacts
+              </span>
               {selectedArtifact && (
-                <span className="deep-research-artifact-count">Current: {selectedArtifact.title}</span>
+                <span className="deep-research-artifact-count">
+                  Current: {selectedArtifact.title}
+                </span>
               )}
             </div>
             {state.artifacts.map((artifact) => (

--- a/examples/playground-ui/src/components/DeepResearchRunCard.tsx
+++ b/examples/playground-ui/src/components/DeepResearchRunCard.tsx
@@ -50,7 +50,9 @@ export function DeepResearchRunCard({ state, derived, onOpenPanel }: Props) {
         <button
           className={`deep-research-inline-toggle ${expanded ? "expanded" : ""}`}
           onClick={() => setExpanded((value) => !value)}
-          aria-label={expanded ? "Collapse deep research progress" : "Expand deep research progress"}
+          aria-label={
+            expanded ? "Collapse deep research progress" : "Expand deep research progress"
+          }
         >
           <span className="deep-research-inline-chevron">›</span>
         </button>
@@ -90,7 +92,7 @@ export function DeepResearchRunCard({ state, derived, onOpenPanel }: Props) {
       {expanded && (
         <div className="deep-research-inline-body">
           <div className="deep-research-inline-section">
-              <div className="deep-research-inline-section-title">Plan</div>
+            <div className="deep-research-inline-section-title">Plan</div>
             <div className="deep-research-inline-steps">
               {state.steps.map((step) => (
                 <div key={step.id} className={`deep-research-inline-step ${step.status}`}>
@@ -146,7 +148,9 @@ export function DeepResearchRunCard({ state, derived, onOpenPanel }: Props) {
                   {derived.excludedSources.slice(0, 3).map((source) => (
                     <div key={source.id} className="deep-research-inline-excluded-item">
                       <span>{source.title}</span>
-                      <span>{source.excludeReason ?? source.note ?? "Duplicate or low-relevance source"}</span>
+                      <span>
+                        {source.excludeReason ?? source.note ?? "Duplicate or low-relevance source"}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/examples/playground-ui/src/components/InputBar.tsx
+++ b/examples/playground-ui/src/components/InputBar.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SlashCommandMeta } from "../api";
 
 interface Particle {
   x: number;
@@ -14,7 +15,6 @@ interface Particle {
   life: number;
   maxLife: number;
 }
-import type { SlashCommandMeta } from "../api";
 
 export interface PendingAttachment {
   name: string;

--- a/examples/playground-ui/src/components/KnowledgePanel.tsx
+++ b/examples/playground-ui/src/components/KnowledgePanel.tsx
@@ -85,7 +85,8 @@ function KBSelector({ onSelect }: KBSelectorProps) {
 
   const handleDelete = async (id: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!confirm(`Delete knowledge base "${id}" and all its documents? This cannot be undone.`)) return;
+    if (!confirm(`Delete knowledge base "${id}" and all its documents? This cannot be undone.`))
+      return;
     setDeletingKb(id);
     try {
       await deleteKB(id);

--- a/examples/playground-ui/src/components/OnboardingTour.tsx
+++ b/examples/playground-ui/src/components/OnboardingTour.tsx
@@ -32,7 +32,8 @@ const STEPS: TourStep[] = [
   {
     selector: ".clear-btn",
     title: "New Chat",
-    description: "Click the New button to quickly start a fresh conversation. Your current session stays in the left sidebar.",
+    description:
+      "Click the New button to quickly start a fresh conversation. Your current session stays in the left sidebar.",
     placement: "bottom",
   },
   {

--- a/examples/playground-ui/src/components/SettingsModal.tsx
+++ b/examples/playground-ui/src/components/SettingsModal.tsx
@@ -55,7 +55,9 @@ export function SettingsModal({ initialTenantId, initialUserId, onSave, onCancel
             </svg>
           </div>
           <div>
-            <div className="settings-title">{isSetup ? "Welcome to Agentrail" : "Identity Settings"}</div>
+            <div className="settings-title">
+              {isSetup ? "Welcome to Agentrail" : "Identity Settings"}
+            </div>
             <div className="settings-subtitle">
               {isSetup
                 ? "Enter your Tenant ID and User ID to get started"

--- a/examples/playground-ui/src/components/WaitingQuestionPrompt.tsx
+++ b/examples/playground-ui/src/components/WaitingQuestionPrompt.tsx
@@ -82,7 +82,9 @@ export function WaitingQuestionPrompt({
           <p className="waiting-question-label">{question}</p>
           {hint && !hasOptions && <p className="waiting-question-hint">{hint}</p>}
           {multiple && hasOptions && (
-            <p className="waiting-question-hint">Multiple selections allowed — click Confirm when done</p>
+            <p className="waiting-question-hint">
+              Multiple selections allowed — click Confirm when done
+            </p>
           )}
         </div>
       </div>

--- a/examples/playground-ui/src/index.css
+++ b/examples/playground-ui/src/index.css
@@ -131,8 +131,7 @@ body {
   font-family: var(--font);
   background:
     radial-gradient(circle at top left, rgba(196, 255, 46, 0.025), transparent 28%),
-    radial-gradient(circle at right top, rgba(255, 255, 255, 0.025), transparent 24%),
-    var(--bg);
+    radial-gradient(circle at right top, rgba(255, 255, 255, 0.025), transparent 24%), var(--bg);
   color: var(--text);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -1032,8 +1031,7 @@ body {
 
 .input-bar.deep-research-mode {
   border-top-color: rgba(14, 165, 233, 0.18);
-  background:
-    linear-gradient(180deg, rgba(14, 165, 233, 0.06), transparent), var(--surface);
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.06), transparent), var(--surface);
   box-shadow: inset 0 1px 0 rgba(14, 165, 233, 0.08);
 }
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -51,6 +51,7 @@ export default app;
 - `loadAgentrailConfig()` — load and validate `agentrail.yaml`.
 
 Reference:
+
 - `https://agentrail.run/reference/create-agent-app`
 - `https://agentrail.run/reference/profile-contract`
 - `https://agentrail.run/reference/host-primitives`

--- a/packages/app/src/app/create-agent-app.ts
+++ b/packages/app/src/app/create-agent-app.ts
@@ -3,24 +3,23 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Message, SessionRef } from "@agentrail/core";
-import type { AgentrailSessionStore } from "@agentrail/core";
-import type { SandboxManager } from "@agentrail/capabilities";
-import type { ReactiveCompactionConfig, SummarizeMessagesFn } from "@/host/reactive-compaction.js";
-import type { AgentrailPlugin, ContextProvider, PluginErrorHandler } from "@/host/types.js";
-import type { AgentrailOrchestrationRegistry } from "@/host/orchestration-registry.js";
-import type { ProfileDefinition } from "@/profile/define-profile.js";
-import type { ProfileResolver } from "@/host/profile-registry.js";
-import type { TelemetrySink } from "@/telemetry/sink.js";
+import { runCapabilityCompatibilityChecks } from "@/compat/capability-check.js";
 import type { WorkflowTraceEventEnvelope } from "@/events/index.js";
 import type { ReadinessCheck } from "@/health/index.js";
 import { createHealthRoute } from "@/health/index.js";
+import type { AgentrailOrchestrationRegistry } from "@/host/orchestration-registry.js";
+import type { ProfileResolver } from "@/host/profile-registry.js";
+import { createStaticProfileResolver } from "@/host/profile-registry.js";
+import type { ReactiveCompactionConfig, SummarizeMessagesFn } from "@/host/reactive-compaction.js";
+import type { AgentrailPlugin, ContextProvider, PluginErrorHandler } from "@/host/types.js";
 import { createInspectorRoute } from "@/inspector/index.js";
-import { runCapabilityCompatibilityChecks } from "@/compat/capability-check.js";
-import { SessionManager } from "@/session/session-manager.js";
+import type { ProfileDefinition } from "@/profile/define-profile.js";
 import { createChatRoute } from "@/routes/chat-route.js";
 import { createStreamRoute } from "@/routes/stream-route.js";
-import { createStaticProfileResolver } from "@/host/profile-registry.js";
+import { SessionManager } from "@/session/session-manager.js";
+import type { TelemetrySink } from "@/telemetry/sink.js";
+import type { SandboxManager } from "@agentrail/capabilities";
+import type { AgentrailSessionStore, Message, SessionRef } from "@agentrail/core";
 import { Hono } from "hono";
 
 /**
@@ -271,27 +270,21 @@ export function createAgentApp(options: CreateAgentAppOptions): Hono {
     : undefined;
 
   if (profiles.length === 0 && !customResolver) {
-    throw new Error(
-      "createAgentApp: at least one of `profiles` or `resolveProfile` is required.",
-    );
+    throw new Error("createAgentApp: at least one of `profiles` or `resolveProfile` is required.");
   }
 
   // Resolve the session store: prefer explicit override, fall back to filesystem.
   const sessionStore: AgentrailSessionStore = (() => {
     if (options.sessionStore) return options.sessionStore;
     if (!dataDir) {
-      throw new Error(
-        "createAgentApp: `dataDir` is required when `sessionStore` is not provided.",
-      );
+      throw new Error("createAgentApp: `dataDir` is required when `sessionStore` is not provided.");
     }
     return new SessionManager(dataDir);
   })();
 
   const defaultAgentId = explicitDefaultAgentId ?? profiles[0]?.id;
   if (!defaultAgentId) {
-    throw new Error(
-      "createAgentApp: `defaultAgentId` is required when `profiles` is empty.",
-    );
+    throw new Error("createAgentApp: `defaultAgentId` is required when `profiles` is empty.");
   }
 
   // Build the static resolver from the profiles array (used when no custom resolver given).

--- a/packages/app/src/commands/route.ts
+++ b/packages/app/src/commands/route.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { Hono } from "hono";
 import type { SlashCommandRegistry } from "@/commands/registry.js";
+import { Hono } from "hono";
 
 interface CommandRequest {
   command: string;

--- a/packages/app/src/compat.ts
+++ b/packages/app/src/compat.ts
@@ -11,23 +11,14 @@
  */
 
 /** @deprecated Use `defineProfile()` from `@agentrail/app` instead. */
-export { defineHostedProfile, createHostedProfileResolver } from "@/host/defaults/profile.js";
+export { createHostedProfileResolver, defineHostedProfile } from "@/host/defaults/profile.js";
 export type { HostedProfileDefinition } from "@/host/defaults/shared-types.js";
 
 /** @deprecated Capability wiring is handled automatically by `defineProfile()`. */
-export { buildDefaultCapabilityTools } from "@/host/defaults/capability-tools.js";
 export {
   createDefaultCapabilityContextProviders,
   createDefaultCapabilityTransformContext,
 } from "@/host/defaults/capability-context.js";
-export { createDefaultContextProviders, createDefaultToolset } from "@/host/defaults/toolset.js";
-export type {
-  DefaultCapabilityContextOptions,
-  DefaultCapabilityToolOptions,
-  DefaultCapabilityTools,
-  DefaultContextProvidersInput,
-  DefaultToolsetInput,
-} from "@/host/defaults/shared-types.js";
 export {
   makeDateContextMessage,
   makeKnowledgeContextMessage,
@@ -36,3 +27,12 @@ export {
   makeUserIdentityMessage,
   translateMemoryPaths,
 } from "@/host/defaults/capability-messages.js";
+export { buildDefaultCapabilityTools } from "@/host/defaults/capability-tools.js";
+export type {
+  DefaultCapabilityContextOptions,
+  DefaultCapabilityToolOptions,
+  DefaultCapabilityTools,
+  DefaultContextProvidersInput,
+  DefaultToolsetInput,
+} from "@/host/defaults/shared-types.js";
+export { createDefaultContextProviders, createDefaultToolset } from "@/host/defaults/toolset.js";

--- a/packages/app/src/compat/capability-check.ts
+++ b/packages/app/src/compat/capability-check.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityDescriptor } from "@agentrail/capabilities";
 import type { ProfileDefinition } from "@/profile/define-profile.js";
+import type { CapabilityDescriptor } from "@agentrail/capabilities";
 
 // ─── Environment detection ────────────────────────────────────────────────────
 
@@ -43,11 +43,7 @@ const SANDBOX_REQUIRED_TYPES = new Set(["filesystem", "browser"]);
  * They are fundamentally incompatible with stateless serverless environments
  * where each invocation starts a fresh process.
  */
-const SERVERLESS_INCOMPATIBLE_TYPES = new Set([
-  "filesystem",
-  "browser",
-  "orchestration",
-]);
+const SERVERLESS_INCOMPATIBLE_TYPES = new Set(["filesystem", "browser", "orchestration"]);
 
 /**
  * Capability types that degrade in serverless environments but may still work

--- a/packages/app/src/config/index.ts
+++ b/packages/app/src/config/index.ts
@@ -373,7 +373,11 @@ export function parseAgentrailConfig(raw: unknown): AgentrailConfig {
   assertNoUnknownKeys(llm, ["provider", "modelId", "baseUrl"], ["llm"]);
 
   const search = getObject(root, "search", [], DEFAULT_AGENTRAIL_CONFIG.search as UnknownRecord);
-  assertNoUnknownKeys(search, ["provider", "tavilyApiKey", "braveApiKey", "jinaApiKey"], ["search"]);
+  assertNoUnknownKeys(
+    search,
+    ["provider", "tavilyApiKey", "braveApiKey", "jinaApiKey"],
+    ["search"],
+  );
 
   const pathsValue = getObject(root, "paths", [], DEFAULT_AGENTRAIL_CONFIG.paths as UnknownRecord);
   assertNoUnknownKeys(pathsValue, ["dataDir"], ["paths"]);

--- a/packages/app/src/events/index.ts
+++ b/packages/app/src/events/index.ts
@@ -3,10 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { randomUUID } from "node:crypto";
-import type { OrchestrationEvent } from "@agentrail/capabilities";
+import type { ExtendedSseEvent, OrchestrationEvent } from "@agentrail/capabilities";
 import type { RuntimeEvent } from "@agentrail/core";
-import type { ExtendedSseEvent } from "@agentrail/capabilities";
+import { randomUUID } from "node:crypto";
 
 /** Event emitted before chat history compaction starts. */
 export interface AgentrailContextCompactionStartEvent {

--- a/packages/app/src/health/index.ts
+++ b/packages/app/src/health/index.ts
@@ -72,10 +72,7 @@ export function createHealthRoute(
 
   // ── Readiness ─────────────────────────────────────────────────────────────
   route.get("/ready", async (c) => {
-    const allChecks: ReadinessCheck[] = [
-      createSessionStoreCheck(sessionStore),
-      ...extraChecks,
-    ];
+    const allChecks: ReadinessCheck[] = [createSessionStoreCheck(sessionStore), ...extraChecks];
 
     const results = await Promise.all(
       allChecks.map(async (check): Promise<ReadinessCheckResult> => {

--- a/packages/app/src/host/context-pipeline.ts
+++ b/packages/app/src/host/context-pipeline.ts
@@ -8,6 +8,6 @@
 // and avoid any structural type mismatch.
 export {
   composeTransformContexts,
-  createTransformContext,
   createContextProviderFromTransform,
+  createTransformContext,
 } from "@agentrail/capabilities";

--- a/packages/app/src/host/defaults/capability-messages.ts
+++ b/packages/app/src/host/defaults/capability-messages.ts
@@ -3,10 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { KBMetadata } from "@agentrail/capabilities";
-import type { MemoryIndex, MemoryIndexEntry } from "@agentrail/core";
-import type { UserMessage } from "@agentrail/core";
-import type { SkillMeta } from "@agentrail/capabilities";
+import type { KBMetadata, SkillMeta } from "@agentrail/capabilities";
+import type { MemoryIndex, MemoryIndexEntry, UserMessage } from "@agentrail/core";
 
 /** Creates a user-scoped identity hint message for default hosted profiles. */
 export function makeUserIdentityMessage(

--- a/packages/app/src/host/defaults/capability-tools.ts
+++ b/packages/app/src/host/defaults/capability-tools.ts
@@ -3,12 +3,20 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createKbListTool, createKbReadTool, createKbSearchTool } from "@agentrail/capabilities";
+import type {
+  DefaultCapabilityToolOptions,
+  DefaultCapabilityTools,
+} from "@/host/defaults/shared-types.js";
 import {
+  buildSkillTool,
+  createAskUserQuestionTool,
   createBrowserAction,
   createBrowserContent,
   createBrowserNavigate,
   createBrowserScroll,
+  createKbListTool,
+  createKbReadTool,
+  createKbSearchTool,
   createSandboxedBash,
   createSandboxedEdit,
   createSandboxedGlob,
@@ -16,10 +24,8 @@ import {
   createSandboxedRead,
   createSandboxedWrite,
   createSleepTool,
+  createTodoWriteTool,
 } from "@agentrail/capabilities";
-import { buildSkillTool } from "@agentrail/capabilities";
-import { createAskUserQuestionTool, createTodoWriteTool } from "@agentrail/capabilities";
-import type { DefaultCapabilityToolOptions, DefaultCapabilityTools } from "@/host/defaults/shared-types.js";
 
 /**
  * Builds the default capability toolset used by the reference host and examples.

--- a/packages/app/src/host/defaults/profile.ts
+++ b/packages/app/src/host/defaults/profile.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { createProfileResolver } from "@/host/profile-registry.js";
 import type { HostedProfileDefinition } from "@/host/defaults/shared-types.js";
+import { createProfileResolver } from "@/host/profile-registry.js";
 
 /**
  * Defines a hosted profile without changing its runtime behavior.

--- a/packages/app/src/host/defaults/shared-types.ts
+++ b/packages/app/src/host/defaults/shared-types.ts
@@ -3,12 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { KBMetadata, KnowledgeManager } from "@agentrail/capabilities";
-import type { MemoryIndex, SessionRef } from "@agentrail/core";
-import type { Message, ModelConfig, RuntimeTool, UserMessage } from "@agentrail/core";
-import type { SandboxManager } from "@agentrail/capabilities";
-import type { ExtendedSseEvent, SkillManager, SkillMeta } from "@agentrail/capabilities";
-import type { WaitHandleRegistry } from "@agentrail/capabilities";
 import type {
   AgentrailChatHandledResponse,
   AgentrailProfile,
@@ -16,6 +10,23 @@ import type {
   AgentrailSessionStore,
   ContextProvider,
 } from "@/host/types.js";
+import type {
+  ExtendedSseEvent,
+  KBMetadata,
+  KnowledgeManager,
+  SandboxManager,
+  SkillManager,
+  SkillMeta,
+  WaitHandleRegistry,
+} from "@agentrail/capabilities";
+import type {
+  MemoryIndex,
+  Message,
+  ModelConfig,
+  RuntimeTool,
+  SessionRef,
+  UserMessage,
+} from "@agentrail/core";
 
 /**
  * Rich hosted profile definition used by the host defaults helpers.

--- a/packages/app/src/host/defaults/toolset.ts
+++ b/packages/app/src/host/defaults/toolset.ts
@@ -3,9 +3,12 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { RuntimeTool } from "@agentrail/core";
+import type {
+  DefaultContextProvidersInput,
+  DefaultToolsetInput,
+} from "@/host/defaults/shared-types.js";
 import type { ContextProvider } from "@/host/types.js";
-import type { DefaultContextProvidersInput, DefaultToolsetInput } from "@/host/defaults/shared-types.js";
+import type { RuntimeTool } from "@agentrail/core";
 
 /**
  * Merges base and optional context providers into a single ordered list.

--- a/packages/app/src/host/orchestration-registry.ts
+++ b/packages/app/src/host/orchestration-registry.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
 import {
   OrchestrationManager,
   createFilesystemOrchestrationPersistence,
@@ -11,6 +10,7 @@ import {
   type ManagedAgentInstance,
   type StartRunInput,
 } from "@agentrail/capabilities";
+import type { SessionRef } from "@agentrail/core";
 
 /** Factory that creates a managed agent bound to one session. */
 export type CreateSessionManagedAgent = (
@@ -81,9 +81,9 @@ class SessionOrchestrationRegistry implements AgentrailOrchestrationRegistry {
         // The existing factory is kept to avoid re-initialising in-flight agents.
         console.warn(
           `[OrchestrationRegistry] A different createManagedAgent factory was passed for ` +
-          `session "${request.sessionId}" (tenant "${request.tenantId}"). ` +
-          `The original factory will continue to be used for this session. ` +
-          `Call invalidate() first if you intentionally want to replace it.`,
+            `session "${request.sessionId}" (tenant "${request.tenantId}"). ` +
+            `The original factory will continue to be used for this session. ` +
+            `Call invalidate() first if you intentionally want to replace it.`,
         );
       }
     }
@@ -93,8 +93,8 @@ class SessionOrchestrationRegistry implements AgentrailOrchestrationRegistry {
       if (!request.createManagedAgent) {
         throw new Error(
           `[OrchestrationRegistry] Cannot create a manager for session "${request.sessionId}" ` +
-          `without a createManagedAgent factory. The orchestration() capability must be ` +
-          `initialized before the stream route subscribes to events.`,
+            `without a createManagedAgent factory. The orchestration() capability must be ` +
+            `initialized before the stream route subscribes to events.`,
         );
       }
       managerPromise = this.createManager(key, request);
@@ -177,19 +177,18 @@ class SessionOrchestrationRegistry implements AgentrailOrchestrationRegistry {
       );
       if (alreadyRunning) return alreadyRunning.id;
 
-      const input =
-        this.options.createStartRunInput?.(request) ?? {
-          runId: `orchestration:${request.sessionId}`,
-          initialTask: {
-            id: `task:${request.sessionId}:root`,
-            kind: "agentrail-default-orchestration",
-            input: {
-              tenantId: request.tenantId,
-              userId: request.userId,
-              sessionId: request.sessionId,
-            },
+      const input = this.options.createStartRunInput?.(request) ?? {
+        runId: `orchestration:${request.sessionId}`,
+        initialTask: {
+          id: `task:${request.sessionId}:root`,
+          kind: "agentrail-default-orchestration",
+          input: {
+            tenantId: request.tenantId,
+            userId: request.userId,
+            sessionId: request.sessionId,
           },
-        };
+        },
+      };
       await manager.startRun(input);
       return input.runId;
     })().finally(() => {

--- a/packages/app/src/host/plugins.ts
+++ b/packages/app/src/host/plugins.ts
@@ -4,11 +4,6 @@
  */
 
 import type {
-  ToolInterceptor,
-  ToolInterceptorAfterContext,
-  ToolInterceptorBeforeContext,
-} from "@agentrail/core";
-import type {
   AgentrailChatHandledResponse,
   AgentrailChatRequestContext,
   AgentrailPlugin,
@@ -21,6 +16,11 @@ import type {
   PluginErrorContext,
   PluginErrorHandler,
 } from "@/host/types.js";
+import type {
+  ToolInterceptor,
+  ToolInterceptorAfterContext,
+  ToolInterceptorBeforeContext,
+} from "@agentrail/core";
 
 // ============================================================================
 // Internal helpers
@@ -35,10 +35,7 @@ const defaultErrorHandler: PluginErrorHandler = ({ plugin, hook, error }) => {
  * falling back to `console.error`. This ensures the callback can never
  * interfere with the main request flow.
  */
-async function safeNotify(
-  onError: PluginErrorHandler,
-  ctx: PluginErrorContext,
-): Promise<void> {
+async function safeNotify(onError: PluginErrorHandler, ctx: PluginErrorContext): Promise<void> {
   try {
     await onError(ctx);
   } catch (notifyErr) {

--- a/packages/app/src/host/profile-registry.ts
+++ b/packages/app/src/host/profile-registry.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef, AgentrailSessionStore } from "@agentrail/core";
 import type { AgentrailProfile, AgentrailProfileContext } from "@/host/types.js";
 import type { ProfileDefinition } from "@/profile/define-profile.js";
+import type { AgentrailSessionStore, SessionRef } from "@agentrail/core";
 
 /**
  * Formal contract for resolving a profile on a per-request basis.

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -10,12 +10,15 @@ import type {
   Agent,
   AgentrailSessionStore,
   ContextProvider,
-  ContextProviderContext,
   SessionRef,
   TransformContextFn,
   Usage,
 } from "@agentrail/core";
-export type { AgentrailSessionStore, ContextProvider, ContextProviderContext } from "@agentrail/core";
+export type {
+  AgentrailSessionStore,
+  ContextProvider,
+  ContextProviderContext,
+} from "@agentrail/core";
 
 // ============================================================================
 // Plugin error reporting
@@ -92,7 +95,9 @@ export interface AgentrailProfile {
    * `capabilities` via `defineProfile`. Route handlers call this after
    * `createAgent` and merge the result with the static `contextProviders`.
    */
-  getContextProviders?(context: AgentrailProfileContext): Promise<ContextProvider[]> | ContextProvider[];
+  getContextProviders?(
+    context: AgentrailProfileContext,
+  ): Promise<ContextProvider[]> | ContextProvider[];
   /**
    * Returns a request-scoped full-message transform for rewrite-style context logic.
    * This runs before context providers so injected messages see the rewritten history.
@@ -125,7 +130,6 @@ export interface AgentrailChatRequestContext {
   agentId: string;
   signal: AbortSignal;
 }
-
 
 /** Fully resolved context for a chat request after session lookup. */
 export interface AgentrailResolvedChatContext {

--- a/packages/app/src/inspector/index.ts
+++ b/packages/app/src/inspector/index.ts
@@ -3,13 +3,13 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { mapOrchestrationEvent, type WorkflowTraceEventEnvelope } from "@/events/index.js";
+import { createFileSystemSessionTraceStore } from "@/session/trace-store.js";
+import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
+import { createSessionRef } from "@agentrail/core";
+import { Hono } from "hono";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
-import { createSessionRef } from "@agentrail/core";
-import { createFilesystemOrchestrationPersistence } from "@agentrail/capabilities";
-import { Hono } from "hono";
-import { createFileSystemSessionTraceStore } from "@/session/trace-store.js";
-import { mapOrchestrationEvent, type WorkflowTraceEventEnvelope } from "@/events/index.js";
 
 // ─── Session listing ──────────────────────────────────────────────────────────
 
@@ -158,14 +158,7 @@ async function loadSessionMessages(
   tenantId: string,
   sessionId: string,
 ): Promise<unknown[]> {
-  const file = path.join(
-    dataDir,
-    "tenants",
-    tenantId,
-    "sessions",
-    sessionId,
-    "messages.jsonl",
-  );
+  const file = path.join(dataDir, "tenants", tenantId, "sessions", sessionId, "messages.jsonl");
   let raw: string;
   try {
     raw = await readFile(file, "utf8");

--- a/packages/app/src/plugins/user-memory/user-memory-consolidation-service.ts
+++ b/packages/app/src/plugins/user-memory/user-memory-consolidation-service.ts
@@ -559,7 +559,10 @@ export class UserMemoryConsolidationService {
     const existingUserMd = await readFile(userMdPath, "utf8").catch(() => "");
     const existingHistory = extractHistorySection(existingUserMd);
     const trigger = forceRebuild ? "manual" : "idle-auto";
-    await atomicWrite(userMdPath, renderUserMd(profile, sessionSummaries, existingHistory, trigger));
+    await atomicWrite(
+      userMdPath,
+      renderUserMd(profile, sessionSummaries, existingHistory, trigger),
+    );
   }
 
   // --------------------------------------------------------------------------

--- a/packages/app/src/profile/define-profile.ts
+++ b/packages/app/src/profile/define-profile.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Agent, ModelConfig, RuntimeTool, TransformContextFn } from "@agentrail/core";
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@agentrail/capabilities";
 import { composeTransformContexts } from "@/host/context-pipeline.js";
 import type { AgentrailProfile, AgentrailProfileContext } from "@/host/types.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@agentrail/capabilities";
+import type { Agent, ModelConfig, RuntimeTool, TransformContextFn } from "@agentrail/core";
 
 /**
  * The value that a dynamic profile's `createAgent()` may return.
@@ -123,9 +123,7 @@ async function buildCapabilityTransformContext(
   capCtx: CapabilityBuildContext,
 ): Promise<TransformContextFn | undefined> {
   if (!capabilities?.length) return undefined;
-  const transforms = await Promise.all(
-    capabilities.map((c) => c.buildTransformContext?.(capCtx)),
-  );
+  const transforms = await Promise.all(capabilities.map((c) => c.buildTransformContext?.(capCtx)));
   const activeTransforms = transforms.filter((t): t is TransformContextFn => Boolean(t));
   return activeTransforms.length > 0 ? composeTransformContexts(activeTransforms) : undefined;
 }
@@ -159,7 +157,16 @@ async function buildCapabilityTransformContext(
  */
 export function defineProfile(def: StaticProfileShape | DynamicProfileShape): ProfileDefinition {
   if (isStaticShape(def)) {
-    const { model, prompt, tools, maxTurns, maxTokens, temperature, thinkingEnabled, maxTurnsMessage } = def.agent;
+    const {
+      model,
+      prompt,
+      tools,
+      maxTurns,
+      maxTokens,
+      temperature,
+      thinkingEnabled,
+      maxTurnsMessage,
+    } = def.agent;
 
     // Normalise model string to a full ModelConfig once, at definition time.
     const colonIdx = model.indexOf(":");
@@ -183,8 +190,7 @@ export function defineProfile(def: StaticProfileShape | DynamicProfileShape): Pr
         onSubAgentEvent?: (event: object) => void,
       ) {
         const { defineAgent } = await import("@agentrail/core");
-        const system =
-          typeof prompt === "function" ? await prompt(context) : prompt;
+        const system = typeof prompt === "function" ? await prompt(context) : prompt;
 
         let agent = defineAgent({
           id: def.id,
@@ -231,10 +237,7 @@ export function defineProfile(def: StaticProfileShape | DynamicProfileShape): Pr
     name: def.name,
     capabilities: def.capabilities,
 
-    async createAgent(
-      context: AgentrailProfileContext,
-      onSubAgentEvent?: (event: object) => void,
-    ) {
+    async createAgent(context: AgentrailProfileContext, onSubAgentEvent?: (event: object) => void) {
       const raw = await def.createAgent(context, onSubAgentEvent);
       const isWrapped = (r: DynamicAgentResult): r is { agent: Agent; modelConfig?: ModelConfig } =>
         typeof r === "object" && r !== null && "agent" in r;

--- a/packages/app/src/routes/attachment-pipeline.ts
+++ b/packages/app/src/routes/attachment-pipeline.ts
@@ -3,8 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
-import path from "node:path";
 import { runAttachmentHandlers } from "@/host/plugins.js";
 import type {
   AgentrailPlugin,
@@ -13,6 +11,8 @@ import type {
   PluginErrorHandler,
 } from "@/host/types.js";
 import type { AttachmentInput } from "@/routes/stream-request.js";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 /**
  * Persists base64-encoded attachments to the session upload directory and
@@ -72,7 +72,12 @@ export async function buildEffectiveMessage(
     return effectiveMessage;
   }
 
-  const result = await runAttachmentHandlers(uploadedFiles, plugins, fallbackHandler, onPluginError);
+  const result = await runAttachmentHandlers(
+    uploadedFiles,
+    plugins,
+    fallbackHandler,
+    onPluginError,
+  );
 
   if (result?.contextText) {
     effectiveMessage = effectiveMessage

--- a/packages/app/src/routes/chat-route-internals.ts
+++ b/packages/app/src/routes/chat-route-internals.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Context } from "hono";
 import type { AgentrailChatHandledResponse, AgentrailChatRequest } from "@/host/types.js";
+import type { Context } from "hono";
 
 export { resolveTransformContext as resolveChatTransformContext } from "@/routes/context-resolver.js";
 

--- a/packages/app/src/routes/chat-route.ts
+++ b/packages/app/src/routes/chat-route.ts
@@ -3,19 +3,20 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { randomUUID } from "node:crypto";
-import type { SessionRef } from "@agentrail/core";
-import type { Message, TransformContextFn } from "@agentrail/core";
-import { Hono } from "hono";
 import {
-  resolveChatTransformContext,
-  respondHandledJson,
-  validateChatRequest,
-} from "@/routes/chat-route-internals.js";
-import { TRACE_PERSISTED_EVENT_TYPES, wrapTraceEvent, type WorkflowTraceEventEnvelope } from "@/events/index.js";
-import { createReactiveCompactionController, type SummarizeMessagesFn } from "@/host/reactive-compaction.js";
-import { runCompactionStep } from "@/routes/compaction-runner.js";
-import { buildToolInterceptor, runPluginChatRequestInterceptors, runPluginRequestHook } from "@/host/plugins.js";
+  TRACE_PERSISTED_EVENT_TYPES,
+  wrapTraceEvent,
+  type WorkflowTraceEventEnvelope,
+} from "@/events/index.js";
+import {
+  buildToolInterceptor,
+  runPluginChatRequestInterceptors,
+  runPluginRequestHook,
+} from "@/host/plugins.js";
+import {
+  createReactiveCompactionController,
+  type SummarizeMessagesFn,
+} from "@/host/reactive-compaction.js";
 import type {
   AgentrailChatHandledResponse,
   AgentrailChatRequest,
@@ -28,6 +29,15 @@ import type {
   ContextProvider,
   PluginErrorHandler,
 } from "@/host/types.js";
+import {
+  resolveChatTransformContext,
+  respondHandledJson,
+  validateChatRequest,
+} from "@/routes/chat-route-internals.js";
+import { runCompactionStep } from "@/routes/compaction-runner.js";
+import type { SessionRef, TransformContextFn } from "@agentrail/core";
+import { Hono } from "hono";
+import { randomUUID } from "node:crypto";
 
 /**
  * Configuration for the JSON chat route factory.
@@ -166,12 +176,16 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
 
     const signal = c.req.raw.signal;
     const agentId = request.agentId ?? options.defaultAgentId;
-    const prehandled = await runPluginChatRequestInterceptors(plugins, {
-      kind: "chat",
-      request,
-      agentId,
-      signal,
-    }, onPluginError);
+    const prehandled = await runPluginChatRequestInterceptors(
+      plugins,
+      {
+        kind: "chat",
+        request,
+        agentId,
+        signal,
+      },
+      onPluginError,
+    );
     if (prehandled) {
       return respondHandledJson(c, prehandled);
     }
@@ -241,10 +255,9 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
         sessionRef,
         sessionStore: options.sessionStore,
       };
-      const agent = await profile.createAgent(
-        profileCtx,
-        () => { /* sub-agent events are not forwarded on the JSON /chat route */ },
-      );
+      const agent = await profile.createAgent(profileCtx, () => {
+        /* sub-agent events are not forwarded on the JSON /chat route */
+      });
       const capProviders = (await profile.getContextProviders?.(profileCtx)) ?? [];
       const profileTransform = await profile.getTransformContext?.(profileCtx);
       const history = await runCompactionStep(
@@ -294,7 +307,9 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
           {
             type: "error",
             traceId,
-            error: { message: invokeError instanceof Error ? invokeError.message : String(invokeError) },
+            error: {
+              message: invokeError instanceof Error ? invokeError.message : String(invokeError),
+            },
           },
           traceSeq++,
           traceId,

--- a/packages/app/src/routes/compaction-runner.ts
+++ b/packages/app/src/routes/compaction-runner.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Message } from "@agentrail/core";
 import { runCompactionIfNeeded, type CompactionConfig } from "@/host/compaction.js";
 import type { SummarizeMessagesFn } from "@/host/reactive-compaction.js";
 import type { AgentrailSessionStore } from "@/host/types.js";
+import type { Message } from "@agentrail/core";
 
 /**
  * Loads all session messages, runs compaction when thresholds are exceeded,
@@ -28,6 +28,14 @@ export async function runCompactionStep(
   },
 ): Promise<Message[]> {
   const allMessages = await sessionStore.loadAllMessages(tenantId, sessionId);
-  await runCompactionIfNeeded(sessionStore, tenantId, sessionId, allMessages, summarize, compaction, opts);
+  await runCompactionIfNeeded(
+    sessionStore,
+    tenantId,
+    sessionId,
+    allMessages,
+    summarize,
+    compaction,
+    opts,
+  );
   return sessionStore.loadMessagesWithBudget(tenantId, sessionId);
 }

--- a/packages/app/src/routes/context-resolver.ts
+++ b/packages/app/src/routes/context-resolver.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { TransformContextFn } from "@agentrail/core";
 import { composeTransformContexts, createTransformContext } from "@/host/context-pipeline.js";
 import { collectPluginContextProviders } from "@/host/plugins.js";
 import type { AgentrailPlugin, ContextProvider } from "@/host/types.js";
+import type { TransformContextFn } from "@agentrail/core";
 
 interface ResolveTransformContextOptions {
   getTransformContext?: (context: {

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { randomUUID } from "node:crypto";
 import {
   mapOrchestrationEvent,
   TRACE_PERSISTED_EVENT_TYPES,
@@ -12,21 +11,11 @@ import {
   type AgentrailErrorEvent,
   type WorkflowTraceEventEnvelope,
 } from "@/events/index.js";
-import type { SessionRef } from "@agentrail/core";
-import type { OrchestrationManager } from "@agentrail/capabilities";
-import type { Agent, Message, RuntimeEvent, ToolInterceptor, TransformContextFn, Usage } from "@agentrail/core";
-import { isRuntimeError } from "@agentrail/core";
-import type { SandboxManager } from "@agentrail/capabilities";
-import { Hono } from "hono";
-import { streamText } from "hono/streaming";
 import { buildToolInterceptor, runPluginRequestHook } from "@/host/plugins.js";
-import { createReactiveCompactionController, type SummarizeMessagesFn } from "@/host/reactive-compaction.js";
-import { runCompactionStep } from "@/routes/compaction-runner.js";
-import { awaitSandboxWarmup } from "@/routes/sandbox-warmup.js";
-import { persistUploadedFiles, buildEffectiveMessage } from "@/routes/attachment-pipeline.js";
-import { createSseEventWriter } from "@/routes/sse-writer.js";
-import { resolveTransformContext } from "@/routes/context-resolver.js";
-import { validateStreamRequest, type StreamRequest } from "@/routes/stream-request.js";
+import {
+  createReactiveCompactionController,
+  type SummarizeMessagesFn,
+} from "@/host/reactive-compaction.js";
 import type {
   AgentrailPlugin,
   AgentrailProfile,
@@ -38,6 +27,26 @@ import type {
   ContextProvider,
   PluginErrorHandler,
 } from "@/host/types.js";
+import { buildEffectiveMessage, persistUploadedFiles } from "@/routes/attachment-pipeline.js";
+import { runCompactionStep } from "@/routes/compaction-runner.js";
+import { resolveTransformContext } from "@/routes/context-resolver.js";
+import { awaitSandboxWarmup } from "@/routes/sandbox-warmup.js";
+import { createSseEventWriter } from "@/routes/sse-writer.js";
+import { validateStreamRequest, type StreamRequest } from "@/routes/stream-request.js";
+import type { OrchestrationManager, SandboxManager } from "@agentrail/capabilities";
+import type {
+  Agent,
+  Message,
+  RuntimeEvent,
+  SessionRef,
+  ToolInterceptor,
+  TransformContextFn,
+  Usage,
+} from "@agentrail/core";
+import { isRuntimeError } from "@agentrail/core";
+import { Hono } from "hono";
+import { streamText } from "hono/streaming";
+import { randomUUID } from "node:crypto";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -179,11 +188,22 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
     const validation = validateStreamRequest(body);
     if (!validation.valid) return c.json({ error: validation.error }, 400);
 
-    const { message, agentId = options.defaultAgentId, tenantId, userId, sessionId, attachments } =
-      body;
+    const {
+      message,
+      agentId = options.defaultAgentId,
+      tenantId,
+      userId,
+      sessionId,
+      attachments,
+    } = body;
 
     // ── 2. Session init ──────────────────────────────────────────────────────
-    const sessionInfo = await options.sessionStore.getOrCreate(tenantId, userId, agentId, sessionId);
+    const sessionInfo = await options.sessionStore.getOrCreate(
+      tenantId,
+      userId,
+      agentId,
+      sessionId,
+    );
     const sid = sessionInfo.sessionId;
     const sessionRef = sessionInfo.sessionRef;
     const requestContext: AgentrailRequestLifecycleContext = {
@@ -350,9 +370,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
         // events because capabilities (e.g. orchestration()) register their
         // createManagedAgent factory into the registry during agent creation.
         // Subscribing first would cause getManager() to fail for new sessions.
-        const agent = await profile.createAgent(profileCtx, (event) =>
-          forwardSubAgentEvent(event),
-        );
+        const agent = await profile.createAgent(profileCtx, (event) => forwardSubAgentEvent(event));
         const capProviders = (await profile.getContextProviders?.(profileCtx)) ?? [];
         const profileTransform = await profile.getTransformContext?.(profileCtx);
         const transformContext = await resolveTransformContext(

--- a/packages/app/src/session/compaction.ts
+++ b/packages/app/src/session/compaction.ts
@@ -3,15 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { estimateMessageTokens } from "@/session/token-estimator.js";
+import type { ImageContent, Message, TextContent, ToolResultMessage } from "@agentrail/core";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type {
-  ImageContent,
-  Message,
-  TextContent,
-  ToolResultMessage,
-} from "@agentrail/core";
-import { estimateMessageTokens } from "@/session/token-estimator.js";
 
 /** Thresholds that control view-only compaction of large tool results. */
 export interface ToolResultCompactionOptions {
@@ -61,55 +56,59 @@ export async function compactToolResults(
     }
   }
 
-  return Promise.all(messages.map(async (m, i): Promise<Message> => {
-    if (m.role !== "toolResult") return m;
+  return Promise.all(
+    messages.map(async (m, i): Promise<Message> => {
+      if (m.role !== "toolResult") return m;
 
-    const estimate = estimateMessageTokens([m]);
-    const isRecentToolResult = recentToolResultIndices.has(i);
-    const shouldCompactRecent = isRecentToolResult && estimate > maxTokensPerRecentToolResult;
-    const exceedsGeneralLimit = estimate > maxTokensPerToolResult;
+      const estimate = estimateMessageTokens([m]);
+      const isRecentToolResult = recentToolResultIndices.has(i);
+      const shouldCompactRecent = isRecentToolResult && estimate > maxTokensPerRecentToolResult;
+      const exceedsGeneralLimit = estimate > maxTokensPerToolResult;
 
-    if (isRecentToolResult && !shouldCompactRecent) return m;
-    if (!shouldCompactRecent && !exceedsGeneralLimit) return m;
+      if (isRecentToolResult && !shouldCompactRecent) return m;
+      if (!shouldCompactRecent && !exceedsGeneralLimit) return m;
 
-    const trm = m as ToolResultMessage;
+      const trm = m as ToolResultMessage;
 
-    // Separate text and image blocks
-    const textBlocks = trm.content.filter((b): b is TextContent => "text" in b);
-    const imageBlocks = trm.content.filter((b): b is ImageContent => b.type === "image");
+      // Separate text and image blocks
+      const textBlocks = trm.content.filter((b): b is TextContent => "text" in b);
+      const imageBlocks = trm.content.filter((b): b is ImageContent => b.type === "image");
 
-    const fullText = textBlocks.map((b) => b.text).join("");
-    const preview = fullText.slice(0, 200).replace(/\n+/g, " ").trim();
-    const persistedPath = sessionDir
-      ? `/workspace/memo/session/tool-results/${trm.toolCallId}.txt`
-      : null;
+      const fullText = textBlocks.map((b) => b.text).join("");
+      const preview = fullText.slice(0, 200).replace(/\n+/g, " ").trim();
+      const persistedPath = sessionDir
+        ? `/workspace/memo/session/tool-results/${trm.toolCallId}.txt`
+        : null;
 
-    if (sessionDir && fullText.length > 0) {
-      const toolResultsDir = path.join(sessionDir, "tool-results");
-      await mkdir(toolResultsDir, { recursive: true });
-      await writeFile(path.join(toolResultsDir, `${trm.toolCallId}.txt`), fullText, "utf8");
-    }
+      if (sessionDir && fullText.length > 0) {
+        const toolResultsDir = path.join(sessionDir, "tool-results");
+        await mkdir(toolResultsDir, { recursive: true });
+        await writeFile(path.join(toolResultsDir, `${trm.toolCallId}.txt`), fullText, "utf8");
+      }
 
-    const compactedText =
-      persistedPath && fullText.length > 0
-        ? `[Tool result compacted — text saved to session storage (~${estimate} tok).\nPreview: ${preview}…\nTo access: Read ${persistedPath}\nNote: For single-line outputs (e.g. minified JSON), Read may truncate; if available, use Grep or another file-search tool to locate relevant content.]`
-        : `[tool result truncated: ~${estimate} tok — re-call the tool to get full content]\n${preview}…`;
+      const compactedText =
+        persistedPath && fullText.length > 0
+          ? `[Tool result compacted — text saved to session storage (~${estimate} tok).\nPreview: ${preview}…\nTo access: Read ${persistedPath}\nNote: For single-line outputs (e.g. minified JSON), Read may truncate; if available, use Grep or another file-search tool to locate relevant content.]`
+          : `[tool result truncated: ~${estimate} tok — re-call the tool to get full content]\n${preview}…`;
 
-    const compactedContent: ToolResultMessage["content"] = [{ type: "text", text: compactedText }];
+      const compactedContent: ToolResultMessage["content"] = [
+        { type: "text", text: compactedText },
+      ];
 
-    // Replace image blocks with path-reference placeholders so the LLM knows
-    // they exist and can request them again, without storing base64 in context.
-    if (imageBlocks.length > 0) {
-      compactedContent.push({
-        type: "text",
-        text: `[${imageBlocks.length} image(s) removed from context]`,
-      });
-    }
+      // Replace image blocks with path-reference placeholders so the LLM knows
+      // they exist and can request them again, without storing base64 in context.
+      if (imageBlocks.length > 0) {
+        compactedContent.push({
+          type: "text",
+          text: `[${imageBlocks.length} image(s) removed from context]`,
+        });
+      }
 
-    const compactedResult: ToolResultMessage = {
-      ...trm,
-      content: compactedContent,
-    };
-    return compactedResult;
-  }));
+      const compactedResult: ToolResultMessage = {
+        ...trm,
+        content: compactedContent,
+      };
+      return compactedResult;
+    }),
+  );
 }

--- a/packages/app/src/session/session-manager-helpers.ts
+++ b/packages/app/src/session/session-manager-helpers.ts
@@ -3,16 +3,16 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Message } from "@agentrail/core";
-import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 import { estimateFileTokens } from "@/session/token-estimator.js";
 import type {
   CompactionMetadata,
   MemoryIndexEntry,
+  Message,
   SessionInfo,
   SessionInitEvent,
   SessionTurnEvent,
 } from "@agentrail/core";
+import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 
 const SUMMARY_RE = /<!--\s*summary:\s*(.+?)\s*-->/;
 const COMPACTION_ARCHIVE_RE = /Archive ID:\s*([0-9]{4,})/i;

--- a/packages/app/src/session/session-manager.ts
+++ b/packages/app/src/session/session-manager.ts
@@ -3,11 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Message, Usage } from "@agentrail/core";
-import { randomUUID } from "node:crypto";
-import type { Dirent } from "node:fs";
-import { access, appendFile, constants, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import * as path from "node:path";
 import {
   buildCompactionMetadata,
   buildMemoryEntry,
@@ -18,21 +13,39 @@ import {
   replaySessionInfo,
   statOrNull,
 } from "@/session/session-manager-helpers.js";
-import type { SessionRef } from "@agentrail/core";
-import { createSessionRef, resolveSessionRef } from "@agentrail/core";
-import type { TodoStorage } from "@agentrail/core";
 import { estimateMessageTokens } from "@/session/token-estimator.js";
-import { createFileSystemSessionTraceStore, type SessionTraceStore } from "@/session/trace-store.js";
+import {
+  createFileSystemSessionTraceStore,
+  type SessionTraceStore,
+} from "@/session/trace-store.js";
 import type {
   CompactionMetadata,
   MemoryIndex,
+  Message,
   SessionContextUsage,
   SessionHandle,
   SessionInfo,
   SessionInitEvent,
   SessionMeta,
+  SessionRef,
   SessionTurnEvent,
+  TodoStorage,
+  Usage,
 } from "@agentrail/core";
+import { createSessionRef, resolveSessionRef } from "@agentrail/core";
+import { randomUUID } from "node:crypto";
+import type { Dirent } from "node:fs";
+import {
+  access,
+  appendFile,
+  constants,
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import * as path from "node:path";
 
 /** Prefix used for synthetic compaction messages written to messages.jsonl. */
 export const COMPACTION_MESSAGE_PREFIX = "[Conversation compacted at ";

--- a/packages/app/src/session/trace-store.ts
+++ b/packages/app/src/session/trace-store.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { appendFile, mkdir, readFile } from "node:fs/promises";
-import path from "node:path";
 import type { SessionRef } from "@agentrail/core";
 import { resolveSessionRef } from "@agentrail/core";
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
 
 /** Session-scoped persistence for workflow trace envelopes. */
 export interface SessionTraceStore<TEnvelope = Record<string, unknown>> {

--- a/packages/app/src/telemetry/sink.ts
+++ b/packages/app/src/telemetry/sink.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { randomUUID } from "node:crypto";
-import { createSessionRef } from "@agentrail/core";
 import { createFileSystemSessionTraceStore } from "@/session/trace-store.js";
+import { createSessionRef } from "@agentrail/core";
+import { randomUUID } from "node:crypto";
 
 // ─── Core interface ───────────────────────────────────────────────────────────
 

--- a/packages/app/test/chat-route-telemetry.test.ts
+++ b/packages/app/test/chat-route-telemetry.test.ts
@@ -12,10 +12,10 @@
  * synthetic lifecycle events are delivered correctly.
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { createChatRoute } from "../src/routes/chat-route.js";
+import { describe, expect, it, vi } from "vitest";
 import type { WorkflowTraceEventEnvelope } from "../src/events/index.js";
-import type { AgentrailSessionStore, AgentrailProfile } from "../src/host/types.js";
+import type { AgentrailProfile, AgentrailSessionStore } from "../src/host/types.js";
+import { createChatRoute } from "../src/routes/chat-route.js";
 
 // ─── Minimal stubs ────────────────────────────────────────────────────────────
 

--- a/packages/app/test/compaction.test.ts
+++ b/packages/app/test/compaction.test.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { Message, ToolResultMessage } from "@agentrail/core";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { Message, ToolResultMessage } from "@agentrail/core";
 import { describe, expect, it } from "vitest";
 import { compactToolResults } from "../src/session/compaction.js";
 

--- a/packages/app/test/config.test.ts
+++ b/packages/app/test/config.test.ts
@@ -4,10 +4,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-  getDeepResearchConfig,
-  parseAgentrailConfig,
-} from "../src/config/index.js";
+import { getDeepResearchConfig, parseAgentrailConfig } from "../src/config/index.js";
 
 describe("Agentrail config search settings", () => {
   it("parses brave and jina API keys", () => {

--- a/packages/app/test/define-profile.test.ts
+++ b/packages/app/test/define-profile.test.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { defineProfile } from "../src/profile/define-profile.js";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentrailProfileContext } from "../src/host/types.js";
+import { defineProfile } from "../src/profile/define-profile.js";
 
 const fakeContext: AgentrailProfileContext = {
   tenantId: "t1",

--- a/packages/app/test/inspector-guards.test.ts
+++ b/packages/app/test/inspector-guards.test.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { createAgentApp } from "../src/app/create-agent-app.js";
 import type { AgentrailSessionStore } from "@agentrail/core";
+import { describe, expect, it, vi } from "vitest";
+import { createAgentApp } from "../src/app/create-agent-app.js";
 
 // Minimal profile definition that satisfies createAgentApp type checks.
 const minimalProfile = {

--- a/packages/app/test/orchestration-registry-concurrency.test.ts
+++ b/packages/app/test/orchestration-registry-concurrency.test.ts
@@ -14,12 +14,12 @@
  * backed by a temporary filesystem directory.
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { randomUUID } from "node:crypto";
-import { createOrchestrationRegistry } from "../src/host/orchestration-registry.js";
 import { createSessionRef } from "@agentrail/core";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createOrchestrationRegistry } from "../src/host/orchestration-registry.js";
 
 describe("OrchestrationRegistry – ensureActiveRunId concurrency", () => {
   it("two concurrent first-spawn calls produce exactly one run", async () => {

--- a/packages/app/test/plugins.test.ts
+++ b/packages/app/test/plugins.test.ts
@@ -3,14 +3,14 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildToolInterceptor,
+  collectPluginContextProviders,
+  runAttachmentHandlers,
+  runPluginChatRequestInterceptors,
   runPluginLifecycle,
   runPluginRequestHook,
-  runPluginChatRequestInterceptors,
-  runAttachmentHandlers,
-  collectPluginContextProviders,
 } from "../src/host/plugins.js";
 import type {
   AfterToolCallEvent,
@@ -64,7 +64,9 @@ describe("runPluginLifecycle", () => {
     const error = new Error("start failure");
     const onError: PluginErrorHandler = vi.fn();
     const plugin = makePlugin("bad", {
-      start: async () => { throw error; },
+      start: async () => {
+        throw error;
+      },
     });
     await expect(runPluginLifecycle([plugin], "start", onError)).rejects.toThrow("start failure");
     expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "start", error });
@@ -73,8 +75,17 @@ describe("runPluginLifecycle", () => {
   it("stop: notifies onPluginError but continues when a plugin throws", async () => {
     const onError: PluginErrorHandler = vi.fn();
     const order: string[] = [];
-    const bad = makePlugin("bad", { stop: async () => { order.push("bad"); throw new Error("stop fail"); } });
-    const good = makePlugin("good", { stop: async () => { order.push("good"); } });
+    const bad = makePlugin("bad", {
+      stop: async () => {
+        order.push("bad");
+        throw new Error("stop fail");
+      },
+    });
+    const good = makePlugin("good", {
+      stop: async () => {
+        order.push("good");
+      },
+    });
     await runPluginLifecycle([bad, good], "stop", onError);
     expect(onError).toHaveBeenCalledOnce();
     expect(order).toEqual(["bad", "good"]);
@@ -82,41 +93,65 @@ describe("runPluginLifecycle", () => {
 
   it("start: executes in descending priority order", async () => {
     const order: string[] = [];
-    const low = makePlugin("low", { priority: 0, start: async () => { order.push("low"); } });
-    const high = makePlugin("high", { priority: 100, start: async () => { order.push("high"); } });
+    const low = makePlugin("low", {
+      priority: 0,
+      start: async () => {
+        order.push("low");
+      },
+    });
+    const high = makePlugin("high", {
+      priority: 100,
+      start: async () => {
+        order.push("high");
+      },
+    });
     await runPluginLifecycle([low, high], "start");
     expect(order).toEqual(["high", "low"]);
   });
 
   it("stop: executes in ascending priority order (reverse of start)", async () => {
     const order: string[] = [];
-    const low = makePlugin("low", { priority: 0, stop: async () => { order.push("low"); } });
-    const high = makePlugin("high", { priority: 100, stop: async () => { order.push("high"); } });
+    const low = makePlugin("low", {
+      priority: 0,
+      stop: async () => {
+        order.push("low");
+      },
+    });
+    const high = makePlugin("high", {
+      priority: 100,
+      stop: async () => {
+        order.push("high");
+      },
+    });
     await runPluginLifecycle([low, high], "stop");
     expect(order).toEqual(["low", "high"]);
   });
 
   it("uses console.warn by default when no onPluginError is provided", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const plugin = makePlugin("bad", { stop: async () => { throw new Error("oops"); } });
+    const plugin = makePlugin("bad", {
+      stop: async () => {
+        throw new Error("oops");
+      },
+    });
     await runPluginLifecycle([plugin], "stop");
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('"bad"'),
-      expect.any(Error),
-    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"bad"'), expect.any(Error));
     warn.mockRestore();
   });
 
   it("safeNotify: falls back to console.error when onPluginError itself throws", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const onError: PluginErrorHandler = () => { throw new Error("handler failure"); };
-    const plugin = makePlugin("bad", { stop: async () => { throw new Error("original"); } });
+    const onError: PluginErrorHandler = () => {
+      throw new Error("handler failure");
+    };
+    const plugin = makePlugin("bad", {
+      stop: async () => {
+        throw new Error("original");
+      },
+    });
     // Must NOT throw even though both plugin and handler threw
     await expect(runPluginLifecycle([plugin], "stop", onError)).resolves.toBeUndefined();
-    expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('"bad"'),
-      expect.any(Error),
-    );
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('"bad"'), expect.any(Error));
     consoleError.mockRestore();
   });
 
@@ -126,8 +161,17 @@ describe("runPluginLifecycle", () => {
       await new Promise((r) => setTimeout(r, 10));
       order.push("handler");
     };
-    const bad = makePlugin("bad", { stop: async () => { order.push("throw"); throw new Error("err"); } });
-    const next = makePlugin("next", { stop: async () => { order.push("next"); } });
+    const bad = makePlugin("bad", {
+      stop: async () => {
+        order.push("throw");
+        throw new Error("err");
+      },
+    });
+    const next = makePlugin("next", {
+      stop: async () => {
+        order.push("next");
+      },
+    });
     await runPluginLifecycle([bad, next], "stop", onError);
     expect(order).toEqual(["throw", "handler", "next"]);
   });
@@ -138,15 +182,28 @@ describe("runPluginLifecycle", () => {
 describe("runPluginRequestHook", () => {
   it("calls hook on all plugins", async () => {
     const onRequestStart = vi.fn();
-    await runPluginRequestHook([makePlugin("p1", { onRequestStart })], "onRequestStart", mockRequestContext);
+    await runPluginRequestHook(
+      [makePlugin("p1", { onRequestStart })],
+      "onRequestStart",
+      mockRequestContext,
+    );
     expect(onRequestStart).toHaveBeenCalledWith(mockRequestContext);
   });
 
   it("isolates errors: other plugins still run", async () => {
     const onError: PluginErrorHandler = vi.fn();
     const order: string[] = [];
-    const bad = makePlugin("bad", { onRequestEnd: async () => { order.push("bad"); throw new Error("boom"); } });
-    const good = makePlugin("good", { onRequestEnd: async () => { order.push("good"); } });
+    const bad = makePlugin("bad", {
+      onRequestEnd: async () => {
+        order.push("bad");
+        throw new Error("boom");
+      },
+    });
+    const good = makePlugin("good", {
+      onRequestEnd: async () => {
+        order.push("good");
+      },
+    });
     await runPluginRequestHook([bad, good], "onRequestEnd", mockRequestContext, onError);
     expect(onError).toHaveBeenCalledOnce();
     expect(order).toEqual(["bad", "good"]);
@@ -154,8 +211,18 @@ describe("runPluginRequestHook", () => {
 
   it("runs plugins in descending priority order", async () => {
     const order: string[] = [];
-    const low = makePlugin("low", { priority: 0, onRequestStart: async () => { order.push("low"); } });
-    const high = makePlugin("high", { priority: 10, onRequestStart: async () => { order.push("high"); } });
+    const low = makePlugin("low", {
+      priority: 0,
+      onRequestStart: async () => {
+        order.push("low");
+      },
+    });
+    const high = makePlugin("high", {
+      priority: 10,
+      onRequestStart: async () => {
+        order.push("high");
+      },
+    });
     await runPluginRequestHook([low, high], "onRequestStart", mockRequestContext);
     expect(order).toEqual(["high", "low"]);
   });
@@ -165,15 +232,15 @@ describe("runPluginRequestHook", () => {
 
 describe("runPluginChatRequestInterceptors", () => {
   it("returns null when no plugin intercepts", async () => {
-    const result = await runPluginChatRequestInterceptors(
-      [makePlugin("p1")],
-      mockChatContext,
-    );
+    const result = await runPluginChatRequestInterceptors([makePlugin("p1")], mockChatContext);
     expect(result).toBeNull();
   });
 
   it("returns the first non-null response", async () => {
-    const handled = { status: 200 as const, body: { text: "handled", usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } } };
+    const handled = {
+      status: 200 as const,
+      body: { text: "handled", usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+    };
     const plugin = makePlugin("p1", { interceptChatRequest: async () => handled });
     const result = await runPluginChatRequestInterceptors([plugin], mockChatContext);
     expect(result).toBe(handled);
@@ -181,10 +248,18 @@ describe("runPluginChatRequestInterceptors", () => {
 
   it("non-critical: isolates errors, notifies onPluginError, continues with null", async () => {
     const onError: PluginErrorHandler = vi.fn();
-    const bad = makePlugin("bad", { interceptChatRequest: async () => { throw new Error("denied"); } });
+    const bad = makePlugin("bad", {
+      interceptChatRequest: async () => {
+        throw new Error("denied");
+      },
+    });
     const result = await runPluginChatRequestInterceptors([bad], mockChatContext, onError);
     expect(result).toBeNull();
-    expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "interceptChatRequest", error: expect.any(Error) });
+    expect(onError).toHaveBeenCalledWith({
+      plugin: "bad",
+      hook: "interceptChatRequest",
+      error: expect.any(Error),
+    });
   });
 
   it("critical: notifies onPluginError then rethrows", async () => {
@@ -192,16 +267,32 @@ describe("runPluginChatRequestInterceptors", () => {
     const error = new Error("auth failure");
     const bad = makePlugin("bad", {
       critical: true,
-      interceptChatRequest: async () => { throw error; },
+      interceptChatRequest: async () => {
+        throw error;
+      },
     });
-    await expect(runPluginChatRequestInterceptors([bad], mockChatContext, onError)).rejects.toThrow("auth failure");
+    await expect(runPluginChatRequestInterceptors([bad], mockChatContext, onError)).rejects.toThrow(
+      "auth failure",
+    );
     expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "interceptChatRequest", error });
   });
 
   it("runs plugins in descending priority order", async () => {
     const order: string[] = [];
-    const low = makePlugin("low", { priority: 0, interceptChatRequest: async () => { order.push("low"); return null; } });
-    const high = makePlugin("high", { priority: 5, interceptChatRequest: async () => { order.push("high"); return null; } });
+    const low = makePlugin("low", {
+      priority: 0,
+      interceptChatRequest: async () => {
+        order.push("low");
+        return null;
+      },
+    });
+    const high = makePlugin("high", {
+      priority: 5,
+      interceptChatRequest: async () => {
+        order.push("high");
+        return null;
+      },
+    });
     await runPluginChatRequestInterceptors([low, high], mockChatContext);
     expect(order).toEqual(["high", "low"]);
   });
@@ -226,11 +317,19 @@ describe("runAttachmentHandlers", () => {
 
   it("isolates errors: skips failing handler, others still run", async () => {
     const onError: PluginErrorHandler = vi.fn();
-    const bad = makePlugin("bad", { attachmentHandler: async () => { throw new Error("fail"); } });
+    const bad = makePlugin("bad", {
+      attachmentHandler: async () => {
+        throw new Error("fail");
+      },
+    });
     const good = makePlugin("good", { attachmentHandler: async () => ({ contextText: "ok" }) });
     const result = await runAttachmentHandlers(files, [bad, good], undefined, onError);
     expect(result?.contextText).toBe("ok");
-    expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "attachmentHandler", error: expect.any(Error) });
+    expect(onError).toHaveBeenCalledWith({
+      plugin: "bad",
+      hook: "attachmentHandler",
+      error: expect.any(Error),
+    });
   });
 
   it("includes fallbackHandler result", async () => {
@@ -246,18 +345,27 @@ const mockProfileCtx: AgentrailProfileContext = {
   tenantId: "t1",
   userId: "u1",
   sessionId: "s1",
-  sessionRef: { tenantId: "t1", userId: "u1", sessionId: "s1" } as AgentrailProfileContext["sessionRef"],
+  sessionRef: {
+    tenantId: "t1",
+    userId: "u1",
+    sessionId: "s1",
+  } as AgentrailProfileContext["sessionRef"],
   sessionStore: {} as AgentrailProfileContext["sessionStore"],
 };
 
 function makeToolPlugin(
   name: string,
-  overrides: Pick<AgentrailPlugin, "priority" | "onBeforeToolCall" | "onAfterToolCall"> & { priority?: number },
+  overrides: Pick<AgentrailPlugin, "priority" | "onBeforeToolCall" | "onAfterToolCall"> & {
+    priority?: number;
+  },
 ): AgentrailPlugin {
   return { name, ...overrides };
 }
 
-function makeBeforeEvent(toolName = "test", input: Record<string, unknown> = { value: "x" }): BeforeToolCallEvent {
+function makeBeforeEvent(
+  toolName = "test",
+  input: Record<string, unknown> = { value: "x" },
+): BeforeToolCallEvent {
   return { toolName, input, context: mockProfileCtx };
 }
 
@@ -286,7 +394,12 @@ describe("buildToolInterceptor", () => {
     const hook = vi.fn();
     const plugin = makeToolPlugin("p1", { onAfterToolCall: hook });
     const interceptor = buildToolInterceptor([plugin], mockProfileCtx)!;
-    await interceptor.onAfterToolCall!({ toolName: "t", input: ["a", "b"], result: {}, durationMs: 0 });
+    await interceptor.onAfterToolCall!({
+      toolName: "t",
+      input: ["a", "b"],
+      result: {},
+      durationMs: 0,
+    });
     expect(hook).not.toHaveBeenCalled();
   });
 
@@ -329,7 +442,9 @@ describe("buildToolInterceptor", () => {
     });
     const interceptor = buildToolInterceptor([plugin], mockProfileCtx);
     // Should not throw; error should be swallowed via defaultErrorHandler → console.warn
-    await expect(interceptor!.onBeforeToolCall!({ toolName: "t", input: {} })).resolves.toMatchObject({ action: "allow" });
+    await expect(
+      interceptor!.onBeforeToolCall!({ toolName: "t", input: {} }),
+    ).resolves.toMatchObject({ action: "allow" });
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -339,11 +454,17 @@ describe("buildToolInterceptor", () => {
       const order: string[] = [];
       const low = makeToolPlugin("low", {
         priority: 0,
-        onBeforeToolCall: vi.fn().mockImplementation(async () => { order.push("low"); return { action: "allow" }; }),
+        onBeforeToolCall: vi.fn().mockImplementation(async () => {
+          order.push("low");
+          return { action: "allow" };
+        }),
       });
       const high = makeToolPlugin("high", {
         priority: 10,
-        onBeforeToolCall: vi.fn().mockImplementation(async () => { order.push("high"); return { action: "allow" }; }),
+        onBeforeToolCall: vi.fn().mockImplementation(async () => {
+          order.push("high");
+          return { action: "allow" };
+        }),
       });
       const interceptor = buildToolInterceptor([low, high], mockProfileCtx)!;
       await interceptor.onBeforeToolCall!({ toolName: "t", input: {} });
@@ -370,7 +491,9 @@ describe("buildToolInterceptor", () => {
       const received: Record<string, unknown>[] = [];
       const first = makeToolPlugin("first", {
         priority: 10,
-        onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow", input: { value: "modified" } }),
+        onBeforeToolCall: vi
+          .fn()
+          .mockResolvedValue({ action: "allow", input: { value: "modified" } }),
       });
       const second = makeToolPlugin("second", {
         priority: 0,
@@ -380,7 +503,10 @@ describe("buildToolInterceptor", () => {
         }),
       });
       const interceptor = buildToolInterceptor([first, second], mockProfileCtx)!;
-      const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: { value: "original" } }) as AppBeforeToolCallResult & { input?: Record<string, unknown> };
+      const result = (await interceptor.onBeforeToolCall!({
+        toolName: "t",
+        input: { value: "original" },
+      })) as AppBeforeToolCallResult & { input?: Record<string, unknown> };
       expect(received[0].value).toBe("modified");
       expect(result).toMatchObject({ action: "allow", input: { value: "modified" } });
     });
@@ -425,7 +551,11 @@ describe("buildToolInterceptor", () => {
       const interceptor = buildToolInterceptor([bad, good], mockProfileCtx, onError)!;
       const result = await interceptor.onBeforeToolCall!({ toolName: "t", input: {} });
       expect(result).toMatchObject({ action: "allow" });
-      expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "onBeforeToolCall", error: expect.any(Error) });
+      expect(onError).toHaveBeenCalledWith({
+        plugin: "bad",
+        hook: "onBeforeToolCall",
+        error: expect.any(Error),
+      });
       expect(good.onBeforeToolCall).toHaveBeenCalledOnce();
     });
   });
@@ -435,15 +565,22 @@ describe("buildToolInterceptor", () => {
       const order: string[] = [];
       const low = makeToolPlugin("low", {
         priority: 0,
-        onAfterToolCall: vi.fn().mockImplementation(async () => { order.push("low"); }),
+        onAfterToolCall: vi.fn().mockImplementation(async () => {
+          order.push("low");
+        }),
       });
       const high = makeToolPlugin("high", {
         priority: 10,
-        onAfterToolCall: vi.fn().mockImplementation(async () => { order.push("high"); }),
+        onAfterToolCall: vi.fn().mockImplementation(async () => {
+          order.push("high");
+        }),
       });
       const interceptor = buildToolInterceptor([low, high], mockProfileCtx)!;
       const ctx: Parameters<NonNullable<typeof interceptor.onAfterToolCall>>[0] = {
-        toolName: "t", input: {}, result: {}, durationMs: 0,
+        toolName: "t",
+        input: {},
+        result: {},
+        durationMs: 0,
       };
       await interceptor.onAfterToolCall!(ctx);
       expect(order).toEqual(["high", "low"]);
@@ -465,7 +602,12 @@ describe("buildToolInterceptor", () => {
         }),
       });
       const interceptor = buildToolInterceptor([plugin1, plugin2], mockProfileCtx)!;
-      await interceptor.onAfterToolCall!({ toolName: "t", input: { value: "x" }, result: {}, durationMs: 0 });
+      await interceptor.onAfterToolCall!({
+        toolName: "t",
+        input: { value: "x" },
+        result: {},
+        durationMs: 0,
+      });
 
       expect(receivedRefs[0]).not.toBe(receivedRefs[1]);
       expect(receivedRefs[1].mutated).toBeUndefined();
@@ -480,14 +622,23 @@ describe("buildToolInterceptor", () => {
       });
       const good = makeToolPlugin("good", {
         priority: 0,
-        onAfterToolCall: vi.fn().mockImplementation(async () => { order.push("good"); }),
+        onAfterToolCall: vi.fn().mockImplementation(async () => {
+          order.push("good");
+        }),
       });
       const interceptor = buildToolInterceptor([bad, good], mockProfileCtx, onError)!;
       const ctx: Parameters<NonNullable<typeof interceptor.onAfterToolCall>>[0] = {
-        toolName: "t", input: {}, result: {}, durationMs: 0,
+        toolName: "t",
+        input: {},
+        result: {},
+        durationMs: 0,
       };
       await interceptor.onAfterToolCall!(ctx);
-      expect(onError).toHaveBeenCalledWith({ plugin: "bad", hook: "onAfterToolCall", error: expect.any(Error) });
+      expect(onError).toHaveBeenCalledWith({
+        plugin: "bad",
+        hook: "onAfterToolCall",
+        error: expect.any(Error),
+      });
       expect(order).toEqual(["good"]);
     });
 

--- a/packages/app/test/session-manager.test.ts
+++ b/packages/app/test/session-manager.test.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { AssistantMessage, Message, Usage } from "@agentrail/core";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { AssistantMessage, Message, Usage } from "@agentrail/core";
 import { describe, expect, it } from "vitest";
 import { SessionManager } from "../src/session/session-manager.js";
 

--- a/packages/app/test/stream-route-persistence.test.ts
+++ b/packages/app/test/stream-route-persistence.test.ts
@@ -11,11 +11,18 @@
  * Also covers flush-failure drop semantics.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  Agent,
+  AgentStream,
+  AssistantMessage,
+  Message,
+  RuntimeEvent,
+  ToolResultMessage,
+  Usage,
+} from "@agentrail/core";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentrailProfile, AgentrailSessionStore } from "../src/host/types.js";
 import { createStreamRoute } from "../src/routes/stream-route.js";
-import type { AgentrailSessionStore, AgentrailProfile } from "../src/host/types.js";
-import type { Agent, AgentStream, RuntimeEvent, Message, Usage } from "@agentrail/core";
-import type { AssistantMessage, ToolResultMessage } from "@agentrail/core";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -74,7 +81,13 @@ function makeTwoTurnStream(): AgentStream {
     yield { type: "message.start", message: assistantMsg1 };
     yield { type: "message.end", message: assistantMsg1 };
     yield { type: "tool.before", toolCallId: "tc1", toolName: "search", args: {} };
-    yield { type: "tool.after", toolCallId: "tc1", toolName: "search", result: "result", isError: false };
+    yield {
+      type: "tool.after",
+      toolCallId: "tc1",
+      toolName: "search",
+      result: "result",
+      isError: false,
+    };
     yield { type: "message.start", message: toolResultMsg };
     yield { type: "message.end", message: toolResultMsg };
     yield { type: "turn.complete", message: assistantMsg1, toolResults: [toolResultMsg] };
@@ -240,7 +253,8 @@ describe("stream-route – incremental persistence", () => {
 
     const agentStream: AgentStream = {
       [Symbol.asyncIterator]: () => earlyEndStream(),
-      result: () => Promise.resolve({ text: "", messages: [], usage: ZERO_USAGE, stopReason: "stop" } as any),
+      result: () =>
+        Promise.resolve({ text: "", messages: [], usage: ZERO_USAGE, stopReason: "stop" } as any),
     };
 
     const route = createStreamRoute({
@@ -313,7 +327,12 @@ describe("stream-route – flush failure drop semantics", () => {
     const req = new Request("http://localhost/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tenantId: TENANT_ID, userId: USER_ID, agentId: AGENT_ID, message: "hi" }),
+      body: JSON.stringify({
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        agentId: AGENT_ID,
+        message: "hi",
+      }),
     });
 
     const res = await route.fetch(req);
@@ -343,7 +362,12 @@ describe("stream-route – abort race condition", () => {
       method: "POST",
       signal,
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tenantId: TENANT_ID, userId: USER_ID, agentId: AGENT_ID, message: "hello" }),
+      body: JSON.stringify({
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        agentId: AGENT_ID,
+        message: "hello",
+      }),
     });
   }
 
@@ -379,7 +403,12 @@ describe("stream-route – abort race condition", () => {
     const agentStream: AgentStream = {
       [Symbol.asyncIterator]: () => streamWithSessionEnd(),
       result: () =>
-        Promise.resolve({ text: "done", messages: [], usage: ZERO_USAGE, stopReason: "stop" } as any),
+        Promise.resolve({
+          text: "done",
+          messages: [],
+          usage: ZERO_USAGE,
+          stopReason: "stop",
+        } as any),
     };
 
     const route = createStreamRoute({

--- a/packages/app/test/telemetry.test.ts
+++ b/packages/app/test/telemetry.test.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { wrapTraceEvent, TRACE_PERSISTED_EVENT_TYPES } from "../src/events/index.js";
+import { describe, expect, it } from "vitest";
+import { TRACE_PERSISTED_EVENT_TYPES, wrapTraceEvent } from "../src/events/index.js";
 import type { TelemetrySink, TelemetrySinkEvent } from "../src/telemetry/sink.js";
 
 // ─── TRACE_PERSISTED_EVENT_TYPES ──────────────────────────────────────────────
@@ -19,13 +19,27 @@ describe("TRACE_PERSISTED_EVENT_TYPES", () => {
   });
 
   it("includes core runtime event types", () => {
-    for (const type of ["session.start", "session.end", "turn.start", "turn.complete", "tool.before", "tool.after", "error"]) {
+    for (const type of [
+      "session.start",
+      "session.end",
+      "turn.start",
+      "turn.complete",
+      "tool.before",
+      "tool.after",
+      "error",
+    ]) {
       expect(TRACE_PERSISTED_EVENT_TYPES.has(type), `missing: ${type}`).toBe(true);
     }
   });
 
   it("does not include high-frequency streaming noise events", () => {
-    for (const type of ["message_start", "message_end", "message_update", "session_id", "text_delta"]) {
+    for (const type of [
+      "message_start",
+      "message_end",
+      "message_update",
+      "session_id",
+      "text_delta",
+    ]) {
       expect(TRACE_PERSISTED_EVENT_TYPES.has(type), `should be absent: ${type}`).toBe(false);
     }
   });

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -4,8 +4,8 @@
  */
 
 import { resolve } from "node:path";
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/packages/capabilities/src/ask-user/descriptor.ts
+++ b/packages/capabilities/src/ask-user/descriptor.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 import { createAskUserQuestionTool, type WaitHandleRegistry } from "@/tools/index.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 
 /**
  * Capability that lets the agent pause and ask the user a clarifying question

--- a/packages/capabilities/src/browser/index.ts
+++ b/packages/capabilities/src/browser/index.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 import type { SandboxManager } from "@/sandbox/index.js";
 import {
   createBrowserAction,
@@ -11,6 +10,7 @@ import {
   createBrowserNavigate,
   createBrowserScroll,
 } from "@/sandbox/index.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 
 export interface BrowserOptions {
   /** Override the sandbox manager (e.g. from a custom image). */
@@ -31,8 +31,8 @@ export function browser(opts?: BrowserOptions): CapabilityDescriptor {
       const sm = opts?.sandboxManager ?? ctx.sandboxManager;
       if (!sm) {
         throw new Error(
-          'browser() capability requires a SandboxManager. ' +
-          'Pass one via browser({ sandboxManager }) or ensure the host provides it.',
+          "browser() capability requires a SandboxManager. " +
+            "Pass one via browser({ sandboxManager }) or ensure the host provides it.",
         );
       }
       const { tenantId, userId, sessionId } = ctx;

--- a/packages/capabilities/src/context-pipeline.ts
+++ b/packages/capabilities/src/context-pipeline.ts
@@ -3,8 +3,12 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Message, TransformContextFn } from "@agentrail/core";
-import type { ContextProvider, ContextProviderContext } from "@agentrail/core";
+import type {
+  ContextProvider,
+  ContextProviderContext,
+  Message,
+  TransformContextFn,
+} from "@agentrail/core";
 
 /** Composes multiple transform functions into a single left-to-right pipeline. */
 export function composeTransformContexts(

--- a/packages/capabilities/src/filesystem/index.ts
+++ b/packages/capabilities/src/filesystem/index.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 import type { SandboxManager } from "@/sandbox/index.js";
 import {
   createSandboxedBash,
@@ -14,6 +13,7 @@ import {
   createSandboxedWrite,
 } from "@/sandbox/index.js";
 import { createSleepTool, createTodoWriteTool } from "@/tools/index.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 
 export interface FilesystemOptions {
   /** Override the sandbox manager (e.g. from a custom image). */
@@ -34,8 +34,8 @@ export function filesystem(opts?: FilesystemOptions): CapabilityDescriptor {
       const sm = opts?.sandboxManager ?? ctx.sandboxManager;
       if (!sm) {
         throw new Error(
-          'filesystem() capability requires a SandboxManager. ' +
-          'Pass one via filesystem({ sandboxManager }) or ensure the host provides it.',
+          "filesystem() capability requires a SandboxManager. " +
+            "Pass one via filesystem({ sandboxManager }) or ensure the host provides it.",
         );
       }
       const { tenantId, userId, sessionId, sessionRef, sessionStore } = ctx;

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -95,11 +95,7 @@ export type {
   Taxonomy,
 } from "@/knowledge/index.js";
 
-export {
-  createKbListTool,
-  createKbReadTool,
-  createKbSearchTool,
-} from "@/knowledge/index.js";
+export { createKbListTool, createKbReadTool, createKbSearchTool } from "@/knowledge/index.js";
 
 // ============================================================================
 // SkillManager
@@ -120,7 +116,10 @@ export { buildSkillTool } from "@/skills/index.js";
 // OrchestrationManager
 // ============================================================================
 
-export { OrchestrationManager, createFilesystemOrchestrationPersistence } from "@/orchestration/index.js";
+export {
+  OrchestrationManager,
+  createFilesystemOrchestrationPersistence,
+} from "@/orchestration/index.js";
 export type {
   AgentInputEnvelope,
   CreateManagedAgentInput,
@@ -151,19 +150,19 @@ export {
 
 export {
   bashTool,
+  createAskUserQuestionTool,
   createBraveSearchProvider,
   createGlobTool,
   createJinaSearchProvider,
   createSleepTool,
   createTavilySearchProvider,
+  createTodoWriteTool,
   createWebFetchTool,
   createWebSearchTool,
   editTool,
   grepTool,
   readTool,
   writeTool,
-  createAskUserQuestionTool,
-  createTodoWriteTool,
 } from "@/tools/index.js";
 export type {
   BraveSearchProviderOptions,

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -122,7 +122,9 @@ export {
 } from "@/orchestration/index.js";
 export type {
   AgentInputEnvelope,
+  AgentToolCallRecord,
   CreateManagedAgentInput,
+  JsonValue,
   ManagedAgentDeliveryResult,
   ManagedAgentInstance,
   OrchestrationAgent,

--- a/packages/capabilities/src/knowledge/descriptor.ts
+++ b/packages/capabilities/src/knowledge/descriptor.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 import { createKbListTool, createKbReadTool, createKbSearchTool } from "@/knowledge/kb-tools.js";
 import type { KnowledgeManager } from "@/knowledge/knowledge-manager.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 
 /**
  * Capability that provides knowledge-base tools:

--- a/packages/capabilities/src/knowledge/kb-tools.ts
+++ b/packages/capabilities/src/knowledge/kb-tools.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { KnowledgeManager } from "@/knowledge/knowledge-manager.js";
 import { tool, Type } from "@agentrail/core";
 import { exec } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { KnowledgeManager } from "@/knowledge/knowledge-manager.js";
 
 const execAsync = promisify(exec);
 

--- a/packages/capabilities/src/knowledge/knowledge-manager-helpers.ts
+++ b/packages/capabilities/src/knowledge/knowledge-manager-helpers.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { KBDocMeta, KBMetadata, Taxonomy } from "@/knowledge/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { KBDocMeta, KBMetadata, Taxonomy } from "@/knowledge/types.js";
 
 export async function ensureJsonFile<T>(filePath: string, defaultValue: T): Promise<void> {
   try {

--- a/packages/capabilities/src/knowledge/knowledge-manager.ts
+++ b/packages/capabilities/src/knowledge/knowledge-manager.ts
@@ -3,11 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { execFile } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { promisify } from "node:util";
 import {
   buildKnowledgeMetadata,
   buildTopicSummaries,
@@ -27,6 +22,11 @@ import type {
   SearchResult,
   Taxonomy,
 } from "@/knowledge/types.js";
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/capabilities/src/memory/context.ts
+++ b/packages/capabilities/src/memory/context.ts
@@ -3,8 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { TransformContextFn, UserMessage } from "@agentrail/core";
-import type { ContextProvider } from "@agentrail/core";
 import {
   makeDateContextMessage,
   makeKnowledgeContextMessage,
@@ -15,6 +13,7 @@ import {
 } from "@/memory/messages.js";
 import type { DefaultCapabilityContextOptions } from "@/memory/types.js";
 import { createDefaultContextProviders } from "@/memory/types.js";
+import type { ContextProvider, TransformContextFn, UserMessage } from "@agentrail/core";
 
 export interface DefaultCapabilityContextState {
   cachedContextMsgs: UserMessage[] | null;
@@ -120,8 +119,6 @@ export function createDefaultCapabilityContextProviders(
   state: DefaultCapabilityContextState = createDefaultCapabilityContextState(),
 ): ContextProvider[] {
   return createDefaultContextProviders({
-    baseProviders: [
-      async () => ensureCachedContextMessages(options, state),
-    ],
+    baseProviders: [async () => ensureCachedContextMessages(options, state)],
   });
 }

--- a/packages/capabilities/src/memory/index.ts
+++ b/packages/capabilities/src/memory/index.ts
@@ -3,15 +3,15 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { MemoryIndex, Message } from "@agentrail/core";
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 import type { KBMetadata } from "@/knowledge/types.js";
-import type { SkillMeta } from "@/skills/types.js";
 import {
+  createDefaultCapabilityContextProviders,
   createDefaultCapabilityContextState,
   createDefaultCapabilityTransformContext,
-  createDefaultCapabilityContextProviders,
 } from "@/memory/context.js";
+import type { SkillMeta } from "@/skills/types.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
+import type { MemoryIndex, Message } from "@agentrail/core";
 
 export type { DefaultCapabilityContextOptions } from "@/memory/types.js";
 
@@ -99,25 +99,28 @@ export function memoryContext(
         sessionId: ctx.sessionId,
       };
       const state = getState(ctx);
-      return createDefaultCapabilityContextProviders({
-        tenantId: ctx.tenantId,
-        userId: ctx.userId,
-        sessionId: ctx.sessionId,
-        includeSkillsContext: opts?.includeSkillsContext ?? true,
-        delegateSkillsToSubAgent: builders.delegateSkillsToSubAgent ?? false,
-        cacheTtlMs: opts?.cacheTtlMs,
-        buildMemoryIndex: () => builders.buildMemoryIndex(sessionCtx),
-        listKnowledgeMetadatas: builders.listKnowledgeMetadatas
-          ? () => builders.listKnowledgeMetadatas!(sessionCtx)
-          : () => Promise.resolve([]),
-        listSkills: builders.listSkills
-          ? () => builders.listSkills!(sessionCtx)
-          : () => Promise.resolve([]),
-        listWorkspaceSnapshot: builders.listWorkspaceSnapshot
-          ? () => builders.listWorkspaceSnapshot!(sessionCtx)
-          : undefined,
-        compactMessages: builders.compactMessages,
-      }, state);
+      return createDefaultCapabilityContextProviders(
+        {
+          tenantId: ctx.tenantId,
+          userId: ctx.userId,
+          sessionId: ctx.sessionId,
+          includeSkillsContext: opts?.includeSkillsContext ?? true,
+          delegateSkillsToSubAgent: builders.delegateSkillsToSubAgent ?? false,
+          cacheTtlMs: opts?.cacheTtlMs,
+          buildMemoryIndex: () => builders.buildMemoryIndex(sessionCtx),
+          listKnowledgeMetadatas: builders.listKnowledgeMetadatas
+            ? () => builders.listKnowledgeMetadatas!(sessionCtx)
+            : () => Promise.resolve([]),
+          listSkills: builders.listSkills
+            ? () => builders.listSkills!(sessionCtx)
+            : () => Promise.resolve([]),
+          listWorkspaceSnapshot: builders.listWorkspaceSnapshot
+            ? () => builders.listWorkspaceSnapshot!(sessionCtx)
+            : undefined,
+          compactMessages: builders.compactMessages,
+        },
+        state,
+      );
     },
 
     buildTransformContext(ctx: CapabilityBuildContext) {
@@ -128,25 +131,28 @@ export function memoryContext(
       };
       const state = getState(ctx);
 
-      return createDefaultCapabilityTransformContext({
-        tenantId: ctx.tenantId,
-        userId: ctx.userId,
-        sessionId: ctx.sessionId,
-        includeSkillsContext: opts?.includeSkillsContext ?? true,
-        delegateSkillsToSubAgent: builders.delegateSkillsToSubAgent ?? false,
-        cacheTtlMs: opts?.cacheTtlMs,
-        buildMemoryIndex: () => builders.buildMemoryIndex(sessionCtx),
-        listKnowledgeMetadatas: builders.listKnowledgeMetadatas
-          ? () => builders.listKnowledgeMetadatas!(sessionCtx)
-          : () => Promise.resolve([]),
-        listSkills: builders.listSkills
-          ? () => builders.listSkills!(sessionCtx)
-          : () => Promise.resolve([]),
-        listWorkspaceSnapshot: builders.listWorkspaceSnapshot
-          ? () => builders.listWorkspaceSnapshot!(sessionCtx)
-          : undefined,
-        compactMessages: builders.compactMessages,
-      }, state);
+      return createDefaultCapabilityTransformContext(
+        {
+          tenantId: ctx.tenantId,
+          userId: ctx.userId,
+          sessionId: ctx.sessionId,
+          includeSkillsContext: opts?.includeSkillsContext ?? true,
+          delegateSkillsToSubAgent: builders.delegateSkillsToSubAgent ?? false,
+          cacheTtlMs: opts?.cacheTtlMs,
+          buildMemoryIndex: () => builders.buildMemoryIndex(sessionCtx),
+          listKnowledgeMetadatas: builders.listKnowledgeMetadatas
+            ? () => builders.listKnowledgeMetadatas!(sessionCtx)
+            : () => Promise.resolve([]),
+          listSkills: builders.listSkills
+            ? () => builders.listSkills!(sessionCtx)
+            : () => Promise.resolve([]),
+          listWorkspaceSnapshot: builders.listWorkspaceSnapshot
+            ? () => builders.listWorkspaceSnapshot!(sessionCtx)
+            : undefined,
+          compactMessages: builders.compactMessages,
+        },
+        state,
+      );
     },
   };
 }

--- a/packages/capabilities/src/memory/messages.ts
+++ b/packages/capabilities/src/memory/messages.ts
@@ -4,9 +4,8 @@
  */
 
 import type { KBMetadata } from "@/knowledge/types.js";
-import type { MemoryIndex, MemoryIndexEntry } from "@agentrail/core";
-import type { UserMessage } from "@agentrail/core";
 import type { SkillMeta } from "@/skills/types.js";
+import type { MemoryIndex, MemoryIndexEntry, UserMessage } from "@agentrail/core";
 
 /** Creates a user-scoped identity hint message for default hosted profiles. */
 export function makeUserIdentityMessage(

--- a/packages/capabilities/src/memory/types.ts
+++ b/packages/capabilities/src/memory/types.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { ContextProvider, MemoryIndex, Message } from "@agentrail/core";
 import type { KBMetadata } from "@/knowledge/types.js";
 import type { SkillMeta } from "@/skills/types.js";
+import type { ContextProvider, MemoryIndex, Message } from "@agentrail/core";
 
 /** Request-scoped data needed to build default capability context messages. */
 export interface DefaultCapabilityContextOptions {

--- a/packages/capabilities/src/orchestration/descriptor.ts
+++ b/packages/capabilities/src/orchestration/descriptor.ts
@@ -3,15 +3,19 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
-import type { CreateManagedAgentInput, ManagedAgentInstance, OrchestrationManager } from "@/orchestration/orchestration-manager.js";
+import type {
+  CreateManagedAgentInput,
+  ManagedAgentInstance,
+  OrchestrationManager,
+} from "@/orchestration/orchestration-manager.js";
 import {
   createCloseAgentTool,
   createSendInputTool,
   createSpawnAgentTool,
   createWaitAgentTool,
 } from "@/orchestration/tools/index.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
+import type { SessionRef } from "@agentrail/core";
 
 /**
  * Minimal registry interface for resolving session-scoped orchestration managers.
@@ -120,26 +124,27 @@ export function orchestration(
         });
       }
 
-      const getRunId = "manager" in registryOrOpts
-        ? async () => {
-            const activeRun = Object.values(om.getSnapshot().runs).find(
-              (r) => r.status === "running",
-            );
-            if (!activeRun) {
-              throw new Error(
-                `orchestration() capability: spawn_agent was called but no active run exists in the manager. ` +
-                  `Ensure manager.startRun() has been called before spawning agents.`,
+      const getRunId =
+        "manager" in registryOrOpts
+          ? async () => {
+              const activeRun = Object.values(om.getSnapshot().runs).find(
+                (r) => r.status === "running",
               );
+              if (!activeRun) {
+                throw new Error(
+                  `orchestration() capability: spawn_agent was called but no active run exists in the manager. ` +
+                    `Ensure manager.startRun() has been called before spawning agents.`,
+                );
+              }
+              return activeRun.id;
             }
-            return activeRun.id;
-          }
-        : () =>
-            (registryOrOpts as OrchestrationRegistryLike).ensureActiveRunId({
-              tenantId: ctx.tenantId,
-              userId: ctx.userId,
-              sessionId: ctx.sessionId,
-              sessionRef: ctx.sessionRef,
-            });
+          : () =>
+              (registryOrOpts as OrchestrationRegistryLike).ensureActiveRunId({
+                tenantId: ctx.tenantId,
+                userId: ctx.userId,
+                sessionId: ctx.sessionId,
+                sessionRef: ctx.sessionRef,
+              });
 
       return [
         createSpawnAgentTool(om, getRunId),

--- a/packages/capabilities/src/orchestration/orchestration-manager-helpers.ts
+++ b/packages/capabilities/src/orchestration/orchestration-manager-helpers.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { randomUUID } from "node:crypto";
 import type {
   AgentInputEnvelope,
   ManagedAgentDeliveryResult,
@@ -12,6 +11,7 @@ import type {
   WaitCondition,
   WaitMatch,
 } from "@/orchestration/types.js";
+import { randomUUID } from "node:crypto";
 
 /** Normalizes a wait input so omitted fields are filled with stable defaults. */
 export function normalizeWaitInput(input: WaitAgentInput): WaitAgentInput {
@@ -92,6 +92,7 @@ export function normalizeDeliveryResult(
       outcome: result.outcome,
       outputText: result.outputText,
       error: result.error,
+      toolCalls: result.toolCalls,
     };
   }
 

--- a/packages/capabilities/src/orchestration/orchestration-manager.ts
+++ b/packages/capabilities/src/orchestration/orchestration-manager.ts
@@ -709,6 +709,7 @@ export class OrchestrationManager {
                 outcome: primaryAgent.lastJob.outcome,
                 outputText: primaryAgent.lastJob.outputText,
                 error: primaryAgent.lastJob.error,
+                toolCalls: primaryAgent.lastJob.toolCalls,
               },
             }
           : {}),
@@ -937,6 +938,7 @@ export class OrchestrationManager {
           outcome: deliveryResult.outcome,
           outputText: deliveryResult.outputText,
           error: deliveryResult.error,
+          toolCalls: deliveryResult.toolCalls,
         },
       } as const;
 
@@ -1136,6 +1138,7 @@ export class OrchestrationManager {
         outcome: result.outcome,
         outputText: result.outputText,
         error: result.error,
+        toolCalls: result.toolCalls,
       },
     });
 

--- a/packages/capabilities/src/orchestration/orchestration-store.ts
+++ b/packages/capabilities/src/orchestration/orchestration-store.ts
@@ -3,15 +3,18 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { recoverOrchestrationState, type RecoveredOrchestrationState } from "@/orchestration/recovery.js";
+import {
+  recoverOrchestrationState,
+  type RecoveredOrchestrationState,
+} from "@/orchestration/recovery.js";
 import type {
   OrchestrationEvent,
   OrchestrationMailboxEvent,
   OrchestrationMailboxState,
   OrchestrationSnapshot,
 } from "@/orchestration/types.js";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
 const ORCHESTRATION_DIRECTORY = "orchestration";
 const EVENTS_FILE = "events.jsonl";

--- a/packages/capabilities/src/orchestration/persistence.ts
+++ b/packages/capabilities/src/orchestration/persistence.ts
@@ -3,9 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import { resolveSessionRef } from "@agentrail/core";
-import path from "node:path";
 import { createFilesystemOrchestrationStore } from "@/orchestration/orchestration-store.js";
 import type { RecoveredOrchestrationState } from "@/orchestration/recovery.js";
 import type {
@@ -14,6 +11,9 @@ import type {
   OrchestrationMailboxState,
   OrchestrationSnapshot,
 } from "@/orchestration/types.js";
+import type { SessionRef } from "@agentrail/core";
+import { resolveSessionRef } from "@agentrail/core";
+import path from "node:path";
 
 export interface OrchestrationPersistence {
   appendEvent(event: OrchestrationEvent): Promise<void>;

--- a/packages/capabilities/src/orchestration/tools/close-agent.ts
+++ b/packages/capabilities/src/orchestration/tools/close-agent.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { Type, tool } from "@agentrail/core";
 import type { OrchestrationManager } from "@/orchestration/orchestration-manager.js";
 import type { OrchestrationAgent } from "@/orchestration/types.js";
+import { Type, tool } from "@agentrail/core";
 
 function formatCloseResult(agent: OrchestrationAgent, reason?: string): string {
   return JSON.stringify({

--- a/packages/capabilities/src/orchestration/tools/send-input.ts
+++ b/packages/capabilities/src/orchestration/tools/send-input.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { Type, tool } from "@agentrail/core";
 import type { OrchestrationManager } from "@/orchestration/orchestration-manager.js";
+import { Type, tool } from "@agentrail/core";
 
 function formatSendInputResult(inputId: string, agentId: string): string {
   return JSON.stringify({

--- a/packages/capabilities/src/orchestration/tools/spawn-agent.ts
+++ b/packages/capabilities/src/orchestration/tools/spawn-agent.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { Type, tool } from "@agentrail/core";
 import type { OrchestrationManager } from "@/orchestration/orchestration-manager.js";
 import type { OrchestrationAgent } from "@/orchestration/types.js";
+import { Type, tool } from "@agentrail/core";
 
 function formatSpawnResult(agent: OrchestrationAgent): string {
   return JSON.stringify({

--- a/packages/capabilities/src/orchestration/tools/wait-agent.ts
+++ b/packages/capabilities/src/orchestration/tools/wait-agent.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { Type, tool } from "@agentrail/core";
 import type { OrchestrationManager } from "@/orchestration/orchestration-manager.js";
 import type { WaitCondition } from "@/orchestration/types.js";
+import { Type, tool } from "@agentrail/core";
 
 function formatWaitResult(wait: WaitCondition): string {
   return JSON.stringify({
@@ -14,6 +14,7 @@ function formatWaitResult(wait: WaitCondition): string {
     status: wait.status,
     kind: wait.kind,
     match: wait.match ?? "all",
+    ...(wait.resolution ? { resolution: wait.resolution } : {}),
   });
 }
 

--- a/packages/capabilities/src/orchestration/types.ts
+++ b/packages/capabilities/src/orchestration/types.ts
@@ -5,6 +5,20 @@
 
 import type { ToolResultContent } from "@agentrail/core";
 
+/**
+ * A JSON-serializable value.
+ * Constraining `details` to this type ensures orchestration persistence
+ * (which uses bare JSON.stringify) never receives non-serializable payloads
+ * such as BigInt or circular references.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 /** Lifecycle status for an orchestration run. */
 export type RunStatus = "running" | "completed" | "failed";
 
@@ -36,7 +50,8 @@ export interface AgentToolCallRecord {
   output:
     | {
         content: ToolResultContent[];
-        details?: unknown;
+        /** JSON-safe snapshot of the tool's machine-readable payload. */
+        details?: JsonValue;
       }
     | undefined;
 }

--- a/packages/capabilities/src/orchestration/types.ts
+++ b/packages/capabilities/src/orchestration/types.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolResultContent } from "@agentrail/core";
+
 /** Lifecycle status for an orchestration run. */
 export type RunStatus = "running" | "completed" | "failed";
 
@@ -18,6 +20,27 @@ export type WaitMatch = "any" | "all";
 /** Final outcome recorded for one managed-agent job. */
 export type AgentJobOutcome = "completed" | "failed" | "cancelled" | "timed_out";
 
+/** A single tool call made by a sub-agent, including its input and output. */
+export interface AgentToolCallRecord {
+  /** Provider-assigned identifier for this tool call. */
+  toolCallId: string;
+  /** Name of the tool that was invoked. */
+  toolName: string;
+  /** Parsed arguments supplied by the model. */
+  input: Record<string, unknown>;
+  /**
+   * Result returned by the tool.
+   * `content` carries the model-visible text/image blocks.
+   * `details` carries the machine-readable structured payload preserved for host code.
+   */
+  output:
+    | {
+        content: ToolResultContent[];
+        details?: unknown;
+      }
+    | undefined;
+}
+
 /** Recorded output for one completed managed-agent job. */
 export interface OrchestrationAgentJob {
   jobId: string;
@@ -25,6 +48,8 @@ export interface OrchestrationAgentJob {
   outcome: AgentJobOutcome;
   outputText?: string;
   error?: string;
+  /** Tool calls made by the sub-agent during this job, in execution order. */
+  toolCalls?: AgentToolCallRecord[];
   completedAt: string;
 }
 
@@ -133,6 +158,8 @@ export interface ManagedAgentDeliveryResult {
   outcome: AgentJobOutcome;
   outputText?: string;
   error?: string;
+  /** Tool calls made by the sub-agent during this job, in execution order. */
+  toolCalls?: AgentToolCallRecord[];
 }
 
 /** Mailbox events persisted separately for durable agent input delivery. */

--- a/packages/capabilities/src/orchestration/worker/agent-runtime.ts
+++ b/packages/capabilities/src/orchestration/worker/agent-runtime.ts
@@ -3,9 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import type { Message, RuntimeTool, TransformContextFn } from "@agentrail/core";
 import type { CreateManagedAgentInput } from "@/orchestration/orchestration-manager.js";
+import type { Message, RuntimeTool, SessionRef, TransformContextFn } from "@agentrail/core";
 
 /** Provider/model selection used by a sub-agent worker runtime. */
 export interface ModelConfig {

--- a/packages/capabilities/src/orchestration/worker/subagent-process.ts
+++ b/packages/capabilities/src/orchestration/worker/subagent-process.ts
@@ -3,9 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import { fork } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import type {
   CreateManagedAgentInput,
   ManagedAgentEventHandlers,
@@ -13,6 +10,9 @@ import type {
 } from "@/orchestration/orchestration-manager.js";
 import type { AgentInputEnvelope, ManagedAgentDeliveryResult } from "@/orchestration/types.js";
 import type { SubagentWorkerConfig } from "@/orchestration/worker/agent-runtime.js";
+import type { SessionRef } from "@agentrail/core";
+import { fork } from "node:child_process";
+import { randomUUID } from "node:crypto";
 
 interface WorkerReadyMessage {
   type: "ready";

--- a/packages/capabilities/src/orchestration/worker/subagent-worker.ts
+++ b/packages/capabilities/src/orchestration/worker/subagent-worker.ts
@@ -3,11 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { resolveSessionRef } from "@agentrail/core";
-import { defineAgent, type Message } from "@agentrail/core";
-import { join } from "node:path";
 import {
   type AgentInputEnvelope,
+  type AgentToolCallRecord,
   type CreateManagedAgentInput,
   type ManagedAgentDeliveryResult,
   type OrchestrationMailboxState,
@@ -25,6 +23,14 @@ import {
   type WorkerMessage,
   type WorkerRunTurnMessage,
 } from "@/orchestration/worker/worker-messages.js";
+import {
+  defineAgent,
+  isAssistantMessage,
+  isToolResultMessage,
+  resolveSessionRef,
+  type Message,
+} from "@agentrail/core";
+import { join } from "node:path";
 
 /** Dependencies required to bootstrap a managed sub-agent worker process. */
 export interface WorkerOptions {
@@ -255,6 +261,7 @@ async function runTurn(requestId?: string): Promise<ManagedAgentDeliveryResult |
       consumedInputIds: inputs.map((input) => input.id),
       outcome: "completed",
       outputText: result.outputText,
+      toolCalls: result.toolCalls,
     };
   } catch (error) {
     try {
@@ -279,16 +286,42 @@ async function runTurn(requestId?: string): Promise<ManagedAgentDeliveryResult |
   }
 }
 
+function extractToolCallRecords(messages: Message[]): AgentToolCallRecord[] {
+  const outputs = new Map<string, NonNullable<AgentToolCallRecord["output"]>>();
+  for (const msg of messages) {
+    if (isToolResultMessage(msg)) {
+      outputs.set(msg.toolCallId, { content: msg.content, details: msg.details });
+    }
+  }
+  const records: AgentToolCallRecord[] = [];
+  for (const msg of messages) {
+    if (isAssistantMessage(msg)) {
+      for (const block of msg.content) {
+        if (block.type === "toolCall") {
+          records.push({
+            toolCallId: block.id,
+            toolName: block.name,
+            input: block.arguments,
+            output: outputs.get(block.id),
+          });
+        }
+      }
+    }
+  }
+  return records;
+}
+
 async function executeTurn(
   currentState: WorkerState,
   inputs: AgentInputEnvelope[],
   agent: ReturnType<typeof defineAgent>,
   runtime: SubAgentRuntime,
-): Promise<{ outputText: string; messages: Message[] }> {
+): Promise<{ outputText: string; messages: Message[]; toolCalls: AgentToolCallRecord[] }> {
   if (currentState.workerConfig.fakeExecution === "echo") {
     return {
       outputText: inputs.map((input) => String(input.payload.prompt ?? input.id)).join("\n"),
       messages: [],
+      toolCalls: [],
     };
   }
 
@@ -307,6 +340,7 @@ async function executeTurn(
   return {
     outputText: result.text,
     messages: result.messages,
+    toolCalls: extractToolCallRecords(result.messages),
   };
 }
 

--- a/packages/capabilities/src/orchestration/worker/subagent-worker.ts
+++ b/packages/capabilities/src/orchestration/worker/subagent-worker.ts
@@ -7,6 +7,7 @@ import {
   type AgentInputEnvelope,
   type AgentToolCallRecord,
   type CreateManagedAgentInput,
+  type JsonValue,
   type ManagedAgentDeliveryResult,
   type OrchestrationMailboxState,
 } from "@/orchestration/index.js";
@@ -286,11 +287,25 @@ async function runTurn(requestId?: string): Promise<ManagedAgentDeliveryResult |
   }
 }
 
+/**
+ * Converts an arbitrary value to a JSON-safe representation.
+ * Non-serializable payloads (BigInt, circular references, class instances, etc.)
+ * are silently dropped rather than crashing the orchestration persistence layer.
+ */
+function toJsonSafe(value: unknown): JsonValue | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.parse(JSON.stringify(value)) as JsonValue;
+  } catch {
+    return undefined;
+  }
+}
+
 function extractToolCallRecords(messages: Message[]): AgentToolCallRecord[] | undefined {
   const outputs = new Map<string, NonNullable<AgentToolCallRecord["output"]>>();
   for (const msg of messages) {
     if (isToolResultMessage(msg)) {
-      outputs.set(msg.toolCallId, { content: msg.content, details: msg.details });
+      outputs.set(msg.toolCallId, { content: msg.content, details: toJsonSafe(msg.details) });
     }
   }
   const records: AgentToolCallRecord[] = [];

--- a/packages/capabilities/src/orchestration/worker/subagent-worker.ts
+++ b/packages/capabilities/src/orchestration/worker/subagent-worker.ts
@@ -286,7 +286,7 @@ async function runTurn(requestId?: string): Promise<ManagedAgentDeliveryResult |
   }
 }
 
-function extractToolCallRecords(messages: Message[]): AgentToolCallRecord[] {
+function extractToolCallRecords(messages: Message[]): AgentToolCallRecord[] | undefined {
   const outputs = new Map<string, NonNullable<AgentToolCallRecord["output"]>>();
   for (const msg of messages) {
     if (isToolResultMessage(msg)) {
@@ -308,7 +308,7 @@ function extractToolCallRecords(messages: Message[]): AgentToolCallRecord[] {
       }
     }
   }
-  return records;
+  return records.length > 0 ? records : undefined;
 }
 
 async function executeTurn(
@@ -316,12 +316,12 @@ async function executeTurn(
   inputs: AgentInputEnvelope[],
   agent: ReturnType<typeof defineAgent>,
   runtime: SubAgentRuntime,
-): Promise<{ outputText: string; messages: Message[]; toolCalls: AgentToolCallRecord[] }> {
+): Promise<{ outputText: string; messages: Message[]; toolCalls?: AgentToolCallRecord[] }> {
   if (currentState.workerConfig.fakeExecution === "echo") {
     return {
       outputText: inputs.map((input) => String(input.payload.prompt ?? input.id)).join("\n"),
       messages: [],
-      toolCalls: [],
+      toolCalls: undefined,
     };
   }
 

--- a/packages/capabilities/src/sandbox/tools/browser-action.ts
+++ b/packages/capabilities/src/sandbox/tools/browser-action.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const BROWSER_TIMEOUT_MS = 20_000;
 

--- a/packages/capabilities/src/sandbox/tools/browser-content.ts
+++ b/packages/capabilities/src/sandbox/tools/browser-content.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const BROWSER_TIMEOUT_MS = 15_000;
 

--- a/packages/capabilities/src/sandbox/tools/browser-navigate.ts
+++ b/packages/capabilities/src/sandbox/tools/browser-navigate.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const BROWSER_TIMEOUT_MS = 30_000;
 

--- a/packages/capabilities/src/sandbox/tools/browser-scroll.ts
+++ b/packages/capabilities/src/sandbox/tools/browser-scroll.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const BROWSER_TIMEOUT_MS = 15_000;
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-edit.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-edit.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { readFile, writeFile } from "node:fs/promises";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const toolDescription = `Performs exact string replacements in files inside the sandbox workspace.
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-glob.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-glob.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import fg from "fast-glob";
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
+import fg from "fast-glob";
 
 const toolDescription = `Find files in the sandbox workspace by glob pattern.
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-grep.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-grep.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const runRg = promisify(execFile);
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-python.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-python.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const TMP_DIR = "/workspace/.deep-research/tmp";

--- a/packages/capabilities/src/sandbox/tools/sandboxed-read.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-read.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { readFile } from "node:fs/promises";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const DEFAULT_READ_LINES = 100;
 const MAX_LINE_LENGTH = 1000;

--- a/packages/capabilities/src/sandbox/tools/sandboxed-write.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-write.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 
 const toolDescription = `Writes a file to the sandbox workspace.
 

--- a/packages/capabilities/src/skills/descriptor.ts
+++ b/packages/capabilities/src/skills/descriptor.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
-import { buildSkillTool } from "@/skills/skill-tools.js";
 import type { SkillManager } from "@/skills/skill-manager.js";
+import { buildSkillTool } from "@/skills/skill-tools.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 
 export interface SkillsOptions {
   /**

--- a/packages/capabilities/src/skills/skill-manager.ts
+++ b/packages/capabilities/src/skills/skill-manager.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { SkillConfig, SkillMeta } from "@/skills/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { SkillConfig, SkillMeta } from "@/skills/types.js";
 
 /**
  * Discovers and reads reusable skills stored beneath `{dataDir}/skills`.
@@ -100,7 +100,7 @@ export class SkillManager {
       if (frontmatter.name && frontmatter.name !== dirName) {
         console.warn(
           `[SkillManager] Skill "${dirName}": SKILL.md declares name "${frontmatter.name}" ` +
-          `but directory is "${dirName}". Using directory name.`,
+            `but directory is "${dirName}". Using directory name.`,
         );
       }
 
@@ -134,8 +134,14 @@ export class SkillManager {
       const key = line.slice(0, colonIdx).trim();
       const rawVal = line.slice(colonIdx + 1).trim();
       // Booleans
-      if (rawVal === "true") { result[key] = true; continue; }
-      if (rawVal === "false") { result[key] = false; continue; }
+      if (rawVal === "true") {
+        result[key] = true;
+        continue;
+      }
+      if (rawVal === "false") {
+        result[key] = false;
+        continue;
+      }
       // Strip surrounding quotes
       result[key] = rawVal.replace(/^["']|["']$/g, "");
     }

--- a/packages/capabilities/src/skills/skill-tools.ts
+++ b/packages/capabilities/src/skills/skill-tools.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { AssistantMessage, ModelConfig, RuntimeTool } from "@agentrail/core";
-import { defineAgent, extractText, isAgentEnd, tool, Type } from "@agentrail/core";
 import type { SkillManager } from "@/skills/skill-manager.js";
 import type { ExtendedSseEvent } from "@/skills/types.js";
+import type { AssistantMessage, ModelConfig, RuntimeTool } from "@agentrail/core";
+import { defineAgent, extractText, isAgentEnd, tool, Type } from "@agentrail/core";
 
 /**
  * Build the single `Skill` tool.

--- a/packages/capabilities/src/todo/descriptor.ts
+++ b/packages/capabilities/src/todo/descriptor.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 import { createTodoWriteTool } from "@/tools/index.js";
+import type { CapabilityBuildContext, CapabilityDescriptor } from "@/types.js";
 
 /**
  * Capability that gives the agent a persistent to-do list for tracking tasks

--- a/packages/capabilities/src/tools/glob.ts
+++ b/packages/capabilities/src/tools/glob.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import fg from "fast-glob";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
+import fg from "fast-glob";
 import path from "node:path";
 
 const toolDescription = `Find files by glob pattern.

--- a/packages/capabilities/src/tools/todo-write.ts
+++ b/packages/capabilities/src/tools/todo-write.ts
@@ -3,8 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { TodoStorage } from "@agentrail/core";
-import type { RuntimeTool } from "@agentrail/core";
+import type { RuntimeTool, TodoStorage } from "@agentrail/core";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { mkdir, readFile, writeFile } from "node:fs/promises";

--- a/packages/capabilities/src/tools/web-fetch.ts
+++ b/packages/capabilities/src/tools/web-fetch.ts
@@ -4,8 +4,8 @@
  */
 
 import { tool } from "@agentrail/core";
-import { Type } from "@sinclair/typebox";
 import { Readability } from "@mozilla/readability";
+import { Type } from "@sinclair/typebox";
 import { JSDOM } from "jsdom";
 import TurndownService from "turndown";
 
@@ -114,7 +114,9 @@ const parametersSchema = Type.Object({
 });
 
 function createTimedSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
-  return signal ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs);
+  return signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
+    : AbortSignal.timeout(timeoutMs);
 }
 
 function getFromCache<T>(cache: Map<string, CacheEntry<T>>, key: string): T | null {
@@ -127,7 +129,12 @@ function getFromCache<T>(cache: Map<string, CacheEntry<T>>, key: string): T | nu
   return entry.value;
 }
 
-function setCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T, ttlMs: number): void {
+function setCache<T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  value: T,
+  ttlMs: number,
+): void {
   cache.set(key, {
     value,
     expiresAt: Date.now() + ttlMs,
@@ -135,7 +142,11 @@ function setCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T, t
 }
 
 function normalizeWhitespace(text: string): string {
-  return text.replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 function normalizeFetchUrl(rawUrl: string): string {
@@ -182,7 +193,9 @@ function truncateIfNeeded(content: string, maxChars: number, trusted: boolean) {
 }
 
 function extractReadableMarkdown(source: string, url: string, contentType: string | null) {
-  const looksHtml = Boolean(contentType?.includes("text/html")) || /<html[\s>]|<body[\s>]|<article[\s>]/i.test(source);
+  const looksHtml =
+    Boolean(contentType?.includes("text/html")) ||
+    /<html[\s>]|<body[\s>]|<article[\s>]/i.test(source);
 
   if (!looksHtml) {
     return {
@@ -193,11 +206,7 @@ function extractReadableMarkdown(source: string, url: string, contentType: strin
 
   const dom = new JSDOM(source, { url });
   const article = new Readability(dom.window.document).parse();
-  const title = normalizeWhitespace(
-    article?.title ||
-      dom.window.document.title ||
-      url,
-  );
+  const title = normalizeWhitespace(article?.title || dom.window.document.title || url);
 
   const articleHtml = article?.content ?? dom.window.document.body?.innerHTML ?? "";
   const markdown = normalizeWhitespace(turndown.turndown(articleHtml));
@@ -295,7 +304,11 @@ export function createWebFetchTool(options: WebFetchToolOptions = {}) {
           }
 
           const source = await response.text();
-          const extracted = extractReadableMarkdown(source, finalUrl, response.headers.get("content-type"));
+          const extracted = extractReadableMarkdown(
+            source,
+            finalUrl,
+            response.headers.get("content-type"),
+          );
 
           if (!extracted.markdown) {
             return {
@@ -332,8 +345,7 @@ export function createWebFetchTool(options: WebFetchToolOptions = {}) {
           const message = error instanceof Error ? error.message : String(error);
           const isTimeout =
             error instanceof Error &&
-            (error.name === "TimeoutError" ||
-              /timed out|timeout/i.test(error.message));
+            (error.name === "TimeoutError" || /timed out|timeout/i.test(error.message));
 
           return {
             content: [{ type: "text" as const, text: `Error: ${message}` }],
@@ -376,7 +388,9 @@ export function createWebFetchTool(options: WebFetchToolOptions = {}) {
       }
 
       let fromExtractionCache = false;
-      const cachedExtraction = extractionCacheKey ? getFromCache(extractionCache, extractionCacheKey) : null;
+      const cachedExtraction = extractionCacheKey
+        ? getFromCache(extractionCache, extractionCacheKey)
+        : null;
       let extraction: CachedExtraction;
 
       if (cachedExtraction) {

--- a/packages/capabilities/src/tools/web-search.ts
+++ b/packages/capabilities/src/tools/web-search.ts
@@ -71,7 +71,9 @@ interface JinaSearchResult {
 }
 
 function createTimedSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
-  return signal ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs);
+  return signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
+    : AbortSignal.timeout(timeoutMs);
 }
 
 function normalizeWhitespace(text: string): string {
@@ -171,9 +173,7 @@ export function createTavilySearchProvider(
 }
 
 /** Creates a Brave-backed search provider adapter. */
-export function createBraveSearchProvider(
-  options: BraveSearchProviderOptions,
-): WebSearchProvider {
+export function createBraveSearchProvider(options: BraveSearchProviderOptions): WebSearchProvider {
   return {
     async search(query, searchOptions = {}) {
       const url = new URL("https://api.search.brave.com/res/v1/web/search");

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -3,6 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { KnowledgeManager } from "@/knowledge/index.js";
+import type { SandboxManager } from "@/sandbox/index.js";
+import type { SkillManager } from "@/skills/index.js";
+import type { WaitHandleRegistry } from "@/tools/index.js";
 import type {
   AgentrailSessionStore,
   ContextProvider,
@@ -11,10 +15,6 @@ import type {
   SessionRef,
   TransformContextFn,
 } from "@agentrail/core";
-import type { KnowledgeManager } from "@/knowledge/index.js";
-import type { SandboxManager } from "@/sandbox/index.js";
-import type { SkillManager } from "@/skills/index.js";
-import type { WaitHandleRegistry } from "@/tools/index.js";
 
 /**
  * Request-scoped context passed to `CapabilityDescriptor.buildTools` and

--- a/packages/capabilities/test/capability-descriptors.test.ts
+++ b/packages/capabilities/test/capability-descriptors.test.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect } from "vitest";
-import { filesystem } from "../src/filesystem/index.js";
+import { describe, expect, it } from "vitest";
 import { browser } from "../src/browser/index.js";
+import { filesystem } from "../src/filesystem/index.js";
 import type { CapabilityBuildContext } from "../src/types.js";
 
 // Minimal stub that satisfies the shape used by buildTools
@@ -26,9 +26,7 @@ describe("filesystem() capability descriptor", () => {
 
   it("throws a descriptive error when no sandboxManager is available", async () => {
     const cap = filesystem();
-    await expect(cap.buildTools(stubCtx(undefined))).rejects.toThrow(
-      /sandboxManager/,
-    );
+    await expect(cap.buildTools(stubCtx(undefined))).rejects.toThrow(/sandboxManager/);
   });
 
   it("accepts a sandboxManager via opts and does not throw during construction", () => {
@@ -61,9 +59,7 @@ describe("browser() capability descriptor", () => {
 
   it("throws a descriptive error when no sandboxManager is available", async () => {
     const cap = browser();
-    await expect(cap.buildTools(stubCtx(undefined))).rejects.toThrow(
-      /sandboxManager/,
-    );
+    await expect(cap.buildTools(stubCtx(undefined))).rejects.toThrow(/sandboxManager/);
   });
 
   it("prefers opts.sandboxManager over ctx.sandboxManager", async () => {

--- a/packages/capabilities/test/glob-tool.test.ts
+++ b/packages/capabilities/test/glob-tool.test.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/capabilities/test/subagent-tool-calls.test.ts
+++ b/packages/capabilities/test/subagent-tool-calls.test.ts
@@ -1,0 +1,300 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+/**
+ * Tests for the sub-agent toolCalls propagation chain (Issue #23).
+ *
+ * Covers:
+ * - normalizeDeliveryResult() passes toolCalls through
+ * - OrchestrationManager stores toolCalls in agent.lastJob after job completion
+ * - OrchestrationManager includes toolCalls in wait resolution
+ * - wait_agent formatWaitResult includes resolution (outputText + toolCalls)
+ */
+
+import { createSessionRef } from "@agentrail/core";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { normalizeDeliveryResult } from "../src/orchestration/orchestration-manager-helpers.js";
+import {
+  OrchestrationManager,
+  type OrchestrationAgentFactory,
+} from "../src/orchestration/orchestration-manager.js";
+import { createFilesystemOrchestrationPersistence } from "../src/orchestration/persistence.js";
+import { createWaitAgentTool } from "../src/orchestration/tools/wait-agent.js";
+import type { AgentInputEnvelope, AgentToolCallRecord } from "../src/orchestration/types.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function makeEnvelope(id = "input-1"): AgentInputEnvelope {
+  return {
+    id,
+    agentId: "agent-1",
+    payload: { prompt: "do something" },
+    queuedAt: new Date().toISOString(),
+  };
+}
+
+const SAMPLE_TOOL_CALLS: AgentToolCallRecord[] = [
+  {
+    toolCallId: "call-1",
+    toolName: "search",
+    input: { query: "hello world" },
+    output: {
+      content: [{ type: "text", text: "Results: ..." }],
+      details: { count: 3, urls: ["https://example.com"] },
+    },
+  },
+  {
+    toolCallId: "call-2",
+    toolName: "calculator",
+    input: { expression: "1 + 1" },
+    output: {
+      content: [{ type: "text", text: "2" }],
+      details: { result: 2 },
+    },
+  },
+];
+
+async function createManager() {
+  const dataDir = join(tmpdir(), `agentrail-test-${randomUUID()}`);
+  const sessionRef = createSessionRef("tenant-1", randomUUID());
+  const deliverInput = vi.fn();
+  const runtime: OrchestrationAgentFactory = {
+    createAgent: vi.fn().mockResolvedValue({ deliverInput, close: vi.fn() }),
+  };
+  const manager = await OrchestrationManager.create({
+    persistence: createFilesystemOrchestrationPersistence(dataDir, sessionRef),
+    runtime,
+  });
+  return { manager, deliverInput };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeDeliveryResult
+// ---------------------------------------------------------------------------
+
+describe("normalizeDeliveryResult", () => {
+  it("passes toolCalls through when present", () => {
+    const result = normalizeDeliveryResult(
+      makeEnvelope(),
+      {
+        jobId: "job-1",
+        consumedInputIds: ["input-1"],
+        outcome: "completed",
+        outputText: "done",
+        toolCalls: SAMPLE_TOOL_CALLS,
+      },
+      new Date().toISOString(),
+    );
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls![0].toolName).toBe("search");
+    expect(result.toolCalls![0].input).toEqual({ query: "hello world" });
+    const out0 = result.toolCalls![0].output as { content: unknown[]; details?: unknown };
+    expect(out0.details).toEqual({ count: 3, urls: ["https://example.com"] });
+    expect(result.toolCalls![1].toolName).toBe("calculator");
+  });
+
+  it("preserves undefined toolCalls when not present in result", () => {
+    const result = normalizeDeliveryResult(
+      makeEnvelope(),
+      {
+        jobId: "job-2",
+        consumedInputIds: ["input-1"],
+        outcome: "completed",
+        outputText: "done",
+      },
+      new Date().toISOString(),
+    );
+    expect(result.toolCalls).toBeUndefined();
+  });
+
+  it("falls back gracefully when result is void (error recovery path)", () => {
+    const result = normalizeDeliveryResult(makeEnvelope(), undefined, new Date().toISOString());
+    expect(result.outcome).toBe("completed");
+    expect(result.toolCalls).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OrchestrationManager – toolCalls stored in agent.lastJob
+// ---------------------------------------------------------------------------
+
+describe("OrchestrationManager – toolCalls in lastJob", () => {
+  it("stores toolCalls in agent.lastJob after a successful job", async () => {
+    const { manager, deliverInput } = await createManager();
+    const runId = randomUUID();
+    await manager.startRun({
+      runId,
+      initialTask: { id: randomUUID(), kind: "test", input: {} },
+    });
+    const agentId = "agent-tc-test";
+
+    await manager.spawnAgent({ id: agentId, runId, role: "researcher" });
+
+    deliverInput.mockResolvedValueOnce({
+      jobId: "job-tc-1",
+      consumedInputIds: ["input-1"],
+      outcome: "completed",
+      outputText: "Research complete",
+      toolCalls: SAMPLE_TOOL_CALLS,
+    });
+
+    await manager.sendInput({ id: "input-1", agentId, payload: { prompt: "research" } });
+
+    // waitForAgents blocks until delivery loop finishes and agent becomes idle.
+    await manager.waitForAgents({
+      id: "wait-tc-1",
+      agentId,
+      kind: "agent-idle",
+      description: "wait for job",
+    });
+
+    const agent = manager.getSnapshot().agents[agentId];
+    expect(agent?.lastJob?.toolCalls).toHaveLength(2);
+    expect(agent?.lastJob?.toolCalls![0].toolName).toBe("search");
+    expect(agent?.lastJob?.toolCalls![0].input).toEqual({ query: "hello world" });
+    const out = agent?.lastJob?.toolCalls![0].output as { details?: unknown };
+    expect(out?.details).toEqual({ count: 3, urls: ["https://example.com"] });
+    expect(agent?.lastJob?.toolCalls![1].toolName).toBe("calculator");
+    expect(agent?.lastJob?.outputText).toBe("Research complete");
+  });
+
+  it("stores undefined toolCalls when sub-agent made no tool calls", async () => {
+    const { manager, deliverInput } = await createManager();
+    const runId = randomUUID();
+    await manager.startRun({
+      runId,
+      initialTask: { id: randomUUID(), kind: "test", input: {} },
+    });
+    const agentId = "agent-no-tools";
+
+    await manager.spawnAgent({ id: agentId, runId, role: "writer" });
+
+    deliverInput.mockResolvedValueOnce({
+      jobId: "job-no-tools",
+      consumedInputIds: ["input-2"],
+      outcome: "completed",
+      outputText: "Plain text output",
+    });
+
+    await manager.sendInput({ id: "input-2", agentId, payload: { prompt: "write" } });
+
+    await manager.waitForAgents({
+      id: "wait-no-tools",
+      agentId,
+      kind: "agent-idle",
+      description: "wait for job",
+    });
+
+    const agent = manager.getSnapshot().agents[agentId];
+    expect(agent?.lastJob?.toolCalls).toBeUndefined();
+    expect(agent?.lastJob?.outputText).toBe("Plain text output");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OrchestrationManager – toolCalls in wait resolution
+// ---------------------------------------------------------------------------
+
+describe("OrchestrationManager – toolCalls in wait resolution", () => {
+  it("includes toolCalls in resolution.job when kind is agent-idle", async () => {
+    const { manager, deliverInput } = await createManager();
+    const runId = randomUUID();
+    await manager.startRun({
+      runId,
+      initialTask: { id: randomUUID(), kind: "test", input: {} },
+    });
+    const agentId = "agent-wait-res";
+
+    await manager.spawnAgent({ id: agentId, runId, role: "worker" });
+
+    deliverInput.mockResolvedValueOnce({
+      jobId: "job-wait-1",
+      consumedInputIds: ["input-3"],
+      outcome: "completed",
+      outputText: "Work done",
+      toolCalls: SAMPLE_TOOL_CALLS,
+    });
+
+    await manager.sendInput({ id: "input-3", agentId, payload: { prompt: "do work" } });
+
+    const wait = await manager.waitForAgents({
+      id: "wait-res-1",
+      agentId,
+      kind: "agent-idle",
+      description: "wait for result",
+    });
+
+    const job = (
+      wait.resolution as { job?: { toolCalls?: AgentToolCallRecord[]; outputText?: string } }
+    )?.job;
+    expect(job?.outputText).toBe("Work done");
+    expect(job?.toolCalls).toHaveLength(2);
+    expect(job?.toolCalls![0].toolName).toBe("search");
+    expect(job?.toolCalls![1].toolName).toBe("calculator");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wait-agent tool – formatWaitResult includes resolution
+// ---------------------------------------------------------------------------
+
+describe("wait-agent formatWaitResult", () => {
+  it("includes resolution in the JSON content when wait resolves with a job", async () => {
+    const { manager, deliverInput } = await createManager();
+    const runId = randomUUID();
+    await manager.startRun({
+      runId,
+      initialTask: { id: randomUUID(), kind: "test", input: {} },
+    });
+    const agentId = "agent-fmt-test";
+
+    await manager.spawnAgent({ id: agentId, runId, role: "worker" });
+
+    deliverInput.mockResolvedValueOnce({
+      jobId: "job-fmt-1",
+      consumedInputIds: ["input-4"],
+      outcome: "completed",
+      outputText: "Output text here",
+      toolCalls: SAMPLE_TOOL_CALLS,
+    });
+
+    await manager.sendInput({ id: "input-4", agentId, payload: { prompt: "go" } });
+
+    // Drain the delivery so agent is idle before calling the wait_agent tool.
+    await manager.waitForAgents({
+      id: "pre-wait",
+      agentId,
+      kind: "agent-idle",
+      description: "wait for idle",
+    });
+
+    // Invoke the wait_agent tool — agent is already idle, so it resolves immediately.
+    const waitTool = createWaitAgentTool(manager);
+    const result = await waitTool.execute("call-wait", {
+      id: "wait-fmt-1",
+      agentId,
+      kind: "agent-idle",
+      description: "wait",
+    });
+
+    const text = (result.content as Array<{ type: string; text?: string }>)[0]?.text ?? "";
+    const parsed = JSON.parse(text) as {
+      waitId: string;
+      resolution?: {
+        job?: { outputText?: string; toolCalls?: AgentToolCallRecord[] };
+      };
+    };
+
+    expect(parsed.resolution?.job?.outputText).toBe("Output text here");
+    expect(parsed.resolution?.job?.toolCalls).toHaveLength(2);
+    expect(parsed.resolution?.job?.toolCalls![0].toolName).toBe("search");
+  });
+});

--- a/packages/capabilities/test/web-fetch.test.ts
+++ b/packages/capabilities/test/web-fetch.test.ts
@@ -13,11 +13,15 @@ describe("createWebFetchTool", () => {
   });
 
   it("converts HTML into readable markdown", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("<html><head><title>Example</title></head><body><article><h1>Hello</h1><p>World</p></article></body></html>", {
-        status: 200,
-        headers: { "content-type": "text/html" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          "<html><head><title>Example</title></head><body><article><h1>Hello</h1><p>World</p></article></body></html>",
+          {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -36,11 +40,12 @@ describe("createWebFetchTool", () => {
   });
 
   it("upgrades http URLs to https before fetching", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("plain text", {
-        status: 200,
-        headers: { "content-type": "text/plain" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("plain text", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -51,11 +56,12 @@ describe("createWebFetchTool", () => {
   });
 
   it("reuses the page cache for repeated fetches", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("<html><body><article><p>cached page</p></article></body></html>", {
-        status: 200,
-        headers: { "content-type": "text/html" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("<html><body><article><p>cached page</p></article></body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -71,11 +77,12 @@ describe("createWebFetchTool", () => {
   });
 
   it("reuses extraction cache for repeated query extraction", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("<html><body><article><p>OpenAI builds models.</p></article></body></html>", {
-        status: 200,
-        headers: { "content-type": "text/html" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("<html><body><article><p>OpenAI builds models.</p></article></body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -120,8 +127,9 @@ describe("createWebFetchTool", () => {
   });
 
   it("does not cache HTTP failures", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("forbidden", { status: 403, headers: { "content-type": "text/plain" } }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("forbidden", { status: 403, headers: { "content-type": "text/plain" } }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/packages/capabilities/test/web-search.test.ts
+++ b/packages/capabilities/test/web-search.test.ts
@@ -36,20 +36,21 @@ describe("createWebSearchTool", () => {
   });
 
   it("maps Tavily responses into generic search results", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          results: [
-            {
-              title: "OpenAI",
-              url: "https://openai.com",
-              content: "AI research and products",
-              published_date: "2026-04-09",
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: "OpenAI",
+                url: "https://openai.com",
+                content: "AI research and products",
+                published_date: "2026-04-09",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -69,22 +70,23 @@ describe("createWebSearchTool", () => {
   });
 
   it("maps Brave responses into generic search results", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          web: {
-            results: [
-              {
-                title: "OpenAI",
-                url: "https://openai.com",
-                description: "AI research and deployment company",
-                page_age: "2026-04-09",
-              },
-            ],
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            web: {
+              results: [
+                {
+                  title: "OpenAI",
+                  url: "https://openai.com",
+                  description: "AI research and deployment company",
+                  page_age: "2026-04-09",
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -108,20 +110,21 @@ describe("createWebSearchTool", () => {
   });
 
   it("maps Jina responses into generic search results", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          data: [
-            {
-              title: "OpenAI",
-              url: "https://openai.com",
-              content: "Search snippet",
-              publishedAt: "2026-04-09",
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                title: "OpenAI",
+                url: "https://openai.com",
+                content: "Search snippet",
+                publishedAt: "2026-04-09",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/packages/capabilities/vitest.config.ts
+++ b/packages/capabilities/vitest.config.ts
@@ -4,8 +4,8 @@
  */
 
 import { resolve } from "node:path";
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,6 +24,7 @@ pnpm agentrail config validate --format json
 - `runCreate(args)` — programmatic entrypoint used by `@agentrail/create-agentrail-app`.
 
 Reference:
+
 - `https://agentrail.run/guides/quickstart`
 - `https://agentrail.run/guides/deployment`
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { access, constants, stat } from "node:fs/promises";
 import { loadAgentrailConfig } from "@agentrail/app";
+import { access, constants, stat } from "node:fs/promises";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -197,9 +197,7 @@ export async function runDoctorChecks(opts: DoctorOptions): Promise<CheckResult[
 
   // ── 5. Worker path (conditional) ───────────────────────────────────────────
   const orchestrationCfg = config.orchestration?.subagent;
-  const needsWorker =
-    orchestrationCfg !== undefined &&
-    orchestrationCfg.fakeExecution !== "echo";
+  const needsWorker = orchestrationCfg !== undefined && orchestrationCfg.fakeExecution !== "echo";
 
   if (needsWorker) {
     if (opts.workerPath) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,9 +4,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { runConfigValidate } from "./commands/config-validate.js";
 import { runCreate } from "./commands/create.js";
 import { runDoctor } from "./commands/doctor.js";
-import { runConfigValidate } from "./commands/config-validate.js";
 
 // ─── Public API (used by create-agentrail-app wrapper) ───────────────────────
 export { runCreate } from "./commands/create.js";

--- a/packages/cli/templates/minimal/src/agent.ts
+++ b/packages/cli/templates/minimal/src/agent.ts
@@ -1,5 +1,5 @@
-import { defineAgent, isRuntimeError, type Message } from "@agentrail/core";
 import { defineProfile } from "@agentrail/app";
+import { defineAgent, isRuntimeError, type Message } from "@agentrail/core";
 // To add filesystem, browser, knowledge, or orchestration capabilities install
 // @agentrail/capabilities and import the relevant factory functions:
 //   import { filesystem, knowledge, browser } from "@agentrail/capabilities";

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -17,7 +17,5 @@
     }
   },
   "include": ["src"],
-  "plugins": [
-    { "transform": "tsc-alias" }
-  ]
+  "plugins": [{ "transform": "tsc-alias" }]
 }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,8 +4,8 @@
  */
 
 import { resolve } from "node:path";
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -47,6 +47,7 @@ const agent = defineAgent({
 - `Type` — TypeBox export for schemas used by tools and typed data.
 
 Reference:
+
 - `https://agentrail.run/concepts/agents`
 - `https://agentrail.run/reference/prompt-sdk`
 

--- a/packages/core/src/agent/agent-impl.ts
+++ b/packages/core/src/agent/agent-impl.ts
@@ -3,7 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { randomUUID } from "node:crypto";
+import { agentLoop } from "@/agent/agent-loop.js";
+import type { AgentConfig, ModelConfig } from "@/agent/define-agent.js";
 import type { Agent } from "@/interfaces/agent.js";
 import type { LlmClient } from "@/interfaces/llm-client.js";
 import { DefaultLlmClient } from "@/llm/default-llm-client.js";
@@ -15,19 +16,14 @@ import type {
   ReactiveCompactionController,
   TransformContextFn,
 } from "@/types/agent.types.js";
-import {
-  createEmptyAssistantMessage,
-  extractText,
-  extractToolCalls,
-} from "@/types/agent.types.js";
+import { createEmptyAssistantMessage, extractText, extractToolCalls } from "@/types/agent.types.js";
 import type { UserContent } from "@/types/content.types.js";
 import type { Message, StopReason, UserMessage } from "@/types/message.types.js";
 import { isAssistantMessage, isUserMessage } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
 import type { RuntimeTool } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
-import { agentLoop } from "@/agent/agent-loop.js";
-import type { AgentConfig, ModelConfig } from "@/agent/define-agent.js";
+import { randomUUID } from "node:crypto";
 
 // ============================================================================
 // ============================================================================

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ModelConfig } from "@/agent/define-agent.js";
 import { executeToolCalls } from "@/executor/tool-executor.js";
 import type { LlmClient, LlmRequest } from "@/interfaces/llm-client.js";
 import { EventStream } from "@/llm/event-stream.js";
@@ -15,7 +16,6 @@ import type { AssistantMessage, Message, ToolResultMessage } from "@/types/messa
 import type { RuntimeEvent } from "@/types/result.types.js";
 import type { RuntimeTool, ToolInterceptor } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
-import type { ModelConfig } from "@/agent/define-agent.js";
 
 // ============================================================================
 // ============================================================================
@@ -238,19 +238,14 @@ async function runLoop(
       stream.push({ type: "turn.complete", message, toolResults });
 
       const compactedMessages = config.reactiveCompaction
-        ? await maybeApplyReactiveCompaction(
-            currentMessages,
-            config.reactiveCompaction,
-            stream,
-            {
-              turnCount,
-              usage: message.usage,
-              latestMessage: message,
-              protectedMessages,
-              records: compactionRecords,
-              trigger: "proactive",
-            },
-          )
+        ? await maybeApplyReactiveCompaction(currentMessages, config.reactiveCompaction, stream, {
+            turnCount,
+            usage: message.usage,
+            latestMessage: message,
+            protectedMessages,
+            records: compactionRecords,
+            trigger: "proactive",
+          })
         : null;
       if (compactedMessages) {
         currentMessages.splice(0, currentMessages.length, ...compactedMessages);

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -9,7 +9,6 @@ import { validateToolArguments, validateToolInput } from "@/llm/utils/validation
 import type { TextContent, ToolCall } from "@/types/content.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
-import type { Static, TSchema } from "@sinclair/typebox";
 import type {
   RuntimeTool,
   ToolInterceptor,
@@ -17,6 +16,7 @@ import type {
   ToolSignalEvent,
   ValidationResult,
 } from "@/types/tool.types.js";
+import type { Static, TSchema } from "@sinclair/typebox";
 
 /** Result produced by executing a single tool call against the runtime registry. */
 export interface ToolExecutionResult {
@@ -138,7 +138,10 @@ export async function executeToolCalls(
     if (tool.validate) {
       let vr: ValidationResult;
       try {
-        vr = await tool.validate(effectiveArgs as Static<TSchema>, { toolCallId: toolCall.id, signal });
+        vr = await tool.validate(effectiveArgs as Static<TSchema>, {
+          toolCallId: toolCall.id,
+          signal,
+        });
       } catch (e) {
         vr = { valid: false, reason: e instanceof Error ? e.message : String(e) };
       }
@@ -273,8 +276,20 @@ function rejectToolCall(
     content: [{ type: "text", text: errorText } as TextContent],
     details: {},
   };
-  stream.push({ type: "tool.before", toolCallId: toolCall.id, toolName: toolCall.name, args, rawArgs });
-  stream.push({ type: "tool.after", toolCallId: toolCall.id, toolName: toolCall.name, result: errorResult, isError: true });
+  stream.push({
+    type: "tool.before",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    args,
+    rawArgs,
+  });
+  stream.push({
+    type: "tool.after",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    result: errorResult,
+    isError: true,
+  });
   const msg = buildToolResultMessage(toolCall, errorResult, true);
   results.push(msg);
   stream.push({ type: "message.start", message: msg });

--- a/packages/core/src/interfaces/agent.ts
+++ b/packages/core/src/interfaces/agent.ts
@@ -3,12 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type {
-  AgentInput,
-  AgentResult,
-  AgentRunOptions,
-  AgentStream,
-} from "@/types/agent.types.js";
+import type { AgentInput, AgentResult, AgentRunOptions, AgentStream } from "@/types/agent.types.js";
 import type { RuntimeTool } from "@/types/tool.types.js";
 
 /**

--- a/packages/core/src/llm/providers/anthropic-llm-provider.ts
+++ b/packages/core/src/llm/providers/anthropic-llm-provider.ts
@@ -3,13 +3,13 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import Anthropic from "@anthropic-ai/sdk";
 import type { LlmProvider, LlmRequest, LlmStream } from "@/interfaces/llm-client.js";
-import type { ImageContent, TextContent } from "@/types/content.types.js";
-import type { AssistantMessage, StopReason, ToolResultMessage } from "@/types/message.types.js";
 import { AssistantMessageEventStream } from "@/llm/event-stream.js";
 import { parseStreamingJson } from "@/llm/utils/json-parse.js";
 import { sanitizeSurrogates } from "@/llm/utils/sanitize-unicode.js";
+import type { ImageContent, TextContent } from "@/types/content.types.js";
+import type { AssistantMessage, StopReason, ToolResultMessage } from "@/types/message.types.js";
+import Anthropic from "@anthropic-ai/sdk";
 
 type MutableBlock = {
   type: "text" | "thinking" | "toolCall";

--- a/packages/core/src/llm/providers/openai-llm-provider.ts
+++ b/packages/core/src/llm/providers/openai-llm-provider.ts
@@ -3,13 +3,13 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import OpenAI from "openai";
 import type { LlmProvider, LlmRequest, LlmStream } from "@/interfaces/llm-client.js";
-import type { TextContent, ToolCall } from "@/types/content.types.js";
-import type { AssistantMessage, StopReason } from "@/types/message.types.js";
 import { AssistantMessageEventStream } from "@/llm/event-stream.js";
 import { parseStreamingJson } from "@/llm/utils/json-parse.js";
 import { sanitizeSurrogates } from "@/llm/utils/sanitize-unicode.js";
+import type { TextContent, ToolCall } from "@/types/content.types.js";
+import type { AssistantMessage, StopReason } from "@/types/message.types.js";
+import OpenAI from "openai";
 
 type MutableBlock = {
   type: "text" | "thinking" | "toolCall";

--- a/packages/core/src/llm/utils/validation.ts
+++ b/packages/core/src/llm/utils/validation.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Static, TSchema } from "@sinclair/typebox";
-import { Value } from "@sinclair/typebox/value";
 import { ToolValidationError } from "@/errors.js";
 import type { ToolCall } from "@/types/content.types.js";
 import type { ToolDefinition } from "@/types/tool.types.js";
+import type { Static, TSchema } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 
 /**
  * Validates a raw value against a tool's TypeBox schema and returns typed data.

--- a/packages/core/src/session/contracts.ts
+++ b/packages/core/src/session/contracts.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Message } from "@/types/message.types.js";
-import type { Usage } from "@/types/usage.types.js";
 import type { SessionRef } from "@/session/session-ref.js";
 import type { TodoStorage } from "@/session/todo-storage.js";
+import type { Message } from "@/types/message.types.js";
+import type { Usage } from "@/types/usage.types.js";
 
 /**
  * Minimal storage surface the host runtime needs to load, persist, and compact

--- a/packages/core/src/tools/define-tool.ts
+++ b/packages/core/src/tools/define-tool.ts
@@ -3,9 +3,14 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { tool, type ToolExecutionContext } from "@/tools/tool-builder.js";
+import type {
+  RuntimeTool,
+  ToolResult,
+  ToolValidationContext,
+  ValidationResult,
+} from "@/types/tool.types.js";
 import { Type, type Static, type TSchema } from "@sinclair/typebox";
-import type { RuntimeTool, ToolResult, ToolValidationContext, ValidationResult } from "@/types/tool.types.js";
-import { type ToolExecutionContext, tool } from "@/tools/tool-builder.js";
 
 /**
  * Defines a runtime tool using an object-style declaration.
@@ -69,7 +74,10 @@ export function defineTool<TSchema_ extends TSchema, TDetails>(options: {
   if (options.validate) {
     const validateFn = options.validate;
     builder = builder.validate(
-      validateFn as (params: Static<typeof schema>, ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult,
+      validateFn as (
+        params: Static<typeof schema>,
+        ctx: ToolValidationContext,
+      ) => Promise<ValidationResult> | ValidationResult,
     );
   }
 

--- a/packages/core/src/tools/tool-builder.ts
+++ b/packages/core/src/tools/tool-builder.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { Type, type Static, type TSchema } from "@sinclair/typebox";
 import type {
   RuntimeTool,
   ToolResult,
@@ -11,6 +10,7 @@ import type {
   ToolValidationContext,
   ValidationResult,
 } from "@/types/tool.types.js";
+import { Type, type Static, type TSchema } from "@sinclair/typebox";
 
 // ============================================================================
 // ============================================================================
@@ -43,7 +43,10 @@ interface ToolConfig<TParams, TDetails> {
   label?: string;
   description?: string;
   parameters?: TSchema;
-  validate?: (params: TParams, ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult;
+  validate?: (
+    params: TParams,
+    ctx: ToolValidationContext,
+  ) => Promise<ValidationResult> | ValidationResult;
   execute?: (params: TParams, ctx: ToolExecutionContext) => Promise<ToolResult<TDetails>>;
 }
 
@@ -91,7 +94,10 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
    * `execute`. Returning `{ valid: false }` or throwing prevents execution.
    */
   validate(
-    fn: (params: TParams, ctx: ToolValidationContext) => Promise<ValidationResult> | ValidationResult,
+    fn: (
+      params: TParams,
+      ctx: ToolValidationContext,
+    ) => Promise<ValidationResult> | ValidationResult,
   ): this {
     this.config.validate = fn;
     return this;

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -4,7 +4,12 @@
  */
 
 import type { ToolCall } from "@/types/content.types.js";
-import type { AssistantMessage, Message, StopReason, ToolResultMessage } from "@/types/message.types.js";
+import type {
+  AssistantMessage,
+  Message,
+  StopReason,
+  ToolResultMessage,
+} from "@/types/message.types.js";
 import type { ToolResult } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
 

--- a/packages/core/src/types/tool.types.ts
+++ b/packages/core/src/types/tool.types.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { Static, TSchema } from "@sinclair/typebox";
 import type { ImageContent, TextContent } from "@/types/content.types.js";
+import type { Static, TSchema } from "@sinclair/typebox";
 
 /** Schema-only description of a tool that can be exposed to a model. */
 export interface ToolDefinition<TParameters extends TSchema = TSchema> {

--- a/packages/core/test/agent-loop-text-streaming.test.ts
+++ b/packages/core/test/agent-loop-text-streaming.test.ts
@@ -13,12 +13,12 @@
  * These tests verify that text_* events now produce immediate message.update events.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import type { AgentLoopConfig, InternalContext, InternalSpec } from "../src/agent/agent-loop.js";
 import { agentLoop } from "../src/agent/agent-loop.js";
-import type { AgentLoopConfig, InternalSpec, InternalContext } from "../src/agent/agent-loop.js";
 import type { LlmClient, LlmRequest, LlmStream } from "../src/interfaces/llm-client.js";
-import type { LlmStreamEvent, RuntimeEvent } from "../src/types/result.types.js";
 import type { AssistantMessage } from "../src/types/message.types.js";
+import type { LlmStreamEvent, RuntimeEvent } from "../src/types/result.types.js";
 import type { Usage } from "../src/types/usage.types.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -113,7 +113,10 @@ describe("agent-loop – text event streaming", () => {
   it("text_delta events produce message.update events before message.end (pure text turn)", async () => {
     const finalMsg = makeAssistantMsg("hello world", "stop");
     const partial: AssistantMessage = { ...finalMsg, content: [] };
-    const partialWithText: AssistantMessage = { ...finalMsg, content: [{ type: "text", text: "hello" }] };
+    const partialWithText: AssistantMessage = {
+      ...finalMsg,
+      content: [{ type: "text", text: "hello" }],
+    };
 
     async function* llmEvents(): AsyncGenerator<LlmStreamEvent> {
       yield { type: "start", partial };
@@ -156,10 +159,20 @@ describe("agent-loop – text event streaming", () => {
     async function* llmEvents(): AsyncGenerator<LlmStreamEvent> {
       yield { type: "start", partial: partialEmpty };
       yield { type: "text_start", contentIndex: 0, partial: partialEmpty };
-      yield { type: "text_delta", contentIndex: 0, delta: "let me search", partial: partialWithText };
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "let me search",
+        partial: partialWithText,
+      };
       yield { type: "text_end", contentIndex: 0, content: "let me search", partial: finalMsg };
       yield { type: "toolcall_start", contentIndex: 1, partial: finalMsg };
-      yield { type: "toolcall_end", contentIndex: 1, toolCall: { type: "toolCall", id: "tc1", name: "search", arguments: {} }, partial: finalMsg };
+      yield {
+        type: "toolcall_end",
+        contentIndex: 1,
+        toolCall: { type: "toolCall", id: "tc1", name: "search", arguments: {} },
+        partial: finalMsg,
+      };
       yield { type: "done", reason: "toolUse", message: finalMsg };
     }
 
@@ -189,7 +202,9 @@ describe("agent-loop – text event streaming", () => {
                 if (value.type === "done" || value.type === "error") finalM = value.message;
                 return { done: false, value };
               },
-              [Symbol.asyncIterator]() { return this; },
+              [Symbol.asyncIterator]() {
+                return this;
+              },
             };
           },
           result: async () => finalM!,

--- a/packages/core/test/define-tool.test.ts
+++ b/packages/core/test/define-tool.test.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect, vi } from "vitest";
 import { Type } from "@sinclair/typebox";
+import { describe, expect, it, vi } from "vitest";
 import { defineTool } from "../src/tools/define-tool.js";
 import { defineSimpleTool } from "../src/tools/tool-builder.js";
 import type { ToolValidationContext } from "../src/types/tool.types.js";

--- a/packages/core/test/session-contracts.test.ts
+++ b/packages/core/test/session-contracts.test.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createSessionRef, resolveSessionRef } from "../src/session/session-ref.js";
 
 describe("session-ref", () => {

--- a/packages/core/test/tool-executor.test.ts
+++ b/packages/core/test/tool-executor.test.ts
@@ -3,13 +3,17 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Type } from "@sinclair/typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { executeToolCalls } from "../src/executor/tool-executor.js";
 import { EventStream } from "../src/llm/event-stream.js";
 import type { AssistantMessage, Message } from "../src/types/message.types.js";
 import type { RuntimeEvent } from "../src/types/result.types.js";
-import type { RuntimeTool, ToolInterceptor, ToolValidationContext } from "../src/types/tool.types.js";
+import type {
+  RuntimeTool,
+  ToolInterceptor,
+  ToolValidationContext,
+} from "../src/types/tool.types.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -23,7 +27,10 @@ function makeStream(): { stream: EventStream<RuntimeEvent, Message[]>; events: R
   // Use "session.end" as the completion sentinel (same as agent-loop.ts).
   const stream = new EventStream<RuntimeEvent, Message[]>(
     (e) => e.type === "session.end",
-    (e) => (e.type === "session.end" ? (e as Extract<RuntimeEvent, { type: "session.end" }>).messages : []),
+    (e) =>
+      e.type === "session.end"
+        ? (e as Extract<RuntimeEvent, { type: "session.end" }>).messages
+        : [],
   );
 
   // Tap into push by wrapping the stream in a Proxy so we can intercept events.
@@ -49,7 +56,9 @@ function makeTool(name: string, result = "ok"): RuntimeTool {
   };
 }
 
-function makeAssistantMessage(toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>): AssistantMessage {
+function makeAssistantMessage(
+  toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>,
+): AssistantMessage {
   return {
     role: "assistant",
     content: toolCalls.map((tc) => ({
@@ -60,7 +69,14 @@ function makeAssistantMessage(toolCalls: Array<{ id: string; name: string; argum
     })),
     provider: "test",
     modelId: "test",
-    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
     stopReason: "toolUse",
     timestamp: Date.now(),
   };
@@ -86,7 +102,10 @@ describe("executeToolCalls — ToolInterceptor", () => {
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "hello" } }]);
     await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
 
-    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<
+      RuntimeEvent,
+      { type: "tool.before" }
+    >;
     expect(beforeEvent).toBeDefined();
     expect(beforeEvent.args).toEqual({ value: "hello" });
     expect(beforeEvent.rawArgs).toEqual({ value: "hello" });
@@ -105,10 +124,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
       }),
     };
 
-    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "sensitive" } }]);
+    const msg = makeAssistantMessage([
+      { id: "c1", name: "echo", arguments: { value: "sensitive" } },
+    ]);
     await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
 
-    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<
+      RuntimeEvent,
+      { type: "tool.before" }
+    >;
     expect((beforeEvent.args as Record<string, unknown>).value).toBe("SANITIZED");
     expect((beforeEvent.rawArgs as Record<string, unknown>).value).toBe("sensitive");
 
@@ -146,7 +170,10 @@ describe("executeToolCalls — ToolInterceptor", () => {
 
     expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
     expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
-    const afterEvent = collectedEvents.find((e) => e.type === "tool.after") as Extract<RuntimeEvent, { type: "tool.after" }>;
+    const afterEvent = collectedEvents.find((e) => e.type === "tool.after") as Extract<
+      RuntimeEvent,
+      { type: "tool.after" }
+    >;
     expect(afterEvent.isError).toBe(true);
   });
 
@@ -193,7 +220,10 @@ describe("executeToolCalls — ToolInterceptor", () => {
     expect(ctx.toolName).toBe("echo");
     expect(typeof ctx.durationMs).toBe("number");
     expect(ctx.durationMs).toBeGreaterThanOrEqual(0);
-    expect((ctx.result as { content: unknown[] }).content[0]).toMatchObject({ type: "text", text: "result-text" });
+    expect((ctx.result as { content: unknown[] }).content[0]).toMatchObject({
+      type: "text",
+      text: "result-text",
+    });
   });
 
   it("tool not found: emits tool.before + tool.after error events, no interceptor calls", async () => {
@@ -223,7 +253,9 @@ describe("executeToolCalls — ToolInterceptor", () => {
       description: "Array tool",
       // Type.Array would normally be used; use an empty schema to keep the test lean.
       parameters: Type.Array(Type.String()),
-      execute: vi.fn().mockResolvedValue({ content: [{ type: "text" as const, text: "ok" }], details: {} }),
+      execute: vi
+        .fn()
+        .mockResolvedValue({ content: [{ type: "text" as const, text: "ok" }], details: {} }),
     };
     const interceptor: ToolInterceptor = {
       onBeforeToolCall: vi.fn().mockImplementation(async (ctx) => {
@@ -232,7 +264,9 @@ describe("executeToolCalls — ToolInterceptor", () => {
       }),
     };
 
-    const msg = makeAssistantMessage([{ id: "c1", name: "arr", arguments: ["a", "b"] as unknown as Record<string, unknown> }]);
+    const msg = makeAssistantMessage([
+      { id: "c1", name: "arr", arguments: ["a", "b"] as unknown as Record<string, unknown> },
+    ]);
     await executeToolCalls([arrayTool], msg, undefined, stream, undefined, interceptor);
 
     // The interceptor should receive exactly what came out of validateToolArguments,
@@ -248,7 +282,10 @@ describe("executeToolCalls — ToolInterceptor", () => {
 
     expect(tool.execute).toHaveBeenCalledOnce();
     expect(result.toolResults[0].isError).toBe(false);
-    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<
+      RuntimeEvent,
+      { type: "tool.before" }
+    >;
     expect(beforeEvent.rawArgs).toEqual({ value: "x" });
   });
 
@@ -269,9 +306,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
     expect(result.toolResults[0].isError).toBe(true);
-    expect(result.toolResults[0].content[0]).toMatchObject({ type: "text", text: expect.stringContaining('Invalid arguments for tool') });
+    expect(result.toolResults[0].content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Invalid arguments for tool"),
+    });
     // tool.before.args should reflect the interceptor-rewritten value
-    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<RuntimeEvent, { type: "tool.before" }>;
+    const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<
+      RuntimeEvent,
+      { type: "tool.before" }
+    >;
     expect((beforeEvent.args as Record<string, unknown>).value).toBe(42);
   });
 });
@@ -351,7 +394,10 @@ describe("executeToolCalls — tool.validate()", () => {
 
     expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
     expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
-    const afterEvent = collectedEvents.find((e) => e.type === "tool.after") as Extract<RuntimeEvent, { type: "tool.after" }>;
+    const afterEvent = collectedEvents.find((e) => e.type === "tool.after") as Extract<
+      RuntimeEvent,
+      { type: "tool.after" }
+    >;
     expect(afterEvent.isError).toBe(true);
   });
 
@@ -369,17 +415,23 @@ describe("executeToolCalls — tool.validate()", () => {
   it("validate runs on effectiveArgs (post-interceptor), not original args", async () => {
     const tool = makeTool("echo");
     const receivedParams: unknown[] = [];
-    (tool as RuntimeTool & { validate: (p: unknown, ctx: ToolValidationContext) => { valid: true } }).validate = vi
-      .fn()
-      .mockImplementation((params: unknown) => {
-        receivedParams.push(params);
-        return { valid: true as const };
-      });
+    (
+      tool as RuntimeTool & {
+        validate: (p: unknown, ctx: ToolValidationContext) => { valid: true };
+      }
+    ).validate = vi.fn().mockImplementation((params: unknown) => {
+      receivedParams.push(params);
+      return { valid: true as const };
+    });
     const interceptor: ToolInterceptor = {
-      onBeforeToolCall: vi.fn().mockResolvedValue({ action: "allow", input: { value: "MODIFIED" } }),
+      onBeforeToolCall: vi
+        .fn()
+        .mockResolvedValue({ action: "allow", input: { value: "MODIFIED" } }),
     };
 
-    const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "original" } }]);
+    const msg = makeAssistantMessage([
+      { id: "c1", name: "echo", arguments: { value: "original" } },
+    ]);
     await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
 
     expect(receivedParams[0]).toEqual({ value: "MODIFIED" });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { describe, it, expect } from "vitest";
 import { Type } from "@sinclair/typebox";
-import { validateToolInput } from "../src/llm/utils/validation.js";
+import { describe, expect, it } from "vitest";
 import { ToolValidationError } from "../src/errors.js";
+import { validateToolInput } from "../src/llm/utils/validation.js";
 
 const schema = Type.Object({
   name: Type.String(),
@@ -61,7 +61,9 @@ describe("validateToolInput", () => {
   });
 
   it("violating minimum constraint produces an error with the correct path", () => {
-    expect(() => validateToolInput(tool, { name: "Charlie", age: -1 })).toThrow(ToolValidationError);
+    expect(() => validateToolInput(tool, { name: "Charlie", age: -1 })).toThrow(
+      ToolValidationError,
+    );
     let caught: ToolValidationError | undefined;
     try {
       validateToolInput(tool, { name: "Charlie", age: -1 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/packages/create-agentrail-app/README.md
+++ b/packages/create-agentrail-app/README.md
@@ -23,6 +23,7 @@ pnpm dev
 - Runtime API surface: none. This package exists as a CLI entry shim only.
 
 Reference:
+
 - `https://agentrail.run/guides/quickstart`
 
 ## Related packages

--- a/packages/create-agentrail-app/templates/minimal/src/agent.ts
+++ b/packages/create-agentrail-app/templates/minimal/src/agent.ts
@@ -1,5 +1,5 @@
-import { defineAgent, isRuntimeError, type Message } from "@agentrail/core";
 import { defineProfile } from "@agentrail/app";
+import { defineAgent, isRuntimeError, type Message } from "@agentrail/core";
 // To add filesystem, browser, knowledge, or orchestration capabilities install
 // @agentrail/capabilities and import the relevant factory functions:
 //   import { filesystem, knowledge, browser } from "@agentrail/capabilities";

--- a/packages/deep-research/README.md
+++ b/packages/deep-research/README.md
@@ -39,6 +39,7 @@ const route = createDeepResearchRunRoute({
 - `createFileSystemDeepResearchStore(dataDir, sessionRef)` — persisted state/event store for deep-research runs.
 
 Reference:
+
 - `https://agentrail.run/examples/deep-research`
 
 ## Related packages

--- a/packages/deep-research/src/agents/deep-research-subagent-runtime.ts
+++ b/packages/deep-research/src/agents/deep-research-subagent-runtime.ts
@@ -3,22 +3,19 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { getRolePrompt } from "@/prompts.js";
+import type { DeepResearchRuntimeConfig } from "@/runtime.js";
+import { createFetchUrlTool, createWebSearchTool } from "@/tools.js";
+import type { CreateManagedAgentInput, SubAgentRuntime } from "@agentrail/capabilities";
 import {
   createKbListTool,
   createKbReadTool,
   createKbSearchTool,
+  createSandboxedPython,
   KnowledgeManager,
+  SandboxManager,
 } from "@agentrail/capabilities";
-import type {
-  CreateManagedAgentInput,
-  SubAgentRuntime,
-} from "@agentrail/capabilities";
-import type { ModelConfig } from "@agentrail/core";
-import type { RuntimeTool, TransformContextFn } from "@agentrail/core";
-import { createSandboxedPython, SandboxManager } from "@agentrail/capabilities";
-import { getRolePrompt } from "@/prompts.js";
-import type { DeepResearchRuntimeConfig } from "@/runtime.js";
-import { createFetchUrlTool, createWebSearchTool } from "@/tools.js";
+import type { ModelConfig, RuntimeTool, TransformContextFn } from "@agentrail/core";
 
 export interface DeepResearchSubAgentRuntimeConfig {
   tenantId: string;

--- a/packages/deep-research/src/agents/deep-research-worker-entry.ts
+++ b/packages/deep-research/src/agents/deep-research-worker-entry.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { DeepResearchSubAgentRuntime } from "@/agents/deep-research-subagent-runtime.js";
+import type { DeepResearchRuntimeConfig } from "@/runtime.js";
 import { initializeWorker } from "@agentrail/capabilities/orchestration/worker";
 import "@agentrail/core/providers";
-import type { DeepResearchRuntimeConfig } from "@/runtime.js";
-import { DeepResearchSubAgentRuntime } from "@/agents/deep-research-subagent-runtime.js";
 
 interface WorkerInitPayload {
   type: "init";

--- a/packages/deep-research/src/coordinator-internals.ts
+++ b/packages/deep-research/src/coordinator-internals.ts
@@ -3,6 +3,9 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { DeepResearchCoordinatorOptions } from "@/coordinator.js";
+import type { DeepResearchRun } from "@/types.js";
+import { nowIso } from "@/utils.js";
 import type {
   CreateManagedAgentInput,
   ManagedAgentInstance,
@@ -12,9 +15,6 @@ import { createSubAgentProcess } from "@agentrail/capabilities";
 import type { Message, Usage } from "@agentrail/core";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { DeepResearchCoordinatorOptions } from "@/coordinator.js";
-import type { DeepResearchRun } from "@/types.js";
-import { nowIso } from "@/utils.js";
 
 export function getDeepResearchWorkerPath(): string {
   const currentFile = fileURLToPath(import.meta.url);

--- a/packages/deep-research/src/coordinator.ts
+++ b/packages/deep-research/src/coordinator.ts
@@ -3,16 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import {
-  OrchestrationManager,
-  createFilesystemOrchestrationPersistence,
-} from "@agentrail/capabilities";
-import { defineAgent, type Message, type RuntimeEvent } from "@agentrail/core";
-import { SandboxManager } from "@agentrail/capabilities";
-import { randomUUID } from "node:crypto";
-import { copyFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
 import {
   createManagedDeepResearchAgent,
   createRun,
@@ -60,6 +50,16 @@ import {
   selectSourcesForResearchContext,
   slugifyTitle,
 } from "@/utils.js";
+import {
+  OrchestrationManager,
+  SandboxManager,
+  createFilesystemOrchestrationPersistence,
+} from "@agentrail/capabilities";
+import type { SessionRef } from "@agentrail/core";
+import { defineAgent, type Message, type RuntimeEvent } from "@agentrail/core";
+import { randomUUID } from "node:crypto";
+import { copyFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
 
 export interface DeepResearchCoordinatorOptions {
   tenantId: string;

--- a/packages/deep-research/src/routes.ts
+++ b/packages/deep-research/src/routes.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { createFileSystemDeepResearchStore } from "@/store.js";
+import { slugifyTitle } from "@/utils.js";
 import { createSessionRef } from "@agentrail/core";
 import { Hono } from "hono";
 import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
-import { createFileSystemDeepResearchStore } from "@/store.js";
-import { slugifyTitle } from "@/utils.js";
 
 const ARTIFACT_MIME_MAP: Record<string, string> = {
   ".png": "image/png",

--- a/packages/deep-research/src/run.ts
+++ b/packages/deep-research/src/run.ts
@@ -3,12 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import type { SessionRef } from "@agentrail/core";
-import type { Message, Usage } from "@agentrail/core";
-import { Hono } from "hono";
 import { DeepResearchCoordinator } from "@/coordinator.js";
 import type { DeepResearchRuntimeConfig } from "@/runtime.js";
 import type { DeepResearchEvent, DeepResearchState } from "@/types.js";
+import type { Message, SessionRef, Usage } from "@agentrail/core";
+import { Hono } from "hono";
 
 export interface DeepResearchSessionStore {
   getOrCreate(

--- a/packages/deep-research/src/store.ts
+++ b/packages/deep-research/src/store.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { DeepResearchEvent, DeepResearchState } from "@/types.js";
 import type { SessionRef } from "@agentrail/core";
 import { resolveSessionRef } from "@agentrail/core";
 import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { DeepResearchEvent, DeepResearchState } from "@/types.js";
 
 const STATE_FILE = "state.json";
 const EVENTS_FILE = "events.jsonl";

--- a/packages/deep-research/src/tools.ts
+++ b/packages/deep-research/src/tools.ts
@@ -3,18 +3,18 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { DeepResearchRuntimeConfig } from "@/runtime.js";
+import { normalizeResearchUrl } from "@/utils.js";
 import {
   createBraveSearchProvider,
-  createJinaSearchProvider,
-  createTavilySearchProvider,
   createWebFetchTool as createGenericWebFetchTool,
   createWebSearchTool as createGenericWebSearchTool,
+  createJinaSearchProvider,
+  createTavilySearchProvider,
   type WebFetchDetails,
   type WebSearchProvider,
 } from "@agentrail/capabilities";
 import { tool, Type } from "@agentrail/core";
-import type { DeepResearchRuntimeConfig } from "@/runtime.js";
-import { normalizeResearchUrl } from "@/utils.js";
 
 interface WebSearchItem {
   title: string;
@@ -101,16 +101,17 @@ export function createWebSearchTool(runtime: DeepResearchRuntimeConfig) {
         ctx.onSignal,
       );
 
-      const rawResults = (
-        baseResult.details as {
-          results?: Array<{
-            title?: string;
-            url?: string;
-            snippet?: string;
-            publishedAt?: string;
-          }>;
-        }
-      ).results ?? [];
+      const rawResults =
+        (
+          baseResult.details as {
+            results?: Array<{
+              title?: string;
+              url?: string;
+              snippet?: string;
+              publishedAt?: string;
+            }>;
+          }
+        ).results ?? [];
 
       const items: WebSearchItem[] = rawResults
         .map((item) => {
@@ -175,9 +176,7 @@ export function createFetchUrlTool() {
         evidenceLevel:
           details.status === "success" && details.content ? "body_verified" : "unverified",
         fetchStatus: mapFetchStatus(details),
-        ...(details.status === "success"
-          ? {}
-          : { error: details.error }),
+        ...(details.status === "success" ? {} : { error: details.error }),
       };
 
       return {

--- a/packages/deep-research/src/utils.ts
+++ b/packages/deep-research/src/utils.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-import path from "node:path";
 import type {
   DeepResearchArtifact,
   DeepResearchEntityProfile,
@@ -18,6 +17,7 @@ import type {
   DeepResearchStepDigest,
   PlannerOutput,
 } from "@/types.js";
+import path from "node:path";
 
 /**
  * This file holds the "quality guardrails" for Deep Research.
@@ -167,7 +167,9 @@ export function normalizePlan(
 }
 
 export function buildFallbackPlan(query: string): DeepResearchPlan {
-  const processingNeeded = /(chart|plot|trend|compare|stat|forecast|distribution|ratio)/i.test(query);
+  const processingNeeded = /(chart|plot|trend|compare|stat|forecast|distribution|ratio)/i.test(
+    query,
+  );
   return {
     title: `Deep Research: ${query.slice(0, 60)}`,
     thought: "Collect external sources, synthesize them, and produce a sourced report.",
@@ -265,7 +267,10 @@ const DECODE_ENTITIES: Record<string, string> = {
 };
 
 function decodeHtmlEntities(text: string): string {
-  return text.replace(/&(nbsp|amp|lt|gt|#39|quot);?/gi, (_, e) => DECODE_ENTITIES[e.toLowerCase()] ?? `&${e};`);
+  return text.replace(
+    /&(nbsp|amp|lt|gt|#39|quot);?/gi,
+    (_, e) => DECODE_ENTITIES[e.toLowerCase()] ?? `&${e};`,
+  );
 }
 
 export function normalizeResearchUrl(rawUrl: string): string {
@@ -481,7 +486,6 @@ export function normalizeResearchProfile(
   };
 }
 
-
 function computeDigestConfidence(
   sources: DeepResearchSource[],
   findingsCount: number,
@@ -509,13 +513,17 @@ export function buildStepDigest(
   const findings = compressAtomicLines(
     candidates.filter(
       (line) =>
-        !/(open question|unknown|uncertain|unverified|not confirmed|possibly|may be|pending)/i.test(line),
+        !/(open question|unknown|uncertain|unverified|not confirmed|possibly|may be|pending)/i.test(
+          line,
+        ),
     ),
     5,
   );
   const openQuestions = compressAtomicLines(
     candidates.filter((line) =>
-      /(open question|uncertain|unverified|not confirmed|not found|possibly|may be|pending|needs? verification)/i.test(line),
+      /(open question|uncertain|unverified|not confirmed|not found|possibly|may be|pending|needs? verification)/i.test(
+        line,
+      ),
     ),
     3,
   );

--- a/packages/deep-research/test/tools.test.ts
+++ b/packages/deep-research/test/tools.test.ts
@@ -13,20 +13,21 @@ describe("deep-research tool adapters", () => {
   });
 
   it("maps Tavily search results into deep research source candidates", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          results: [
-            {
-              title: "OpenAI",
-              url: "https://openai.com/research",
-              content: "AI research",
-              published_date: "2026-04-09",
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: "OpenAI",
+                url: "https://openai.com/research",
+                content: "AI research",
+                published_date: "2026-04-09",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -48,21 +49,22 @@ describe("deep-research tool adapters", () => {
   });
 
   it("selects Brave when configured", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          web: {
-            results: [
-              {
-                title: "OpenAI",
-                url: "https://openai.com",
-                description: "AI research",
-              },
-            ],
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            web: {
+              results: [
+                {
+                  title: "OpenAI",
+                  url: "https://openai.com",
+                  description: "AI research",
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -83,19 +85,20 @@ describe("deep-research tool adapters", () => {
   });
 
   it("selects Jina when configured", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          data: [
-            {
-              title: "OpenAI",
-              url: "https://openai.com",
-              content: "AI research",
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                title: "OpenAI",
+                url: "https://openai.com",
+                content: "AI research",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -116,11 +119,15 @@ describe("deep-research tool adapters", () => {
   });
 
   it("maps successful fetches into deep research fetch payloads", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("<html><head><title>Example</title></head><body><article><h1>Hello</h1></article></body></html>", {
-        status: 200,
-        headers: { "content-type": "text/html" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          "<html><head><title>Example</title></head><body><article><h1>Hello</h1></article></body></html>",
+          {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -135,11 +142,12 @@ describe("deep-research tool adapters", () => {
   });
 
   it("maps forbidden fetches into the legacy 403 shape", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response("forbidden", {
-        status: 403,
-        headers: { "content-type": "text/plain" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("forbidden", {
+          status: 403,
+          headers: { "content-type": "text/plain" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/packages/deep-research/tsconfig.json
+++ b/packages/deep-research/tsconfig.json
@@ -9,8 +9,5 @@
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
-  "references": [
-    { "path": "../core" },
-    { "path": "../capabilities" }
-  ]
+  "references": [{ "path": "../core" }, { "path": "../capabilities" }]
 }

--- a/packages/deep-research/vitest.config.ts
+++ b/packages/deep-research/vitest.config.ts
@@ -4,8 +4,8 @@
  */
 
 import { resolve } from "node:path";
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -48,6 +48,7 @@ assertFinalText(result, "done");
 - `assertToolCalled(result, toolName)` / `assertToolCalledWith(...)` — assert tool usage.
 
 Reference:
+
 - `https://agentrail.run/concepts/agents`
 - `https://agentrail.run/guides/quickstart`
 

--- a/packages/testing/src/assertions.ts
+++ b/packages/testing/src/assertions.ts
@@ -1,5 +1,5 @@
-import assert from "node:assert";
 import type { AgentResult, ToolCall } from "@agentrail/core";
+import assert from "node:assert";
 
 /** Collects all tool calls across every assistant turn in the result. */
 function collectAllToolCalls(result: AgentResult): ToolCall[] {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./mock-llm-provider.js";
-export * from "./test-agent-factory.js";
 export * from "./assertions.js";
+export * from "./mock-llm-provider.js";
 export * from "./mock-session-store.js";
+export * from "./test-agent-factory.js";

--- a/packages/testing/src/mock-llm-provider.ts
+++ b/packages/testing/src/mock-llm-provider.ts
@@ -1,13 +1,12 @@
-import type { 
-  LlmProvider, 
-  LlmRequest, 
-  LlmStream, 
-  LlmStreamEvent,
-  AssistantMessage, 
-  StopReason,
+import type {
   AssistantContent,
+  AssistantMessage,
+  LlmProvider,
+  LlmRequest,
+  LlmStream,
+  LlmStreamEvent,
+  StopReason,
   ToolCall,
-  Usage
 } from "@agentrail/core";
 
 export interface MockProviderResponse {
@@ -34,24 +33,24 @@ export class MockLlmProvider implements LlmProvider {
     const { messages, model } = request;
     const callIndex = this.callCount;
     const content: AssistantContent[] = [];
-    
+
     if (response.text) {
       content.push({ type: "text", text: response.text });
     }
-    
+
     if (response.toolCalls && response.toolCalls.length > 0) {
       for (const [index, tc] of response.toolCalls.entries()) {
         content.push({
           type: "toolCall",
           id: `call_${callIndex}_${index}`,
           name: tc.name,
-          arguments: tc.input
+          arguments: tc.input,
         });
       }
     }
 
-    const stopReason: Extract<StopReason, "stop" | "length" | "toolUse"> = 
-        (response.toolCalls && response.toolCalls.length > 0) ? "toolUse" : "stop";
+    const stopReason: Extract<StopReason, "stop" | "length" | "toolUse"> =
+      response.toolCalls && response.toolCalls.length > 0 ? "toolUse" : "stop";
 
     const partialMessage: AssistantMessage = {
       role: "assistant",
@@ -69,46 +68,46 @@ export class MockLlmProvider implements LlmProvider {
           output: 0,
           cacheRead: 0,
           cacheWrite: 0,
-          total: 0
-        }
+          total: 0,
+        },
       },
       stopReason,
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     const finalMessage: AssistantMessage = { ...partialMessage, content };
 
     async function* generateEvents(): AsyncIterable<LlmStreamEvent> {
       yield { type: "start", partial: partialMessage };
-      
+
       let contentIndex = 0;
-      
+
       if (response.text) {
         yield { type: "text_start", contentIndex, partial: partialMessage };
         yield { type: "text_end", contentIndex, content: response.text, partial: partialMessage };
         contentIndex++;
       }
-      
+
       if (response.toolCalls) {
         for (const [index, tc] of response.toolCalls.entries()) {
           const toolCall: ToolCall = {
             type: "toolCall",
             id: `call_${callIndex}_${index}`,
             name: tc.name,
-            arguments: tc.input
+            arguments: tc.input,
           };
           yield { type: "toolcall_start", contentIndex, partial: partialMessage };
           yield { type: "toolcall_end", contentIndex, toolCall, partial: partialMessage };
           contentIndex++;
         }
       }
-      
+
       yield { type: "done", reason: stopReason, message: finalMessage };
     }
 
     const streamObj: LlmStream = {
       [Symbol.asyncIterator]: () => generateEvents()[Symbol.asyncIterator](),
-      result: async () => finalMessage
+      result: async () => finalMessage,
     };
 
     return streamObj;

--- a/packages/testing/src/mock-session-store.ts
+++ b/packages/testing/src/mock-session-store.ts
@@ -1,5 +1,5 @@
-import { createSessionRef } from "@agentrail/core";
 import type { AgentrailSessionStore, Message, SessionRef, Usage } from "@agentrail/core";
+import { createSessionRef } from "@agentrail/core";
 
 export class MockSessionStore implements AgentrailSessionStore {
   private memory: Map<string, Message[]> = new Map();

--- a/packages/testing/src/test-agent-factory.ts
+++ b/packages/testing/src/test-agent-factory.ts
@@ -1,6 +1,6 @@
+import type { MockLlmProvider } from "@/mock-llm-provider.js";
 import type { Agent, AgentConfig } from "@agentrail/core";
 import { defineAgent } from "@agentrail/core";
-import type { MockLlmProvider } from "@/mock-llm-provider.js";
 
 export interface CreateTestAgentOptions {
   definition: AgentConfig;

--- a/packages/testing/test/testing.test.ts
+++ b/packages/testing/test/testing.test.ts
@@ -1,9 +1,8 @@
-import { Type } from "@agentrail/core";
-import { defineTool, defineAgent } from "@agentrail/core";
-import { describe, it, expect } from "vitest";
+import { defineTool, Type } from "@agentrail/core";
+import { describe, expect, it } from "vitest";
+import { assertFinalText, assertToolCalled, assertToolCalledWith } from "../src/assertions.js";
 import { MockLlmProvider } from "../src/mock-llm-provider.js";
 import { createTestAgent } from "../src/test-agent-factory.js";
-import { assertToolCalled, assertToolCalledWith, assertFinalText } from "../src/assertions.js";
 
 describe("Testing Package", () => {
   it("should run a test agent with mock provider and execute tools", async () => {

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -8,7 +8,5 @@
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
-  "references": [
-    { "path": "../core" }
-  ]
+  "references": [{ "path": "../core" }]
 }

--- a/packages/testing/tsconfig.test.json
+++ b/packages/testing/tsconfig.test.json
@@ -6,7 +6,5 @@
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src", "test"],
-  "references": [
-    { "path": "../core" }
-  ]
+  "references": [{ "path": "../core" }]
 }

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,17 +1,16 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
-      '@changesets/changelog-github':
+      "@changesets/changelog-github":
         specifier: ^0.6.0
         version: 0.6.0
-      '@changesets/cli':
+      "@changesets/cli":
         specifier: ^2.30.0
         version: 2.30.0(@types/node@22.19.15)
       concurrently:
@@ -38,26 +37,26 @@ importers:
 
   examples/deep-research:
     dependencies:
-      '@agentrail/app':
+      "@agentrail/app":
         specifier: workspace:*
         version: link:../../packages/app
-      '@agentrail/capabilities':
+      "@agentrail/capabilities":
         specifier: workspace:*
         version: link:../../packages/capabilities
-      '@agentrail/core':
+      "@agentrail/core":
         specifier: workspace:*
         version: link:../../packages/core
-      '@agentrail/deep-research':
+      "@agentrail/deep-research":
         specifier: workspace:*
         version: link:../../packages/deep-research
-      '@hono/node-server':
+      "@hono/node-server":
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.12)
       hono:
         specifier: ^4.12.12
         version: 4.12.12
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -69,26 +68,26 @@ importers:
 
   examples/playground-server:
     dependencies:
-      '@agentrail/app':
+      "@agentrail/app":
         specifier: workspace:*
         version: link:../../packages/app
-      '@agentrail/capabilities':
+      "@agentrail/capabilities":
         specifier: workspace:*
         version: link:../../packages/capabilities
-      '@agentrail/core':
+      "@agentrail/core":
         specifier: workspace:*
         version: link:../../packages/core
-      '@agentrail/deep-research':
+      "@agentrail/deep-research":
         specifier: workspace:*
         version: link:../../packages/deep-research
-      '@hono/node-server':
+      "@hono/node-server":
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.12)
       hono:
         specifier: ^4.12.12
         version: 4.12.12
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -100,10 +99,10 @@ importers:
 
   examples/playground-ui:
     dependencies:
-      '@agentrail/app':
+      "@agentrail/app":
         specifier: workspace:*
         version: link:../../packages/app
-      '@types/dompurify':
+      "@types/dompurify":
         specifier: ^3.0.5
         version: 3.2.0
       dompurify:
@@ -131,16 +130,16 @@ importers:
         specifier: ^0.18.5
         version: 0.18.5
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
-      '@types/react':
+      "@types/react":
         specifier: ^19.0.0
         version: 19.2.14
-      '@types/react-dom':
+      "@types/react-dom":
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
+      "@vitejs/plugin-react":
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
       vite:
@@ -149,10 +148,10 @@ importers:
 
   packages/app:
     dependencies:
-      '@agentrail/capabilities':
+      "@agentrail/capabilities":
         specifier: workspace:*
         version: link:../capabilities
-      '@agentrail/core':
+      "@agentrail/core":
         specifier: workspace:*
         version: link:../core
       hono:
@@ -162,7 +161,7 @@ importers:
         specifier: ^2.0.0
         version: 2.8.3
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -177,13 +176,13 @@ importers:
 
   packages/capabilities:
     dependencies:
-      '@agentrail/core':
+      "@agentrail/core":
         specifier: workspace:*
         version: link:../core
-      '@mozilla/readability':
+      "@mozilla/readability":
         specifier: ^0.6.0
         version: 0.6.0
-      '@sinclair/typebox':
+      "@sinclair/typebox":
         specifier: ^0.34.0
         version: 0.34.49
       dockerode:
@@ -202,19 +201,19 @@ importers:
         specifier: ^7.2.1
         version: 7.2.4
     devDependencies:
-      '@types/dockerode':
+      "@types/dockerode":
         specifier: ^3.3.38
         version: 3.3.47
-      '@types/jsdom':
+      "@types/jsdom":
         specifier: ^21.1.7
         version: 21.1.7
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
-      '@types/tar-stream':
+      "@types/tar-stream":
         specifier: ^3.1.4
         version: 3.1.4
-      '@types/turndown':
+      "@types/turndown":
         specifier: ^5.0.5
         version: 5.0.6
       tsc-alias:
@@ -229,14 +228,14 @@ importers:
 
   packages/cli:
     dependencies:
-      '@agentrail/app':
+      "@agentrail/app":
         specifier: workspace:*
         version: link:../app
-      '@clack/prompts':
+      "@clack/prompts":
         specifier: ^0.9.1
         version: 0.9.1
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -254,17 +253,17 @@ importers:
 
   packages/core:
     dependencies:
-      '@anthropic-ai/sdk':
+      "@anthropic-ai/sdk":
         specifier: ^0.39.0
         version: 0.39.0
-      '@sinclair/typebox':
+      "@sinclair/typebox":
         specifier: ^0.34.0
         version: 0.34.49
       openai:
         specifier: ^4.0.0
         version: 4.104.0(ws@8.20.0)
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -279,27 +278,27 @@ importers:
 
   packages/create-agentrail-app:
     dependencies:
-      '@agentrail/cli':
+      "@agentrail/cli":
         specifier: workspace:*
         version: link:../cli
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
 
   packages/deep-research:
     dependencies:
-      '@agentrail/capabilities':
+      "@agentrail/capabilities":
         specifier: workspace:*
         version: link:../capabilities
-      '@agentrail/core':
+      "@agentrail/core":
         specifier: workspace:*
         version: link:../core
       hono:
         specifier: ^4.12.12
         version: 4.12.12
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -314,11 +313,11 @@ importers:
 
   packages/testing:
     dependencies:
-      '@agentrail/core':
+      "@agentrail/core":
         specifier: workspace:*
         version: link:../core
     devDependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -335,1121 +334,1894 @@ importers:
         version: 2.1.9(@types/node@22.19.15)(jsdom@26.1.0)
 
 packages:
+  "@antfu/install-pkg@1.1.0":
+    resolution:
+      {
+        integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==,
+      }
 
-  '@antfu/install-pkg@1.1.0':
-    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+  "@anthropic-ai/sdk@0.39.0":
+    resolution:
+      {
+        integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==,
+      }
 
-  '@anthropic-ai/sdk@0.39.0':
-    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+  "@asamuzakjp/css-color@3.2.0":
+    resolution:
+      {
+        integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==,
+      }
 
-  '@asamuzakjp/css-color@3.2.0':
-    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+  "@babel/code-frame@7.29.0":
+    resolution:
+      {
+        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/compat-data@7.29.0":
+    resolution:
+      {
+        integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/core@7.29.0":
+    resolution:
+      {
+        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/generator@7.29.1":
+    resolution:
+      {
+        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-compilation-targets@7.28.6":
+    resolution:
+      {
+        integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-globals@7.28.0":
+    resolution:
+      {
+        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-module-imports@7.28.6":
+    resolution:
+      {
+        integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-module-transforms@7.28.6":
+    resolution:
+      {
+        integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-plugin-utils@7.28.6":
+    resolution:
+      {
+        integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-string-parser@7.27.1":
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-identifier@7.28.5":
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-option@7.27.1":
+    resolution:
+      {
+        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helpers@7.29.2":
+    resolution:
+      {
+        integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
+  "@babel/parser@7.29.2":
+    resolution:
+      {
+        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/plugin-transform-react-jsx-self@7.27.1":
+    resolution:
+      {
+        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      "@babel/core": ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/plugin-transform-react-jsx-source@7.27.1":
+    resolution:
+      {
+        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      "@babel/core": ^7.0.0-0
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
+  "@babel/runtime@7.29.2":
+    resolution:
+      {
+        integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
+  "@babel/template@7.28.6":
+    resolution:
+      {
+        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/traverse@7.29.0":
+    resolution:
+      {
+        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
+  "@babel/types@7.29.0":
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@balena/dockerignore@1.0.2':
-    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+  "@balena/dockerignore@1.0.2":
+    resolution:
+      {
+        integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==,
+      }
 
-  '@braintree/sanitize-url@7.1.2':
-    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+  "@braintree/sanitize-url@7.1.2":
+    resolution:
+      {
+        integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==,
+      }
 
-  '@changesets/apply-release-plan@7.1.0':
-    resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
+  "@changesets/apply-release-plan@7.1.0":
+    resolution:
+      {
+        integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==,
+      }
 
-  '@changesets/assemble-release-plan@6.0.9':
-    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
+  "@changesets/assemble-release-plan@6.0.9":
+    resolution:
+      {
+        integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==,
+      }
 
-  '@changesets/changelog-git@0.2.1':
-    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+  "@changesets/changelog-git@0.2.1":
+    resolution:
+      {
+        integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
+      }
 
-  '@changesets/changelog-github@0.6.0':
-    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
+  "@changesets/changelog-github@0.6.0":
+    resolution:
+      {
+        integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==,
+      }
 
-  '@changesets/cli@2.30.0':
-    resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
+  "@changesets/cli@2.30.0":
+    resolution:
+      {
+        integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==,
+      }
     hasBin: true
 
-  '@changesets/config@3.1.3':
-    resolution: {integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==}
+  "@changesets/config@3.1.3":
+    resolution:
+      {
+        integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==,
+      }
 
-  '@changesets/errors@0.2.0':
-    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+  "@changesets/errors@0.2.0":
+    resolution:
+      {
+        integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==,
+      }
 
-  '@changesets/get-dependents-graph@2.1.3':
-    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+  "@changesets/get-dependents-graph@2.1.3":
+    resolution:
+      {
+        integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==,
+      }
 
-  '@changesets/get-github-info@0.8.0':
-    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
+  "@changesets/get-github-info@0.8.0":
+    resolution:
+      {
+        integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==,
+      }
 
-  '@changesets/get-release-plan@4.0.15':
-    resolution: {integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==}
+  "@changesets/get-release-plan@4.0.15":
+    resolution:
+      {
+        integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==,
+      }
 
-  '@changesets/get-version-range-type@0.4.0':
-    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+  "@changesets/get-version-range-type@0.4.0":
+    resolution:
+      {
+        integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==,
+      }
 
-  '@changesets/git@3.0.4':
-    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+  "@changesets/git@3.0.4":
+    resolution:
+      {
+        integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==,
+      }
 
-  '@changesets/logger@0.1.1':
-    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+  "@changesets/logger@0.1.1":
+    resolution:
+      {
+        integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==,
+      }
 
-  '@changesets/parse@0.4.3':
-    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+  "@changesets/parse@0.4.3":
+    resolution:
+      {
+        integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==,
+      }
 
-  '@changesets/pre@2.0.2':
-    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+  "@changesets/pre@2.0.2":
+    resolution:
+      {
+        integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==,
+      }
 
-  '@changesets/read@0.6.7':
-    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+  "@changesets/read@0.6.7":
+    resolution:
+      {
+        integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==,
+      }
 
-  '@changesets/should-skip-package@0.1.2':
-    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+  "@changesets/should-skip-package@0.1.2":
+    resolution:
+      {
+        integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==,
+      }
 
-  '@changesets/types@4.1.0':
-    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+  "@changesets/types@4.1.0":
+    resolution:
+      {
+        integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==,
+      }
 
-  '@changesets/types@6.1.0':
-    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+  "@changesets/types@6.1.0":
+    resolution:
+      {
+        integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==,
+      }
 
-  '@changesets/write@0.4.0':
-    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+  "@changesets/write@0.4.0":
+    resolution:
+      {
+        integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
+      }
 
-  '@chevrotain/cst-dts-gen@11.1.2':
-    resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
+  "@chevrotain/cst-dts-gen@11.1.2":
+    resolution:
+      {
+        integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==,
+      }
 
-  '@chevrotain/gast@11.1.2':
-    resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
+  "@chevrotain/gast@11.1.2":
+    resolution:
+      {
+        integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==,
+      }
 
-  '@chevrotain/regexp-to-ast@11.1.2':
-    resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
+  "@chevrotain/regexp-to-ast@11.1.2":
+    resolution:
+      {
+        integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==,
+      }
 
-  '@chevrotain/types@11.1.2':
-    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+  "@chevrotain/types@11.1.2":
+    resolution:
+      {
+        integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==,
+      }
 
-  '@chevrotain/utils@11.1.2':
-    resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
+  "@chevrotain/utils@11.1.2":
+    resolution:
+      {
+        integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==,
+      }
 
-  '@clack/core@0.4.1':
-    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+  "@clack/core@0.4.1":
+    resolution:
+      {
+        integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==,
+      }
 
-  '@clack/prompts@0.9.1':
-    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
+  "@clack/prompts@0.9.1":
+    resolution:
+      {
+        integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==,
+      }
 
-  '@csstools/color-helpers@5.1.0':
-    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
-    engines: {node: '>=18'}
+  "@csstools/color-helpers@5.1.0":
+    resolution:
+      {
+        integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==,
+      }
+    engines: { node: ">=18" }
 
-  '@csstools/css-calc@2.1.4':
-    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
-    engines: {node: '>=18'}
+  "@csstools/css-calc@2.1.4":
+    resolution:
+      {
+        integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      "@csstools/css-parser-algorithms": ^3.0.5
+      "@csstools/css-tokenizer": ^3.0.4
 
-  '@csstools/css-color-parser@3.1.0':
-    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
-    engines: {node: '>=18'}
+  "@csstools/css-color-parser@3.1.0":
+    resolution:
+      {
+        integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      "@csstools/css-parser-algorithms": ^3.0.5
+      "@csstools/css-tokenizer": ^3.0.4
 
-  '@csstools/css-parser-algorithms@3.0.5':
-    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
-    engines: {node: '>=18'}
+  "@csstools/css-parser-algorithms@3.0.5":
+    resolution:
+      {
+        integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
-      '@csstools/css-tokenizer': ^3.0.4
+      "@csstools/css-tokenizer": ^3.0.4
 
-  '@csstools/css-tokenizer@3.0.4':
-    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
-    engines: {node: '>=18'}
+  "@csstools/css-tokenizer@3.0.4":
+    resolution:
+      {
+        integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==,
+      }
+    engines: { node: ">=18" }
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  "@esbuild/aix-ppc64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
+  "@esbuild/aix-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
-    engines: {node: '>=18'}
+  "@esbuild/aix-ppc64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm@0.21.5":
+    resolution:
+      {
+        integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm@0.27.4":
+    resolution:
+      {
+        integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  "@esbuild/android-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
+  "@esbuild/android-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
-    engines: {node: '>=18'}
+  "@esbuild/android-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm@0.21.5":
+    resolution:
+      {
+        integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm@0.27.4":
+    resolution:
+      {
+        integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ia32@0.21.5":
+    resolution:
+      {
+        integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ia32@0.27.4":
+    resolution:
+      {
+        integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-loong64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
+      }
+    engines: { node: ">=12" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-loong64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-loong64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-mips64el@0.21.5":
+    resolution:
+      {
+        integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
+      }
+    engines: { node: ">=12" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-mips64el@0.25.12":
+    resolution:
+      {
+        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+      }
+    engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-mips64el@0.27.4":
+    resolution:
+      {
+        integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==,
+      }
+    engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ppc64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ppc64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-riscv64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
+      }
+    engines: { node: ">=12" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-riscv64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+      }
+    engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-riscv64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==,
+      }
+    engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-s390x@0.21.5":
+    resolution:
+      {
+        integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
+      }
+    engines: { node: ">=12" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-s390x@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-s390x@0.27.4":
+    resolution:
+      {
+        integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  "@esbuild/netbsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  "@esbuild/openbsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
+  "@esbuild/openharmony-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
-    engines: {node: '>=18'}
+  "@esbuild/openharmony-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  "@esbuild/sunos-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
+  "@esbuild/sunos-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
-    engines: {node: '>=18'}
+  "@esbuild/sunos-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-ia32@0.21.5":
+    resolution:
+      {
+        integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-ia32@0.27.4":
+    resolution:
+      {
+        integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
-    engines: {node: '>=12.10.0'}
+  "@grpc/grpc-js@1.14.3":
+    resolution:
+      {
+        integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==,
+      }
+    engines: { node: ">=12.10.0" }
 
-  '@grpc/proto-loader@0.7.15':
-    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
-    engines: {node: '>=6'}
+  "@grpc/proto-loader@0.7.15":
+    resolution:
+      {
+        integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
-  '@grpc/proto-loader@0.8.0':
-    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
-    engines: {node: '>=6'}
+  "@grpc/proto-loader@0.8.0":
+    resolution:
+      {
+        integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
+  "@hono/node-server@1.19.13":
+    resolution:
+      {
+        integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==,
+      }
+    engines: { node: ">=18.14.1" }
     peerDependencies:
       hono: ^4
 
-  '@iconify/types@2.0.0':
-    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+  "@iconify/types@2.0.0":
+    resolution:
+      {
+        integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==,
+      }
 
-  '@iconify/utils@3.1.0':
-    resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
+  "@iconify/utils@3.1.0":
+    resolution:
+      {
+        integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==,
+      }
 
-  '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
-    engines: {node: '>=18'}
+  "@inquirer/external-editor@1.0.3":
+    resolution:
+      {
+        integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
-      '@types/node': '>=18'
+      "@types/node": ">=18"
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
 
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+  "@jridgewell/gen-mapping@0.3.13":
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+  "@jridgewell/remapping@2.3.5":
+    resolution:
+      {
+        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
+      }
 
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
+  "@jridgewell/resolve-uri@3.1.2":
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: ">=6.0.0" }
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
 
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+  "@jridgewell/trace-mapping@0.3.31":
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
 
-  '@js-sdsl/ordered-map@4.4.2':
-    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+  "@js-sdsl/ordered-map@4.4.2":
+    resolution:
+      {
+        integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==,
+      }
 
-  '@manypkg/find-root@1.1.0':
-    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+  "@manypkg/find-root@1.1.0":
+    resolution:
+      {
+        integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==,
+      }
 
-  '@manypkg/get-packages@1.1.3':
-    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+  "@manypkg/get-packages@1.1.3":
+    resolution:
+      {
+        integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==,
+      }
 
-  '@mermaid-js/parser@1.0.1':
-    resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
+  "@mermaid-js/parser@1.0.1":
+    resolution:
+      {
+        integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==,
+      }
 
-  '@mixmark-io/domino@2.2.0':
-    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+  "@mixmark-io/domino@2.2.0":
+    resolution:
+      {
+        integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==,
+      }
 
-  '@mozilla/readability@0.6.0':
-    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
-    engines: {node: '>=14.0.0'}
+  "@mozilla/readability@0.6.0":
+    resolution:
+      {
+        integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==,
+      }
+    engines: { node: ">=14.0.0" }
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.scandir@2.1.5":
+    resolution:
+      {
+        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
+      }
+    engines: { node: ">= 8" }
 
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.stat@2.0.5":
+    resolution:
+      {
+        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
+      }
+    engines: { node: ">= 8" }
 
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.walk@1.2.8":
+    resolution:
+      {
+        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
+      }
+    engines: { node: ">= 8" }
 
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+  "@protobufjs/aspromise@1.1.2":
+    resolution:
+      {
+        integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
+      }
 
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+  "@protobufjs/base64@1.1.2":
+    resolution:
+      {
+        integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
+      }
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  "@protobufjs/codegen@2.0.4":
+    resolution:
+      {
+        integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
+      }
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  "@protobufjs/eventemitter@1.1.0":
+    resolution:
+      {
+        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
+      }
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  "@protobufjs/fetch@1.1.0":
+    resolution:
+      {
+        integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==,
+      }
 
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+  "@protobufjs/float@1.0.2":
+    resolution:
+      {
+        integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
+      }
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  "@protobufjs/inquire@1.1.0":
+    resolution:
+      {
+        integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
+      }
 
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+  "@protobufjs/path@1.1.2":
+    resolution:
+      {
+        integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
+      }
 
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+  "@protobufjs/pool@1.1.0":
+    resolution:
+      {
+        integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
+      }
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  "@protobufjs/utf8@1.1.0":
+    resolution:
+      {
+        integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
+      }
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  "@rolldown/pluginutils@1.0.0-beta.27":
+    resolution:
+      {
+        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
+      }
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
-    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
+  "@rollup/rollup-android-arm-eabi@4.60.0":
+    resolution:
+      {
+        integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==,
+      }
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.0':
-    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
+  "@rollup/rollup-android-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==,
+      }
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
-    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
+  "@rollup/rollup-darwin-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==,
+      }
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.0':
-    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
+  "@rollup/rollup-darwin-x64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==,
+      }
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
-    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
+  "@rollup/rollup-freebsd-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==,
+      }
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.0':
-    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
+  "@rollup/rollup-freebsd-x64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==,
+      }
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
-    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.0":
+    resolution:
+      {
+        integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
-    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
+  "@rollup/rollup-linux-arm-musleabihf@4.60.0":
+    resolution:
+      {
+        integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
-    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
+  "@rollup/rollup-linux-arm64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
-    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
+  "@rollup/rollup-linux-arm64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
-    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
+  "@rollup/rollup-linux-loong64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==,
+      }
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
-    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
+  "@rollup/rollup-linux-loong64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==,
+      }
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
-    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
+  "@rollup/rollup-linux-ppc64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==,
+      }
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
-    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
+  "@rollup/rollup-linux-ppc64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==,
+      }
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
-    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
+  "@rollup/rollup-linux-riscv64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
-    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
+  "@rollup/rollup-linux-riscv64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
-    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
+  "@rollup/rollup-linux-s390x-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==,
+      }
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
+  "@rollup/rollup-linux-x64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
-    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
+  "@rollup/rollup-linux-x64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.60.0':
-    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
+  "@rollup/rollup-openbsd-x64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==,
+      }
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.0':
-    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
+  "@rollup/rollup-openharmony-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==,
+      }
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
-    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
+  "@rollup/rollup-win32-arm64-msvc@4.60.0":
+    resolution:
+      {
+        integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==,
+      }
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
-    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
+  "@rollup/rollup-win32-ia32-msvc@4.60.0":
+    resolution:
+      {
+        integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==,
+      }
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
+  "@rollup/rollup-win32-x64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
-    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
+  "@rollup/rollup-win32-x64-msvc@4.60.0":
+    resolution:
+      {
+        integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@sinclair/typebox@0.34.49':
-    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+  "@sinclair/typebox@0.34.49":
+    resolution:
+      {
+        integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==,
+      }
 
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+  "@types/babel__core@7.20.5":
+    resolution:
+      {
+        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
+      }
 
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+  "@types/babel__generator@7.27.0":
+    resolution:
+      {
+        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
+      }
 
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+  "@types/babel__template@7.4.4":
+    resolution:
+      {
+        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
+      }
 
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+  "@types/babel__traverse@7.28.0":
+    resolution:
+      {
+        integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
+      }
 
-  '@types/chai@5.2.3':
-    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+  "@types/chai@5.2.3":
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
 
-  '@types/d3-array@3.2.2':
-    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+  "@types/d3-array@3.2.2":
+    resolution:
+      {
+        integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==,
+      }
 
-  '@types/d3-axis@3.0.6':
-    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+  "@types/d3-axis@3.0.6":
+    resolution:
+      {
+        integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==,
+      }
 
-  '@types/d3-brush@3.0.6':
-    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+  "@types/d3-brush@3.0.6":
+    resolution:
+      {
+        integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==,
+      }
 
-  '@types/d3-chord@3.0.6':
-    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+  "@types/d3-chord@3.0.6":
+    resolution:
+      {
+        integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==,
+      }
 
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+  "@types/d3-color@3.1.3":
+    resolution:
+      {
+        integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==,
+      }
 
-  '@types/d3-contour@3.0.6':
-    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+  "@types/d3-contour@3.0.6":
+    resolution:
+      {
+        integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==,
+      }
 
-  '@types/d3-delaunay@6.0.4':
-    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+  "@types/d3-delaunay@6.0.4":
+    resolution:
+      {
+        integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==,
+      }
 
-  '@types/d3-dispatch@3.0.7':
-    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+  "@types/d3-dispatch@3.0.7":
+    resolution:
+      {
+        integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==,
+      }
 
-  '@types/d3-drag@3.0.7':
-    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+  "@types/d3-drag@3.0.7":
+    resolution:
+      {
+        integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==,
+      }
 
-  '@types/d3-dsv@3.0.7':
-    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+  "@types/d3-dsv@3.0.7":
+    resolution:
+      {
+        integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==,
+      }
 
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+  "@types/d3-ease@3.0.2":
+    resolution:
+      {
+        integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==,
+      }
 
-  '@types/d3-fetch@3.0.7':
-    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+  "@types/d3-fetch@3.0.7":
+    resolution:
+      {
+        integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==,
+      }
 
-  '@types/d3-force@3.0.10':
-    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+  "@types/d3-force@3.0.10":
+    resolution:
+      {
+        integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==,
+      }
 
-  '@types/d3-format@3.0.4':
-    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+  "@types/d3-format@3.0.4":
+    resolution:
+      {
+        integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==,
+      }
 
-  '@types/d3-geo@3.1.0':
-    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+  "@types/d3-geo@3.1.0":
+    resolution:
+      {
+        integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==,
+      }
 
-  '@types/d3-hierarchy@3.1.7':
-    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+  "@types/d3-hierarchy@3.1.7":
+    resolution:
+      {
+        integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==,
+      }
 
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+  "@types/d3-interpolate@3.0.4":
+    resolution:
+      {
+        integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==,
+      }
 
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+  "@types/d3-path@3.1.1":
+    resolution:
+      {
+        integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==,
+      }
 
-  '@types/d3-polygon@3.0.2':
-    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+  "@types/d3-polygon@3.0.2":
+    resolution:
+      {
+        integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==,
+      }
 
-  '@types/d3-quadtree@3.0.6':
-    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+  "@types/d3-quadtree@3.0.6":
+    resolution:
+      {
+        integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==,
+      }
 
-  '@types/d3-random@3.0.3':
-    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+  "@types/d3-random@3.0.3":
+    resolution:
+      {
+        integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==,
+      }
 
-  '@types/d3-scale-chromatic@3.1.0':
-    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+  "@types/d3-scale-chromatic@3.1.0":
+    resolution:
+      {
+        integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==,
+      }
 
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+  "@types/d3-scale@4.0.9":
+    resolution:
+      {
+        integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==,
+      }
 
-  '@types/d3-selection@3.0.11':
-    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+  "@types/d3-selection@3.0.11":
+    resolution:
+      {
+        integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==,
+      }
 
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+  "@types/d3-shape@3.1.8":
+    resolution:
+      {
+        integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==,
+      }
 
-  '@types/d3-time-format@4.0.3':
-    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+  "@types/d3-time-format@4.0.3":
+    resolution:
+      {
+        integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==,
+      }
 
-  '@types/d3-time@3.0.4':
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+  "@types/d3-time@3.0.4":
+    resolution:
+      {
+        integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==,
+      }
 
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+  "@types/d3-timer@3.0.2":
+    resolution:
+      {
+        integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==,
+      }
 
-  '@types/d3-transition@3.0.9':
-    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+  "@types/d3-transition@3.0.9":
+    resolution:
+      {
+        integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==,
+      }
 
-  '@types/d3-zoom@3.0.8':
-    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+  "@types/d3-zoom@3.0.8":
+    resolution:
+      {
+        integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==,
+      }
 
-  '@types/d3@7.4.3':
-    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+  "@types/d3@7.4.3":
+    resolution:
+      {
+        integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==,
+      }
 
-  '@types/debug@4.1.13':
-    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+  "@types/debug@4.1.13":
+    resolution:
+      {
+        integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
+      }
 
-  '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+  "@types/deep-eql@4.0.2":
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
 
-  '@types/docker-modem@3.0.6':
-    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+  "@types/docker-modem@3.0.6":
+    resolution:
+      {
+        integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==,
+      }
 
-  '@types/dockerode@3.3.47':
-    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+  "@types/dockerode@3.3.47":
+    resolution:
+      {
+        integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==,
+      }
 
-  '@types/dompurify@3.2.0':
-    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+  "@types/dompurify@3.2.0":
+    resolution:
+      {
+        integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==,
+      }
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
 
-  '@types/estree-jsx@1.0.5':
-    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+  "@types/estree-jsx@1.0.5":
+    resolution:
+      {
+        integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
+      }
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  "@types/estree@1.0.8":
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
-  '@types/geojson@7946.0.16':
-    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+  "@types/geojson@7946.0.16":
+    resolution:
+      {
+        integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==,
+      }
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+  "@types/hast@3.0.4":
+    resolution:
+      {
+        integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
+      }
 
-  '@types/jsdom@21.1.7':
-    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+  "@types/jsdom@21.1.7":
+    resolution:
+      {
+        integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==,
+      }
 
-  '@types/mdast@4.0.4':
-    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+  "@types/mdast@4.0.4":
+    resolution:
+      {
+        integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
+      }
 
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+  "@types/ms@2.1.0":
+    resolution:
+      {
+        integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
+      }
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+  "@types/node-fetch@2.6.13":
+    resolution:
+      {
+        integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==,
+      }
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+  "@types/node@12.20.55":
+    resolution:
+      {
+        integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==,
+      }
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+  "@types/node@18.19.130":
+    resolution:
+      {
+        integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==,
+      }
 
-  '@types/node@22.19.15':
-    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+  "@types/node@22.19.15":
+    resolution:
+      {
+        integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==,
+      }
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  "@types/react-dom@19.2.3":
+    resolution:
+      {
+        integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
+      }
     peerDependencies:
-      '@types/react': ^19.2.0
+      "@types/react": ^19.2.0
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  "@types/react@19.2.14":
+    resolution:
+      {
+        integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
+      }
 
-  '@types/ssh2@1.15.5':
-    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
+  "@types/ssh2@1.15.5":
+    resolution:
+      {
+        integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==,
+      }
 
-  '@types/tar-stream@3.1.4':
-    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+  "@types/tar-stream@3.1.4":
+    resolution:
+      {
+        integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==,
+      }
 
-  '@types/tough-cookie@4.0.5':
-    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+  "@types/tough-cookie@4.0.5":
+    resolution:
+      {
+        integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==,
+      }
 
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+  "@types/trusted-types@2.0.7":
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
+      }
 
-  '@types/turndown@5.0.6':
-    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
+  "@types/turndown@5.0.6":
+    resolution:
+      {
+        integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==,
+      }
 
-  '@types/unist@2.0.11':
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+  "@types/unist@2.0.11":
+    resolution:
+      {
+        integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==,
+      }
 
-  '@types/unist@3.0.3':
-    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+  "@types/unist@3.0.3":
+    resolution:
+      {
+        integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
+      }
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+  "@ungap/structured-clone@1.3.0":
+    resolution:
+      {
+        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
+      }
 
-  '@upsetjs/venn.js@2.0.0':
-    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+  "@upsetjs/venn.js@2.0.0":
+    resolution:
+      {
+        integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==,
+      }
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  "@vitejs/plugin-react@4.7.0":
+    resolution:
+      {
+        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
+      }
+    engines: { node: ^14.18.0 || >=16.0.0 }
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+  "@vitest/expect@2.1.9":
+    resolution:
+      {
+        integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==,
+      }
 
-  '@vitest/expect@4.1.3':
-    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+  "@vitest/expect@4.1.3":
+    resolution:
+      {
+        integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==,
+      }
 
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+  "@vitest/mocker@2.1.9":
+    resolution:
+      {
+        integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==,
+      }
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0
@@ -1459,8 +2231,11 @@ packages:
       vite:
         optional: true
 
-  '@vitest/mocker@4.1.3':
-    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+  "@vitest/mocker@4.1.3":
+    resolution:
+      {
+        integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==,
+      }
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1470,145 +2245,250 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  "@vitest/pretty-format@2.1.9":
+    resolution:
+      {
+        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
+      }
 
-  '@vitest/pretty-format@4.1.3':
-    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
+  "@vitest/pretty-format@4.1.3":
+    resolution:
+      {
+        integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==,
+      }
 
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+  "@vitest/runner@2.1.9":
+    resolution:
+      {
+        integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==,
+      }
 
-  '@vitest/runner@4.1.3':
-    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+  "@vitest/runner@4.1.3":
+    resolution:
+      {
+        integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==,
+      }
 
-  '@vitest/snapshot@2.1.9':
-    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+  "@vitest/snapshot@2.1.9":
+    resolution:
+      {
+        integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==,
+      }
 
-  '@vitest/snapshot@4.1.3':
-    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+  "@vitest/snapshot@4.1.3":
+    resolution:
+      {
+        integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==,
+      }
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+  "@vitest/spy@2.1.9":
+    resolution:
+      {
+        integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==,
+      }
 
-  '@vitest/spy@4.1.3':
-    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
+  "@vitest/spy@4.1.3":
+    resolution:
+      {
+        integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==,
+      }
 
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  "@vitest/utils@2.1.9":
+    resolution:
+      {
+        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
+      }
 
-  '@vitest/utils@4.1.3':
-    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
+  "@vitest/utils@4.1.3":
+    resolution:
+      {
+        integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==,
+      }
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
-    engines: {node: '>=10.0.0'}
+  "@xmldom/xmldom@0.8.11":
+    resolution:
+      {
+        integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==,
+      }
+    engines: { node: ">=10.0.0" }
 
   abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
+    resolution:
+      {
+        integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==,
+      }
+    engines: { node: ">=6.5" }
 
   accepts@1.3.8:
-    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==,
+      }
+    engines: { node: ">= 0.6" }
 
   acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
 
   adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==,
+      }
+    engines: { node: ">=0.8" }
 
   agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
+      }
+    engines: { node: ">= 14" }
 
   agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
+    resolution:
+      {
+        integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==,
+      }
+    engines: { node: ">= 8.0.0" }
 
   ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
+      }
+    engines: { node: ">=6" }
 
   ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+      }
+    engines: { node: ">=8" }
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: ">=8" }
 
   anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
+      }
+    engines: { node: ">= 8" }
 
   argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    resolution:
+      {
+        integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    resolution:
+      {
+        integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==,
+      }
 
   array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
+      }
+    engines: { node: ">=8" }
 
   asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    resolution:
+      {
+        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==,
+      }
 
   assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
 
   asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
+      }
 
   b4a@1.8.0:
-    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    resolution:
+      {
+        integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==,
+      }
     peerDependencies:
-      react-native-b4a: '*'
+      react-native-b4a: "*"
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
 
   bail@2.0.2:
-    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+    resolution:
+      {
+        integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
+      }
 
   bare-events@2.8.2:
-    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    resolution:
+      {
+        integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==,
+      }
     peerDependencies:
-      bare-abort-controller: '*'
+      bare-abort-controller: "*"
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
 
   bare-fs@4.5.6:
-    resolution: {integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==}
-    engines: {bare: '>=1.16.0'}
+    resolution:
+      {
+        integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==,
+      }
+    engines: { bare: ">=1.16.0" }
     peerDependencies:
-      bare-buffer: '*'
+      bare-buffer: "*"
     peerDependenciesMeta:
       bare-buffer:
         optional: true
 
   bare-os@3.8.6:
-    resolution: {integrity: sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==}
-    engines: {bare: '>=1.14.0'}
+    resolution:
+      {
+        integrity: sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==,
+      }
+    engines: { bare: ">=1.14.0" }
 
   bare-path@3.0.0:
-    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+    resolution:
+      {
+        integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==,
+      }
 
   bare-stream@2.11.0:
-    resolution: {integrity: sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==}
+    resolution:
+      {
+        integrity: sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==,
+      }
     peerDependencies:
-      bare-abort-controller: '*'
-      bare-buffer: '*'
-      bare-events: '*'
+      bare-abort-controller: "*"
+      bare-buffer: "*"
+      bare-events: "*"
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
@@ -1618,583 +2498,1039 @@ packages:
         optional: true
 
   bare-url@2.4.0:
-    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
+    resolution:
+      {
+        integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==,
+      }
 
   base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
 
   baseline-browser-mapping@2.10.12:
-    resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
   bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+    resolution:
+      {
+        integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==,
+      }
 
   better-path-resolve@1.0.0:
-    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==,
+      }
+    engines: { node: ">=4" }
 
   binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
+      }
+    engines: { node: ">=8" }
 
   bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
 
   bluebird@3.4.7:
-    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+    resolution:
+      {
+        integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==,
+      }
 
   body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    resolution:
+      {
+        integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==,
+      }
+    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
 
   braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+      }
+    engines: { node: ">=8" }
 
   browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    resolution:
+      {
+        integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
 
   buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   buildcheck@0.0.7:
-    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==,
+      }
+    engines: { node: ">=10.0.0" }
 
   bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+      }
+    engines: { node: ">= 0.8" }
 
   cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
+      }
+    engines: { node: ">=8" }
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+      }
+    engines: { node: ">= 0.4" }
 
   caniuse-lite@1.0.30001781:
-    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+    resolution:
+      {
+        integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==,
+      }
 
   ccount@2.0.1:
-    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+    resolution:
+      {
+        integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
+      }
 
   cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==,
+      }
+    engines: { node: ">=0.8" }
 
   chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
+      }
+    engines: { node: ">=18" }
 
   chai@6.2.2:
-    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: ">=18" }
 
   chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: ">=10" }
 
   character-entities-html4@2.1.0:
-    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+    resolution:
+      {
+        integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
+      }
 
   character-entities-legacy@3.0.0:
-    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+    resolution:
+      {
+        integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
+      }
 
   character-entities@2.0.2:
-    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    resolution:
+      {
+        integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
+      }
 
   character-reference-invalid@2.0.1:
-    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+    resolution:
+      {
+        integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
+      }
 
   chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+    resolution:
+      {
+        integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
+      }
 
   check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
+    resolution:
+      {
+        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
+      }
+    engines: { node: ">= 16" }
 
   chevrotain-allstar@0.3.1:
-    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
+    resolution:
+      {
+        integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==,
+      }
     peerDependencies:
       chevrotain: ^11.0.0
 
   chevrotain@11.1.2:
-    resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
+    resolution:
+      {
+        integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==,
+      }
 
   chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+    resolution:
+      {
+        integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
+      }
+    engines: { node: ">= 8.10.0" }
 
   chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    resolution:
+      {
+        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
+      }
 
   cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+      }
+    engines: { node: ">=12" }
 
   codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==,
+      }
+    engines: { node: ">=0.8" }
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
 
   combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: ">= 0.8" }
 
   comma-separated-tokens@2.0.3:
-    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+    resolution:
+      {
+        integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
+      }
 
   commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==,
+      }
+    engines: { node: ">= 10" }
 
   commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==,
+      }
+    engines: { node: ">= 12" }
 
   commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
-    engines: {node: ^12.20.0 || >=14}
+    resolution:
+      {
+        integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==,
+      }
+    engines: { node: ^12.20.0 || >=14 }
 
   concurrently@9.2.1:
-    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    resolution:
+      {
+        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
+      }
 
   content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==,
+      }
+    engines: { node: ">= 0.6" }
 
   content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
+      }
+    engines: { node: ">= 0.6" }
 
   convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
 
   cookie-signature@1.0.7:
-    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+    resolution:
+      {
+        integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==,
+      }
 
   cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
+      }
+    engines: { node: ">= 0.6" }
 
   core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    resolution:
+      {
+        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
+      }
 
   cose-base@1.0.3:
-    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+    resolution:
+      {
+        integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==,
+      }
 
   cose-base@2.2.0:
-    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+    resolution:
+      {
+        integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==,
+      }
 
   cpu-features@0.0.10:
-    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==,
+      }
+    engines: { node: ">=10.0.0" }
 
   crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==,
+      }
+    engines: { node: ">=0.8" }
     hasBin: true
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: ">= 8" }
 
   cssstyle@4.6.0:
-    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==,
+      }
+    engines: { node: ">=18" }
 
   csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+    resolution:
+      {
+        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+      }
 
   cytoscape-cose-bilkent@4.1.0:
-    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    resolution:
+      {
+        integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==,
+      }
     peerDependencies:
       cytoscape: ^3.2.0
 
   cytoscape-fcose@2.2.0:
-    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    resolution:
+      {
+        integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==,
+      }
     peerDependencies:
       cytoscape: ^3.2.0
 
   cytoscape@3.33.1:
-    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==,
+      }
+    engines: { node: ">=0.10" }
 
   d3-array@2.12.1:
-    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+    resolution:
+      {
+        integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==,
+      }
 
   d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==,
+      }
+    engines: { node: ">=12" }
 
   d3-axis@3.0.0:
-    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==,
+      }
+    engines: { node: ">=12" }
 
   d3-brush@3.0.0:
-    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-chord@3.0.1:
-    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==,
+      }
+    engines: { node: ">=12" }
 
   d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==,
+      }
+    engines: { node: ">=12" }
 
   d3-contour@4.0.2:
-    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==,
+      }
+    engines: { node: ">=12" }
 
   d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==,
+      }
+    engines: { node: ">=12" }
 
   d3-dispatch@3.0.1:
-    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==,
+      }
+    engines: { node: ">=12" }
 
   d3-drag@3.0.0:
-    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==,
+      }
+    engines: { node: ">=12" }
 
   d3-dsv@3.0.1:
-    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==,
+      }
+    engines: { node: ">=12" }
     hasBin: true
 
   d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==,
+      }
+    engines: { node: ">=12" }
 
   d3-fetch@3.0.1:
-    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==,
+      }
+    engines: { node: ">=12" }
 
   d3-force@3.0.0:
-    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==,
+      }
+    engines: { node: ">=12" }
 
   d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==,
+      }
+    engines: { node: ">=12" }
 
   d3-geo@3.1.1:
-    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==,
+      }
+    engines: { node: ">=12" }
 
   d3-hierarchy@3.1.2:
-    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==,
+      }
+    engines: { node: ">=12" }
 
   d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==,
+      }
+    engines: { node: ">=12" }
 
   d3-path@1.0.9:
-    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+    resolution:
+      {
+        integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==,
+      }
 
   d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-polygon@3.0.1:
-    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==,
+      }
+    engines: { node: ">=12" }
 
   d3-quadtree@3.0.1:
-    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==,
+      }
+    engines: { node: ">=12" }
 
   d3-random@3.0.1:
-    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-sankey@0.12.3:
-    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+    resolution:
+      {
+        integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==,
+      }
 
   d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-selection@3.0.0:
-    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==,
+      }
+    engines: { node: ">=12" }
 
   d3-shape@1.3.7:
-    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+    resolution:
+      {
+        integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==,
+      }
 
   d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==,
+      }
+    engines: { node: ">=12" }
 
   d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==,
+      }
+    engines: { node: ">=12" }
 
   d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==,
+      }
+    engines: { node: ">=12" }
 
   d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==,
+      }
+    engines: { node: ">=12" }
 
   d3-transition@3.0.1:
-    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==,
+      }
+    engines: { node: ">=12" }
     peerDependencies:
       d3-selection: 2 - 3
 
   d3-zoom@3.0.0:
-    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==,
+      }
+    engines: { node: ">=12" }
 
   d3@7.9.0:
-    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==,
+      }
+    engines: { node: ">=12" }
 
   dagre-d3-es@7.0.14:
-    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+    resolution:
+      {
+        integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==,
+      }
 
   data-urls@5.0.0:
-    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==,
+      }
+    engines: { node: ">=18" }
 
   dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+    resolution:
+      {
+        integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
+      }
 
   dayjs@1.11.20:
-    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+    resolution:
+      {
+        integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==,
+      }
 
   debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    resolution:
+      {
+        integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
+      }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: ">=6.0" }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   decimal.js@10.6.0:
-    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+    resolution:
+      {
+        integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
+      }
 
   decode-named-character-reference@1.3.0:
-    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+    resolution:
+      {
+        integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
+      }
 
   deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
+      }
+    engines: { node: ">=6" }
 
   delaunator@5.1.0:
-    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+    resolution:
+      {
+        integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==,
+      }
 
   delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: ">=0.4.0" }
 
   depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+      }
+    engines: { node: ">= 0.8" }
 
   dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+      }
+    engines: { node: ">=6" }
 
   destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    resolution:
+      {
+        integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==,
+      }
+    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
 
   detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==,
+      }
+    engines: { node: ">=8" }
 
   devlop@1.1.0:
-    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+    resolution:
+      {
+        integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
+      }
 
   dingbat-to-unicode@1.0.1:
-    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+    resolution:
+      {
+        integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==,
+      }
 
   dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
+      }
+    engines: { node: ">=8" }
 
   docker-modem@5.0.7:
-    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
-    engines: {node: '>= 8.0'}
+    resolution:
+      {
+        integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==,
+      }
+    engines: { node: ">= 8.0" }
 
   dockerode@4.0.10:
-    resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
-    engines: {node: '>= 8.0'}
+    resolution:
+      {
+        integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==,
+      }
+    engines: { node: ">= 8.0" }
 
   dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+    resolution:
+      {
+        integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==,
+      }
 
   dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==,
+      }
+    engines: { node: ">=10" }
 
   duck@0.1.12:
-    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
+    resolution:
+      {
+        integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==,
+      }
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: ">= 0.4" }
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution:
+      {
+        integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+      }
 
   electron-to-chromium@1.5.328:
-    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+    resolution:
+      {
+        integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==,
+      }
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution:
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
 
   encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
+      }
+    engines: { node: ">= 0.8" }
 
   end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+      }
 
   enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
+      }
+    engines: { node: ">=8.6" }
 
   entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
+    resolution:
+      {
+        integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
+      }
+    engines: { node: ">=0.12" }
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+    resolution:
+      {
+        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+      }
 
   es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+    resolution:
+      {
+        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
+      }
 
   es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: ">= 0.4" }
 
   esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
+      }
+    engines: { node: ">=12" }
     hasBin: true
 
   esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: ">=6" }
 
   escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    resolution:
+      {
+        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+      }
 
   escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
+      }
+    engines: { node: ">=12" }
 
   esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+      }
+    engines: { node: ">=4" }
     hasBin: true
 
   estree-util-is-identifier-name@3.0.0:
-    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+    resolution:
+      {
+        integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
+      }
 
   estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
 
   etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
+      }
+    engines: { node: ">= 0.6" }
 
   event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==,
+      }
+    engines: { node: ">=6" }
 
   events-universal@1.0.1:
-    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+    resolution:
+      {
+        integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==,
+      }
 
   expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
 
   express@4.22.1:
-    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
-    engines: {node: '>= 0.10.0'}
+    resolution:
+      {
+        integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==,
+      }
+    engines: { node: ">= 0.10.0" }
 
   extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    resolution:
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+      }
 
   extendable-error@0.1.7:
-    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+    resolution:
+      {
+        integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==,
+      }
 
   fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+    resolution:
+      {
+        integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==,
+      }
 
   fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
+    resolution:
+      {
+        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+      }
+    engines: { node: ">=8.6.0" }
 
   fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+    resolution:
+      {
+        integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
+      }
 
   fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2202,262 +3538,472 @@ packages:
         optional: true
 
   fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+      }
+    engines: { node: ">=8" }
 
   finalhandler@1.3.2:
-    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==,
+      }
+    engines: { node: ">= 0.8" }
 
   find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
+      }
+    engines: { node: ">=8" }
 
   form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+    resolution:
+      {
+        integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==,
+      }
 
   form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==,
+      }
+    engines: { node: ">= 6" }
 
   formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
+    resolution:
+      {
+        integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==,
+      }
+    engines: { node: ">= 12.20" }
 
   forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
+      }
+    engines: { node: ">= 0.6" }
 
   frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==,
+      }
+    engines: { node: ">=0.8" }
 
   fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==,
+      }
+    engines: { node: ">= 0.6" }
 
   fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    resolution:
+      {
+        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
+      }
 
   fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
+    resolution:
+      {
+        integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==,
+      }
+    engines: { node: ">=6 <7 || >=8" }
 
   fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
+    resolution:
+      {
+        integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
+      }
+    engines: { node: ">=6 <7 || >=8" }
 
   fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
 
   gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: ">=6.9.0" }
 
   get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+    resolution:
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+    resolution:
+      {
+        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
+      }
 
   glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
+      }
+    engines: { node: ">= 6" }
 
   globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
+      }
+    engines: { node: ">=10" }
 
   globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    resolution:
+      {
+        integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==,
+      }
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: ">= 0.4" }
 
   graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
 
   hachure-fill@0.5.2:
-    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+    resolution:
+      {
+        integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==,
+      }
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: ">= 0.4" }
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   hast-util-to-jsx-runtime@2.3.6:
-    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+    resolution:
+      {
+        integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
+      }
 
   hast-util-whitespace@3.0.0:
-    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+    resolution:
+      {
+        integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
+      }
 
   hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
-    engines: {node: '>=16.9.0'}
+    resolution:
+      {
+        integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==,
+      }
+    engines: { node: ">=16.9.0" }
 
   html-encoding-sniffer@4.0.0:
-    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==,
+      }
+    engines: { node: ">=18" }
 
   html-url-attributes@3.0.1:
-    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+    resolution:
+      {
+        integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==,
+      }
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
+      }
+    engines: { node: ">= 14" }
 
   https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
+      }
+    engines: { node: ">= 14" }
 
   human-id@4.1.3:
-    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
+    resolution:
+      {
+        integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==,
+      }
     hasBin: true
 
   humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    resolution:
+      {
+        integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==,
+      }
 
   iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
 
   ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: ">= 4" }
 
   immediate@3.0.6:
-    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+    resolution:
+      {
+        integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==,
+      }
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   inline-style-parser@0.2.7:
-    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+    resolution:
+      {
+        integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==,
+      }
 
   internmap@1.0.1:
-    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+    resolution:
+      {
+        integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==,
+      }
 
   internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==,
+      }
+    engines: { node: ">=12" }
 
   ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==,
+      }
+    engines: { node: ">= 0.10" }
 
   is-alphabetical@2.0.1:
-    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+    resolution:
+      {
+        integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
+      }
 
   is-alphanumerical@2.0.1:
-    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+    resolution:
+      {
+        integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
+      }
 
   is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
+      }
+    engines: { node: ">=8" }
 
   is-decimal@2.0.1:
-    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+    resolution:
+      {
+        integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
+      }
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+      }
+    engines: { node: ">=8" }
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-hexadecimal@2.0.1:
-    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+    resolution:
+      {
+        integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
+      }
 
   is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: ">=0.12.0" }
 
   is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
+      }
+    engines: { node: ">=12" }
 
   is-potential-custom-element-name@1.0.1:
-    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    resolution:
+      {
+        integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==,
+      }
 
   is-subdir@1.2.0:
-    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==,
+      }
+    engines: { node: ">=4" }
 
   is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    resolution:
+      {
+        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
+      }
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
 
   js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
 
   js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    resolution:
+      {
+        integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
+      }
     hasBin: true
 
   js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
     hasBin: true
 
   jsdom@26.1.0:
-    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==,
+      }
+    engines: { node: ">=18" }
     peerDependencies:
       canvas: ^3.0.0
     peerDependenciesMeta:
@@ -2465,296 +4011,560 @@ packages:
         optional: true
 
   jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
   json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
   jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    resolution:
+      {
+        integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
+      }
 
   jszip@3.10.1:
-    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+    resolution:
+      {
+        integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==,
+      }
 
   katex@0.16.44:
-    resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
+    resolution:
+      {
+        integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==,
+      }
     hasBin: true
 
   khroma@2.1.0:
-    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+    resolution:
+      {
+        integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==,
+      }
 
   langium@4.2.1:
-    resolution: {integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==}
-    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    resolution:
+      {
+        integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==,
+      }
+    engines: { node: ">=20.10.0", npm: ">=10.2.3" }
 
   layout-base@1.0.2:
-    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+    resolution:
+      {
+        integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==,
+      }
 
   layout-base@2.0.1:
-    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+    resolution:
+      {
+        integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==,
+      }
 
   lie@3.3.0:
-    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+    resolution:
+      {
+        integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==,
+      }
 
   locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
+      }
+    engines: { node: ">=8" }
 
   lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+    resolution:
+      {
+        integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==,
+      }
 
   lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+    resolution:
+      {
+        integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==,
+      }
 
   lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    resolution:
+      {
+        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
+      }
 
   long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+    resolution:
+      {
+        integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==,
+      }
 
   longest-streak@3.1.0:
-    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+    resolution:
+      {
+        integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
+      }
 
   lop@0.4.2:
-    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+    resolution:
+      {
+        integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==,
+      }
 
   loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+    resolution:
+      {
+        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
+      }
 
   lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+    resolution:
+      {
+        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+      }
 
   lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    resolution:
+      {
+        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+      }
 
   magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
 
   mammoth@1.12.0:
-    resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==,
+      }
+    engines: { node: ">=12.0.0" }
     hasBin: true
 
   markdown-table@3.0.4:
-    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+    resolution:
+      {
+        integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
+      }
 
   marked@16.4.2:
-    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
-    engines: {node: '>= 20'}
+    resolution:
+      {
+        integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==,
+      }
+    engines: { node: ">= 20" }
     hasBin: true
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: ">= 0.4" }
 
   mdast-util-find-and-replace@3.0.2:
-    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+    resolution:
+      {
+        integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
+      }
 
   mdast-util-from-markdown@2.0.3:
-    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+    resolution:
+      {
+        integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
+      }
 
   mdast-util-gfm-autolink-literal@2.0.1:
-    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+    resolution:
+      {
+        integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==,
+      }
 
   mdast-util-gfm-footnote@2.1.0:
-    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+    resolution:
+      {
+        integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==,
+      }
 
   mdast-util-gfm-strikethrough@2.0.0:
-    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+    resolution:
+      {
+        integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==,
+      }
 
   mdast-util-gfm-table@2.0.0:
-    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+    resolution:
+      {
+        integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==,
+      }
 
   mdast-util-gfm-task-list-item@2.0.0:
-    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+    resolution:
+      {
+        integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==,
+      }
 
   mdast-util-gfm@3.1.0:
-    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+    resolution:
+      {
+        integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==,
+      }
 
   mdast-util-mdx-expression@2.0.1:
-    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+    resolution:
+      {
+        integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==,
+      }
 
   mdast-util-mdx-jsx@3.2.0:
-    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+    resolution:
+      {
+        integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==,
+      }
 
   mdast-util-mdxjs-esm@2.0.1:
-    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+    resolution:
+      {
+        integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
+      }
 
   mdast-util-phrasing@4.1.0:
-    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+    resolution:
+      {
+        integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
+      }
 
   mdast-util-to-hast@13.2.1:
-    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+    resolution:
+      {
+        integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
+      }
 
   mdast-util-to-markdown@2.1.2:
-    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+    resolution:
+      {
+        integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==,
+      }
 
   mdast-util-to-string@4.0.0:
-    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+    resolution:
+      {
+        integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
+      }
 
   media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==,
+      }
+    engines: { node: ">= 0.6" }
 
   merge-descriptors@1.0.3:
-    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+    resolution:
+      {
+        integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==,
+      }
 
   merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+      }
+    engines: { node: ">= 8" }
 
   mermaid@11.13.0:
-    resolution: {integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==}
+    resolution:
+      {
+        integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==,
+      }
 
   methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==,
+      }
+    engines: { node: ">= 0.6" }
 
   micromark-core-commonmark@2.0.3:
-    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+    resolution:
+      {
+        integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
+      }
 
   micromark-extension-gfm-autolink-literal@2.1.0:
-    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+    resolution:
+      {
+        integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==,
+      }
 
   micromark-extension-gfm-footnote@2.1.0:
-    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+    resolution:
+      {
+        integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==,
+      }
 
   micromark-extension-gfm-strikethrough@2.1.0:
-    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+    resolution:
+      {
+        integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==,
+      }
 
   micromark-extension-gfm-table@2.1.1:
-    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+    resolution:
+      {
+        integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==,
+      }
 
   micromark-extension-gfm-tagfilter@2.0.0:
-    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+    resolution:
+      {
+        integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==,
+      }
 
   micromark-extension-gfm-task-list-item@2.1.0:
-    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+    resolution:
+      {
+        integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==,
+      }
 
   micromark-extension-gfm@3.0.0:
-    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+    resolution:
+      {
+        integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==,
+      }
 
   micromark-factory-destination@2.0.1:
-    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+    resolution:
+      {
+        integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==,
+      }
 
   micromark-factory-label@2.0.1:
-    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+    resolution:
+      {
+        integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==,
+      }
 
   micromark-factory-space@2.0.1:
-    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+    resolution:
+      {
+        integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==,
+      }
 
   micromark-factory-title@2.0.1:
-    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+    resolution:
+      {
+        integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==,
+      }
 
   micromark-factory-whitespace@2.0.1:
-    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+    resolution:
+      {
+        integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==,
+      }
 
   micromark-util-character@2.1.1:
-    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+    resolution:
+      {
+        integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==,
+      }
 
   micromark-util-chunked@2.0.1:
-    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+    resolution:
+      {
+        integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==,
+      }
 
   micromark-util-classify-character@2.0.1:
-    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+    resolution:
+      {
+        integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==,
+      }
 
   micromark-util-combine-extensions@2.0.1:
-    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+    resolution:
+      {
+        integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==,
+      }
 
   micromark-util-decode-numeric-character-reference@2.0.2:
-    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+    resolution:
+      {
+        integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==,
+      }
 
   micromark-util-decode-string@2.0.1:
-    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+    resolution:
+      {
+        integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==,
+      }
 
   micromark-util-encode@2.0.1:
-    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+    resolution:
+      {
+        integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==,
+      }
 
   micromark-util-html-tag-name@2.0.1:
-    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+    resolution:
+      {
+        integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==,
+      }
 
   micromark-util-normalize-identifier@2.0.1:
-    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+    resolution:
+      {
+        integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==,
+      }
 
   micromark-util-resolve-all@2.0.1:
-    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+    resolution:
+      {
+        integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==,
+      }
 
   micromark-util-sanitize-uri@2.0.1:
-    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+    resolution:
+      {
+        integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==,
+      }
 
   micromark-util-subtokenize@2.1.0:
-    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+    resolution:
+      {
+        integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==,
+      }
 
   micromark-util-symbol@2.0.1:
-    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+    resolution:
+      {
+        integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==,
+      }
 
   micromark-util-types@2.0.2:
-    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+    resolution:
+      {
+        integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==,
+      }
 
   micromark@4.0.2:
-    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+    resolution:
+      {
+        integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
+      }
 
   micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+      }
+    engines: { node: ">=8.6" }
 
   mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: ">= 0.6" }
 
   mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: ">= 0.6" }
 
   mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==,
+      }
+    engines: { node: ">=4" }
     hasBin: true
 
   mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    resolution:
+      {
+        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
+      }
 
   mlly@1.8.2:
-    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+    resolution:
+      {
+        integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
+      }
 
   mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
+      }
+    engines: { node: ">=4" }
 
   ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    resolution:
+      {
+        integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==,
+      }
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   mylas@2.1.14:
-    resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==,
+      }
+    engines: { node: ">=16.0.0" }
 
   nan@2.26.2:
-    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+    resolution:
+      {
+        integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==,
+      }
 
   nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
   negotiator@0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==,
+      }
+    engines: { node: ">= 0.6" }
 
   node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
+    resolution:
+      {
+        integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==,
+      }
+    engines: { node: ">=10.5.0" }
     deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
     peerDependencies:
       encoding: ^0.1.0
     peerDependenciesMeta:
@@ -2762,31 +4572,55 @@ packages:
         optional: true
 
   node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+    resolution:
+      {
+        integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==,
+      }
 
   normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   nwsapi@2.2.23:
-    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+    resolution:
+      {
+        integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==,
+      }
 
   object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: ">= 0.4" }
 
   obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
 
   on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
+      }
+    engines: { node: ">= 0.8" }
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+      }
 
   openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    resolution:
+      {
+        integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==,
+      }
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -2798,531 +4632,963 @@ packages:
         optional: true
 
   option@0.2.4:
-    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
+    resolution:
+      {
+        integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==,
+      }
 
   outdent@0.5.0:
-    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+    resolution:
+      {
+        integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==,
+      }
 
   p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==,
+      }
+    engines: { node: ">=8" }
 
   p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
+      }
+    engines: { node: ">=6" }
 
   p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
+      }
+    engines: { node: ">=8" }
 
   p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==,
+      }
+    engines: { node: ">=6" }
 
   p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
+      }
+    engines: { node: ">=6" }
 
   package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+    resolution:
+      {
+        integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==,
+      }
 
   package-manager-detector@1.6.0:
-    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+    resolution:
+      {
+        integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==,
+      }
 
   pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    resolution:
+      {
+        integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==,
+      }
 
   parse-entities@4.0.2:
-    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+    resolution:
+      {
+        integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
+      }
 
   parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+    resolution:
+      {
+        integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
+      }
 
   parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   path-data-parser@0.1.0:
-    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+    resolution:
+      {
+        integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==,
+      }
 
   path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: ">=8" }
 
   path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
 
   path-to-regexp@0.1.13:
-    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+    resolution:
+      {
+        integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==,
+      }
 
   path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
+      }
+    engines: { node: ">=8" }
 
   pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    resolution:
+      {
+        integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
+      }
 
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
 
   pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
+    resolution:
+      {
+        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
+      }
+    engines: { node: ">= 14.16" }
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
 
   picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
+      }
+    engines: { node: ">=8.6" }
 
   picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: ">=12" }
 
   pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
+      }
+    engines: { node: ">=6" }
 
   pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    resolution:
+      {
+        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
+      }
 
   playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   plimit-lit@1.6.1:
-    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==,
+      }
+    engines: { node: ">=12" }
 
   points-on-curve@0.2.0:
-    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+    resolution:
+      {
+        integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==,
+      }
 
   points-on-path@0.2.1:
-    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+    resolution:
+      {
+        integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==,
+      }
 
   postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prettier-plugin-organize-imports@4.3.0:
-    resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
+    resolution:
+      {
+        integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==,
+      }
     peerDependencies:
-      prettier: '>=2.0'
-      typescript: '>=2.9'
+      prettier: ">=2.0"
+      typescript: ">=2.9"
       vue-tsc: ^2.1.0 || 3
     peerDependenciesMeta:
       vue-tsc:
         optional: true
 
   prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
+      }
+    engines: { node: ">=10.13.0" }
     hasBin: true
 
   prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+      }
+    engines: { node: ">=14" }
     hasBin: true
 
   process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    resolution:
+      {
+        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
+      }
 
   property-information@7.1.0:
-    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+    resolution:
+      {
+        integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
+      }
 
   protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==,
+      }
+    engines: { node: ">=12.0.0" }
 
   proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
+      }
+    engines: { node: ">= 0.10" }
 
   pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+    resolution:
+      {
+        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
+      }
 
   punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: ">=6" }
 
   qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==,
+      }
+    engines: { node: ">=0.6" }
 
   quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+    resolution:
+      {
+        integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
+      }
 
   queue-lit@1.5.2:
-    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==,
+      }
+    engines: { node: ">=12" }
 
   queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution:
+      {
+        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
 
   range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
+      }
+    engines: { node: ">= 0.6" }
 
   raw-body@2.5.3:
-    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==,
+      }
+    engines: { node: ">= 0.8" }
 
   react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    resolution:
+      {
+        integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==,
+      }
     peerDependencies:
       react: ^19.2.4
 
   react-markdown@10.1.0:
-    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    resolution:
+      {
+        integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==,
+      }
     peerDependencies:
-      '@types/react': '>=18'
-      react: '>=18'
+      "@types/react": ">=18"
+      react: ">=18"
 
   react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==,
+      }
+    engines: { node: ">=6" }
 
   readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+    resolution:
+      {
+        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
+      }
 
   readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: { node: ">= 6" }
 
   readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+    resolution:
+      {
+        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
+      }
+    engines: { node: ">=8.10.0" }
 
   remark-gfm@4.0.1:
-    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+    resolution:
+      {
+        integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==,
+      }
 
   remark-parse@11.0.0:
-    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+    resolution:
+      {
+        integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
+      }
 
   remark-rehype@11.1.2:
-    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+    resolution:
+      {
+        integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==,
+      }
 
   remark-stringify@11.0.0:
-    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+    resolution:
+      {
+        integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
+      }
 
   require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+      }
+    engines: { node: ">=0.10.0" }
 
   resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: ">=8" }
 
   resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+      }
+    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
 
   robust-predicates@3.0.3:
-    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+    resolution:
+      {
+        integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==,
+      }
 
   rollup@4.60.0:
-    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
 
   roughjs@4.6.6:
-    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+    resolution:
+      {
+        integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==,
+      }
 
   rrweb-cssom@0.8.0:
-    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+    resolution:
+      {
+        integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==,
+      }
 
   run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution:
+      {
+        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
+      }
 
   rw@1.3.3:
-    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+    resolution:
+      {
+        integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==,
+      }
 
   rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+    resolution:
+      {
+        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
+      }
 
   safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    resolution:
+      {
+        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
+      }
 
   safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
+    resolution:
+      {
+        integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
+      }
+    engines: { node: ">=v12.22.7" }
 
   scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+    resolution:
+      {
+        integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
+      }
 
   semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    resolution:
+      {
+        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+      }
     hasBin: true
 
   semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   send@0.19.2:
-    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   serve-static@1.16.3:
-    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   setimmediate@1.0.5:
-    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+    resolution:
+      {
+        integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==,
+      }
 
   setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    resolution:
+      {
+        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+      }
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
 
   shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
+      }
+    engines: { node: ">= 0.4" }
 
   siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+      }
+    engines: { node: ">=14" }
 
   sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    resolution:
+      {
+        integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
+      }
 
   slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
+      }
+    engines: { node: ">=8" }
 
   source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   space-separated-tokens@2.0.2:
-    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+    resolution:
+      {
+        integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
+      }
 
   spawndamnit@3.0.1:
-    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+    resolution:
+      {
+        integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==,
+      }
 
   split-ca@1.0.1:
-    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+    resolution:
+      {
+        integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==,
+      }
 
   sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    resolution:
+      {
+        integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
+      }
 
   ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==,
+      }
+    engines: { node: ">=0.8" }
 
   ssh2@1.17.0:
-    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
-    engines: {node: '>=10.16.0'}
+    resolution:
+      {
+        integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==,
+      }
+    engines: { node: ">=10.16.0" }
 
   stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
+      }
+    engines: { node: ">= 0.8" }
 
   std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    resolution:
+      {
+        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+      }
 
   std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+    resolution:
+      {
+        integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
+      }
 
   streamx@2.25.0:
-    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+    resolution:
+      {
+        integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==,
+      }
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+      }
+    engines: { node: ">=8" }
 
   string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+    resolution:
+      {
+        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
+      }
 
   string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
 
   stringify-entities@4.0.4:
-    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+    resolution:
+      {
+        integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
+      }
 
   strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+      }
+    engines: { node: ">=8" }
 
   strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
+      }
+    engines: { node: ">=4" }
 
   style-to-js@1.1.21:
-    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+    resolution:
+      {
+        integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==,
+      }
 
   style-to-object@1.0.14:
-    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+    resolution:
+      {
+        integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
+      }
 
   stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+    resolution:
+      {
+        integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==,
+      }
 
   supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: ">=8" }
 
   supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
+      }
+    engines: { node: ">=10" }
 
   symbol-tree@3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    resolution:
+      {
+        integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
+      }
 
   tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+    resolution:
+      {
+        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
+      }
 
   tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
+      }
+    engines: { node: ">=6" }
 
   tar-stream@3.1.8:
-    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+    resolution:
+      {
+        integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==,
+      }
 
   teex@1.0.1:
-    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+    resolution:
+      {
+        integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==,
+      }
 
   term-size@2.2.1:
-    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
+      }
+    engines: { node: ">=8" }
 
   text-decoder@1.2.7:
-    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+    resolution:
+      {
+        integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==,
+      }
 
   tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
 
   tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    resolution:
+      {
+        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+      }
 
   tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==,
+      }
+    engines: { node: ">=18" }
 
   tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: ">=12.0.0" }
 
   tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+    resolution:
+      {
+        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
 
   tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
+      }
+    engines: { node: ">=14.0.0" }
 
   tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
 
   tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
+      }
+    engines: { node: ">=14.0.0" }
 
   tldts-core@6.1.86:
-    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+    resolution:
+      {
+        integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
+      }
 
   tldts@6.1.86:
-    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    resolution:
+      {
+        integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
+      }
     hasBin: true
 
   to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: ">=8.0" }
 
   toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+      }
+    engines: { node: ">=0.6" }
 
   tough-cookie@5.1.2:
-    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
+      }
+    engines: { node: ">=16" }
 
   tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
 
   tr46@5.1.1:
-    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==,
+      }
+    engines: { node: ">=18" }
 
   tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
     hasBin: true
 
   trim-lines@3.0.1:
-    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+    resolution:
+      {
+        integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
+      }
 
   trough@2.2.0:
-    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+    resolution:
+      {
+        integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
+      }
 
   ts-dedent@2.2.0:
-    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
-    engines: {node: '>=6.10'}
+    resolution:
+      {
+        integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==,
+      }
+    engines: { node: ">=6.10" }
 
   tsc-alias@1.8.16:
-    resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
-    engines: {node: '>=16.20.2'}
+    resolution:
+      {
+        integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==,
+      }
+    engines: { node: ">=16.20.2" }
     hasBin: true
 
   tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
+    resolution:
+      {
+        integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
+      }
+    engines: { node: ^18 || >=20 }
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -3331,123 +5597,210 @@ packages:
         optional: true
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+      }
+    engines: { node: ">=18.0.0" }
     hasBin: true
 
   turndown@7.2.4:
-    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
-    engines: {node: '>=18', npm: '>=9'}
+    resolution:
+      {
+        integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==,
+      }
+    engines: { node: ">=18", npm: ">=9" }
 
   tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+    resolution:
+      {
+        integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==,
+      }
 
   type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==,
+      }
+    engines: { node: ">= 0.6" }
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: ">=14.17" }
     hasBin: true
 
   ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+    resolution:
+      {
+        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
+      }
 
   underscore@1.13.8:
-    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+    resolution:
+      {
+        integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==,
+      }
 
   undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    resolution:
+      {
+        integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==,
+      }
 
   undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
 
   unified@11.0.5:
-    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+    resolution:
+      {
+        integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
+      }
 
   unist-util-is@6.0.1:
-    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+    resolution:
+      {
+        integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==,
+      }
 
   unist-util-position@5.0.0:
-    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+    resolution:
+      {
+        integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
+      }
 
   unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+    resolution:
+      {
+        integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
+      }
 
   unist-util-visit-parents@6.0.2:
-    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+    resolution:
+      {
+        integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==,
+      }
 
   unist-util-visit@5.1.0:
-    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+    resolution:
+      {
+        integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
+      }
 
   universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+    resolution:
+      {
+        integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==,
+      }
+    engines: { node: ">= 4.0.0" }
 
   unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    resolution:
+      {
+        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+      }
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ">= 4.21.0"
 
   util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
+    resolution:
+      {
+        integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
+      }
+    engines: { node: ">= 0.4.0" }
 
   uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    resolution:
+      {
+        integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
+      }
     hasBin: true
 
   uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    resolution:
+      {
+        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
+      }
     hasBin: true
 
   vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
+    engines: { node: ">= 0.8" }
 
   vfile-message@4.0.3:
-    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+    resolution:
+      {
+        integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
+      }
 
   vfile@6.0.3:
-    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+    resolution:
+      {
+        integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
+      }
 
   vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+    resolution:
+      {
+        integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
 
   vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
+    resolution:
+      {
+        integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==,
+      }
     peerDependencies:
-      vite: '*'
+      vite: "*"
 
   vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+    resolution:
+      {
+        integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
+      "@types/node": ^18.0.0 || >=20.0.0
+      less: "*"
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: "*"
+      sass-embedded: "*"
+      stylus: "*"
+      sugarss: "*"
       terser: ^5.4.0
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
       less:
         optional: true
@@ -3465,23 +5818,26 @@ packages:
         optional: true
 
   vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    resolution:
+      {
+        integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
+      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: ">=1.21.0"
+      less: "*"
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: "*"
+      sass-embedded: "*"
+      stylus: "*"
+      sugarss: "*"
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
       jiti:
         optional: true
@@ -3505,24 +5861,27 @@ packages:
         optional: true
 
   vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+    resolution:
+      {
+        integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
     peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
-      happy-dom: '*'
-      jsdom: '*'
+      "@edge-runtime/vm": "*"
+      "@types/node": ^18.0.0 || >=20.0.0
+      "@vitest/browser": 2.1.9
+      "@vitest/ui": 2.1.9
+      happy-dom: "*"
+      jsdom: "*"
     peerDependenciesMeta:
-      '@edge-runtime/vm':
+      "@edge-runtime/vm":
         optional: true
-      '@types/node':
+      "@types/node":
         optional: true
-      '@vitest/browser':
+      "@vitest/browser":
         optional: true
-      '@vitest/ui':
+      "@vitest/ui":
         optional: true
       happy-dom:
         optional: true
@@ -3530,40 +5889,43 @@ packages:
         optional: true
 
   vitest@4.1.3:
-    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    resolution:
+      {
+        integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
     peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.3
-      '@vitest/browser-preview': 4.1.3
-      '@vitest/browser-webdriverio': 4.1.3
-      '@vitest/coverage-istanbul': 4.1.3
-      '@vitest/coverage-v8': 4.1.3
-      '@vitest/ui': 4.1.3
-      happy-dom: '*'
-      jsdom: '*'
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.3
+      "@vitest/browser-preview": 4.1.3
+      "@vitest/browser-webdriverio": 4.1.3
+      "@vitest/coverage-istanbul": 4.1.3
+      "@vitest/coverage-v8": 4.1.3
+      "@vitest/ui": 4.1.3
+      happy-dom: "*"
+      jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
-      '@edge-runtime/vm':
+      "@edge-runtime/vm":
         optional: true
-      '@opentelemetry/api':
+      "@opentelemetry/api":
         optional: true
-      '@types/node':
+      "@types/node":
         optional: true
-      '@vitest/browser-playwright':
+      "@vitest/browser-playwright":
         optional: true
-      '@vitest/browser-preview':
+      "@vitest/browser-preview":
         optional: true
-      '@vitest/browser-webdriverio':
+      "@vitest/browser-webdriverio":
         optional: true
-      '@vitest/coverage-istanbul':
+      "@vitest/coverage-istanbul":
         optional: true
-      '@vitest/coverage-v8':
+      "@vitest/coverage-v8":
         optional: true
-      '@vitest/ui':
+      "@vitest/ui":
         optional: true
       happy-dom:
         optional: true
@@ -3571,87 +5933,150 @@ packages:
         optional: true
 
   vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==,
+      }
+    engines: { node: ">=14.0.0" }
 
   vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+    resolution:
+      {
+        integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==,
+      }
 
   vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+    resolution:
+      {
+        integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==,
+      }
 
   vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+    resolution:
+      {
+        integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==,
+      }
 
   vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    resolution:
+      {
+        integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==,
+      }
     hasBin: true
 
   vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+    resolution:
+      {
+        integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==,
+      }
 
   w3c-xmlserializer@5.0.0:
-    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
+      }
+    engines: { node: ">=18" }
 
   web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
+    resolution:
+      {
+        integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==,
+      }
+    engines: { node: ">= 14" }
 
   webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+      }
 
   webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==,
+      }
+    engines: { node: ">=12" }
 
   whatwg-encoding@3.1.1:
-    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
+      }
+    engines: { node: ">=18" }
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
-    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
+      }
+    engines: { node: ">=18" }
 
   whatwg-url@14.2.0:
-    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==,
+      }
+    engines: { node: ">=18" }
 
   whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
     hasBin: true
 
   wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==,
+      }
+    engines: { node: ">=0.8" }
 
   word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==,
+      }
+    engines: { node: ">=0.8" }
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+      }
+    engines: { node: ">=10" }
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+      }
+    engines: { node: ">=10.0.0" }
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
+      utf-8-validate: ">=5.0.2"
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -3659,55 +6084,84 @@ packages:
         optional: true
 
   xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==,
+      }
+    engines: { node: ">=0.8" }
     hasBin: true
 
   xml-name-validator@5.0.0:
-    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==,
+      }
+    engines: { node: ">=18" }
 
   xmlbuilder@10.1.1:
-    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==,
+      }
+    engines: { node: ">=4.0" }
 
   xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+    resolution:
+      {
+        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
+      }
 
   y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+      }
+    engines: { node: ">=10" }
 
   yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    resolution:
+      {
+        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+      }
 
   yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
+    resolution:
+      {
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
+      }
+    engines: { node: ">= 14.6" }
     hasBin: true
 
   yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+      }
+    engines: { node: ">=12" }
 
   yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+      }
+    engines: { node: ">=12" }
 
   zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+    resolution:
+      {
+        integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
+      }
 
 snapshots:
-
-  '@antfu/install-pkg@1.1.0':
+  "@antfu/install-pkg@1.1.0":
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
 
-  '@anthropic-ai/sdk@0.39.0':
+  "@anthropic-ai/sdk@0.39.0":
     dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
+      "@types/node": 18.19.130
+      "@types/node-fetch": 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
@@ -3716,34 +6170,34 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@asamuzakjp/css-color@3.2.0':
+  "@asamuzakjp/css-color@3.2.0":
     dependencies:
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
       lru-cache: 10.4.3
 
-  '@babel/code-frame@7.29.0':
+  "@babel/code-frame@7.29.0":
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-validator-identifier": 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  "@babel/compat-data@7.29.0": {}
 
-  '@babel/core@7.29.0':
+  "@babel/core@7.29.0":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
+      "@babel/code-frame": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/helper-compilation-targets": 7.28.6
+      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
+      "@babel/helpers": 7.29.2
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.28.6
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
+      "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -3752,104 +6206,104 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
+  "@babel/generator@7.29.1":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.28.6':
+  "@babel/helper-compilation-targets@7.28.6":
     dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
+      "@babel/compat-data": 7.29.0
+      "@babel/helper-validator-option": 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-globals@7.28.0': {}
+  "@babel/helper-globals@7.28.0": {}
 
-  '@babel/helper-module-imports@7.28.6':
+  "@babel/helper-module-imports@7.28.6":
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  "@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/helper-module-imports": 7.28.6
+      "@babel/helper-validator-identifier": 7.28.5
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.28.6': {}
+  "@babel/helper-plugin-utils@7.28.6": {}
 
-  '@babel/helper-string-parser@7.27.1': {}
+  "@babel/helper-string-parser@7.27.1": {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  "@babel/helper-validator-identifier@7.28.5": {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  "@babel/helper-validator-option@7.27.1": {}
 
-  '@babel/helpers@7.29.2':
+  "@babel/helpers@7.29.2":
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      "@babel/template": 7.28.6
+      "@babel/types": 7.29.0
 
-  '@babel/parser@7.29.2':
+  "@babel/parser@7.29.2":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      "@babel/core": 7.29.0
+      "@babel/helper-plugin-utils": 7.28.6
 
-  '@babel/runtime@7.29.2': {}
+  "@babel/runtime@7.29.2": {}
 
-  '@babel/template@7.28.6':
+  "@babel/template@7.28.6":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      "@babel/code-frame": 7.29.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
 
-  '@babel/traverse@7.29.0':
+  "@babel/traverse@7.29.0":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      "@babel/code-frame": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/helper-globals": 7.28.0
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.28.6
+      "@babel/types": 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.0':
+  "@babel/types@7.29.0":
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-string-parser": 7.27.1
+      "@babel/helper-validator-identifier": 7.28.5
 
-  '@balena/dockerignore@1.0.2': {}
+  "@balena/dockerignore@1.0.2": {}
 
-  '@braintree/sanitize-url@7.1.2': {}
+  "@braintree/sanitize-url@7.1.2": {}
 
-  '@changesets/apply-release-plan@7.1.0':
+  "@changesets/apply-release-plan@7.1.0":
     dependencies:
-      '@changesets/config': 3.1.3
-      '@changesets/get-version-range-type': 0.4.0
-      '@changesets/git': 3.0.4
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/config": 3.1.3
+      "@changesets/get-version-range-type": 0.4.0
+      "@changesets/git": 3.0.4
+      "@changesets/should-skip-package": 0.1.2
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
       detect-indent: 6.1.0
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
@@ -3858,45 +6312,45 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  '@changesets/assemble-release-plan@6.0.9':
+  "@changesets/assemble-release-plan@6.0.9":
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/errors": 0.2.0
+      "@changesets/get-dependents-graph": 2.1.3
+      "@changesets/should-skip-package": 0.1.2
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
       semver: 7.7.4
 
-  '@changesets/changelog-git@0.2.1':
+  "@changesets/changelog-git@0.2.1":
     dependencies:
-      '@changesets/types': 6.1.0
+      "@changesets/types": 6.1.0
 
-  '@changesets/changelog-github@0.6.0':
+  "@changesets/changelog-github@0.6.0":
     dependencies:
-      '@changesets/get-github-info': 0.8.0
-      '@changesets/types': 6.1.0
+      "@changesets/get-github-info": 0.8.0
+      "@changesets/types": 6.1.0
       dotenv: 8.6.0
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.30.0(@types/node@22.19.15)':
+  "@changesets/cli@2.30.0(@types/node@22.19.15)":
     dependencies:
-      '@changesets/apply-release-plan': 7.1.0
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.3
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.15
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.7
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/apply-release-plan": 7.1.0
+      "@changesets/assemble-release-plan": 6.0.9
+      "@changesets/changelog-git": 0.2.1
+      "@changesets/config": 3.1.3
+      "@changesets/errors": 0.2.0
+      "@changesets/get-dependents-graph": 2.1.3
+      "@changesets/get-release-plan": 4.0.15
+      "@changesets/git": 3.0.4
+      "@changesets/logger": 0.1.1
+      "@changesets/pre": 2.0.2
+      "@changesets/read": 0.6.7
+      "@changesets/should-skip-package": 0.1.2
+      "@changesets/types": 6.1.0
+      "@changesets/write": 0.4.0
+      "@inquirer/external-editor": 1.0.3(@types/node@22.19.15)
+      "@manypkg/get-packages": 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
       fs-extra: 7.0.1
@@ -3908,901 +6362,901 @@ snapshots:
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
-      - '@types/node'
+      - "@types/node"
 
-  '@changesets/config@3.1.3':
+  "@changesets/config@3.1.3":
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/logger': 0.1.1
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/errors": 0.2.0
+      "@changesets/get-dependents-graph": 2.1.3
+      "@changesets/logger": 0.1.1
+      "@changesets/should-skip-package": 0.1.2
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
       fs-extra: 7.0.1
       micromatch: 4.0.8
 
-  '@changesets/errors@0.2.0':
+  "@changesets/errors@0.2.0":
     dependencies:
       extendable-error: 0.1.7
 
-  '@changesets/get-dependents-graph@2.1.3':
+  "@changesets/get-dependents-graph@2.1.3":
     dependencies:
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
       picocolors: 1.1.1
       semver: 7.7.4
 
-  '@changesets/get-github-info@0.8.0':
+  "@changesets/get-github-info@0.8.0":
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/get-release-plan@4.0.15':
+  "@changesets/get-release-plan@4.0.15":
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.3
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.7
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/assemble-release-plan": 6.0.9
+      "@changesets/config": 3.1.3
+      "@changesets/pre": 2.0.2
+      "@changesets/read": 0.6.7
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
 
-  '@changesets/get-version-range-type@0.4.0': {}
+  "@changesets/get-version-range-type@0.4.0": {}
 
-  '@changesets/git@3.0.4':
+  "@changesets/git@3.0.4":
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/errors": 0.2.0
+      "@manypkg/get-packages": 1.1.3
       is-subdir: 1.2.0
       micromatch: 4.0.8
       spawndamnit: 3.0.1
 
-  '@changesets/logger@0.1.1':
+  "@changesets/logger@0.1.1":
     dependencies:
       picocolors: 1.1.1
 
-  '@changesets/parse@0.4.3':
+  "@changesets/parse@0.4.3":
     dependencies:
-      '@changesets/types': 6.1.0
+      "@changesets/types": 6.1.0
       js-yaml: 4.1.1
 
-  '@changesets/pre@2.0.2':
+  "@changesets/pre@2.0.2":
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/errors": 0.2.0
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
       fs-extra: 7.0.1
 
-  '@changesets/read@0.6.7':
+  "@changesets/read@0.6.7":
     dependencies:
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/parse': 0.4.3
-      '@changesets/types': 6.1.0
+      "@changesets/git": 3.0.4
+      "@changesets/logger": 0.1.1
+      "@changesets/parse": 0.4.3
+      "@changesets/types": 6.1.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
       picocolors: 1.1.1
 
-  '@changesets/should-skip-package@0.1.2':
+  "@changesets/should-skip-package@0.1.2":
     dependencies:
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      "@changesets/types": 6.1.0
+      "@manypkg/get-packages": 1.1.3
 
-  '@changesets/types@4.1.0': {}
+  "@changesets/types@4.1.0": {}
 
-  '@changesets/types@6.1.0': {}
+  "@changesets/types@6.1.0": {}
 
-  '@changesets/write@0.4.0':
+  "@changesets/write@0.4.0":
     dependencies:
-      '@changesets/types': 6.1.0
+      "@changesets/types": 6.1.0
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@chevrotain/cst-dts-gen@11.1.2':
+  "@chevrotain/cst-dts-gen@11.1.2":
     dependencies:
-      '@chevrotain/gast': 11.1.2
-      '@chevrotain/types': 11.1.2
+      "@chevrotain/gast": 11.1.2
+      "@chevrotain/types": 11.1.2
       lodash-es: 4.17.23
 
-  '@chevrotain/gast@11.1.2':
+  "@chevrotain/gast@11.1.2":
     dependencies:
-      '@chevrotain/types': 11.1.2
+      "@chevrotain/types": 11.1.2
       lodash-es: 4.17.23
 
-  '@chevrotain/regexp-to-ast@11.1.2': {}
+  "@chevrotain/regexp-to-ast@11.1.2": {}
 
-  '@chevrotain/types@11.1.2': {}
+  "@chevrotain/types@11.1.2": {}
 
-  '@chevrotain/utils@11.1.2': {}
+  "@chevrotain/utils@11.1.2": {}
 
-  '@clack/core@0.4.1':
+  "@clack/core@0.4.1":
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.9.1':
+  "@clack/prompts@0.9.1":
     dependencies:
-      '@clack/core': 0.4.1
+      "@clack/core": 0.4.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@csstools/color-helpers@5.1.0': {}
+  "@csstools/color-helpers@5.1.0": {}
 
-  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  "@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)":
     dependencies:
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
 
-  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  "@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)":
     dependencies:
-      '@csstools/color-helpers': 5.1.0
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      "@csstools/color-helpers": 5.1.0
+      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
 
-  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+  "@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)":
     dependencies:
-      '@csstools/css-tokenizer': 3.0.4
+      "@csstools/css-tokenizer": 3.0.4
 
-  '@csstools/css-tokenizer@3.0.4': {}
+  "@csstools/css-tokenizer@3.0.4": {}
 
-  '@esbuild/aix-ppc64@0.21.5':
+  "@esbuild/aix-ppc64@0.21.5":
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.12':
+  "@esbuild/aix-ppc64@0.25.12":
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.4':
+  "@esbuild/aix-ppc64@0.27.4":
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  "@esbuild/android-arm64@0.21.5":
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
+  "@esbuild/android-arm64@0.25.12":
     optional: true
 
-  '@esbuild/android-arm64@0.27.4':
+  "@esbuild/android-arm64@0.27.4":
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  "@esbuild/android-arm@0.21.5":
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
+  "@esbuild/android-arm@0.25.12":
     optional: true
 
-  '@esbuild/android-arm@0.27.4':
+  "@esbuild/android-arm@0.27.4":
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  "@esbuild/android-x64@0.21.5":
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
+  "@esbuild/android-x64@0.25.12":
     optional: true
 
-  '@esbuild/android-x64@0.27.4':
+  "@esbuild/android-x64@0.27.4":
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  "@esbuild/darwin-arm64@0.21.5":
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
+  "@esbuild/darwin-arm64@0.25.12":
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.4':
+  "@esbuild/darwin-arm64@0.27.4":
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  "@esbuild/darwin-x64@0.21.5":
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
+  "@esbuild/darwin-x64@0.25.12":
     optional: true
 
-  '@esbuild/darwin-x64@0.27.4':
+  "@esbuild/darwin-x64@0.27.4":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  "@esbuild/freebsd-arm64@0.21.5":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
+  "@esbuild/freebsd-arm64@0.25.12":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.4':
+  "@esbuild/freebsd-arm64@0.27.4":
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  "@esbuild/freebsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
+  "@esbuild/freebsd-x64@0.25.12":
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.4':
+  "@esbuild/freebsd-x64@0.27.4":
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  "@esbuild/linux-arm64@0.21.5":
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
+  "@esbuild/linux-arm64@0.25.12":
     optional: true
 
-  '@esbuild/linux-arm64@0.27.4':
+  "@esbuild/linux-arm64@0.27.4":
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  "@esbuild/linux-arm@0.21.5":
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
+  "@esbuild/linux-arm@0.25.12":
     optional: true
 
-  '@esbuild/linux-arm@0.27.4':
+  "@esbuild/linux-arm@0.27.4":
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  "@esbuild/linux-ia32@0.21.5":
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
+  "@esbuild/linux-ia32@0.25.12":
     optional: true
 
-  '@esbuild/linux-ia32@0.27.4':
+  "@esbuild/linux-ia32@0.27.4":
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  "@esbuild/linux-loong64@0.21.5":
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
+  "@esbuild/linux-loong64@0.25.12":
     optional: true
 
-  '@esbuild/linux-loong64@0.27.4':
+  "@esbuild/linux-loong64@0.27.4":
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  "@esbuild/linux-mips64el@0.21.5":
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
+  "@esbuild/linux-mips64el@0.25.12":
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.4':
+  "@esbuild/linux-mips64el@0.27.4":
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  "@esbuild/linux-ppc64@0.21.5":
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.12':
+  "@esbuild/linux-ppc64@0.25.12":
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.4':
+  "@esbuild/linux-ppc64@0.27.4":
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  "@esbuild/linux-riscv64@0.21.5":
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
+  "@esbuild/linux-riscv64@0.25.12":
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.4':
+  "@esbuild/linux-riscv64@0.27.4":
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  "@esbuild/linux-s390x@0.21.5":
     optional: true
 
-  '@esbuild/linux-s390x@0.25.12':
+  "@esbuild/linux-s390x@0.25.12":
     optional: true
 
-  '@esbuild/linux-s390x@0.27.4':
+  "@esbuild/linux-s390x@0.27.4":
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  "@esbuild/linux-x64@0.21.5":
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
+  "@esbuild/linux-x64@0.25.12":
     optional: true
 
-  '@esbuild/linux-x64@0.27.4':
+  "@esbuild/linux-x64@0.27.4":
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.12':
+  "@esbuild/netbsd-arm64@0.25.12":
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.4':
+  "@esbuild/netbsd-arm64@0.27.4":
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  "@esbuild/netbsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
+  "@esbuild/netbsd-x64@0.25.12":
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.4':
+  "@esbuild/netbsd-x64@0.27.4":
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.12':
+  "@esbuild/openbsd-arm64@0.25.12":
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.4':
+  "@esbuild/openbsd-arm64@0.27.4":
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  "@esbuild/openbsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
+  "@esbuild/openbsd-x64@0.25.12":
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.4':
+  "@esbuild/openbsd-x64@0.27.4":
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.12':
+  "@esbuild/openharmony-arm64@0.25.12":
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.4':
+  "@esbuild/openharmony-arm64@0.27.4":
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  "@esbuild/sunos-x64@0.21.5":
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
+  "@esbuild/sunos-x64@0.25.12":
     optional: true
 
-  '@esbuild/sunos-x64@0.27.4':
+  "@esbuild/sunos-x64@0.27.4":
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  "@esbuild/win32-arm64@0.21.5":
     optional: true
 
-  '@esbuild/win32-arm64@0.25.12':
+  "@esbuild/win32-arm64@0.25.12":
     optional: true
 
-  '@esbuild/win32-arm64@0.27.4':
+  "@esbuild/win32-arm64@0.27.4":
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  "@esbuild/win32-ia32@0.21.5":
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
+  "@esbuild/win32-ia32@0.25.12":
     optional: true
 
-  '@esbuild/win32-ia32@0.27.4':
+  "@esbuild/win32-ia32@0.27.4":
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  "@esbuild/win32-x64@0.21.5":
     optional: true
 
-  '@esbuild/win32-x64@0.25.12':
+  "@esbuild/win32-x64@0.25.12":
     optional: true
 
-  '@esbuild/win32-x64@0.27.4':
+  "@esbuild/win32-x64@0.27.4":
     optional: true
 
-  '@grpc/grpc-js@1.14.3':
+  "@grpc/grpc-js@1.14.3":
     dependencies:
-      '@grpc/proto-loader': 0.8.0
-      '@js-sdsl/ordered-map': 4.4.2
+      "@grpc/proto-loader": 0.8.0
+      "@js-sdsl/ordered-map": 4.4.2
 
-  '@grpc/proto-loader@0.7.15':
+  "@grpc/proto-loader@0.7.15":
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@grpc/proto-loader@0.8.0':
+  "@grpc/proto-loader@0.8.0":
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  "@hono/node-server@1.19.13(hono@4.12.12)":
     dependencies:
       hono: 4.12.12
 
-  '@iconify/types@2.0.0': {}
+  "@iconify/types@2.0.0": {}
 
-  '@iconify/utils@3.1.0':
+  "@iconify/utils@3.1.0":
     dependencies:
-      '@antfu/install-pkg': 1.1.0
-      '@iconify/types': 2.0.0
+      "@antfu/install-pkg": 1.1.0
+      "@iconify/types": 2.0.0
       mlly: 1.8.2
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
+  "@inquirer/external-editor@1.0.3(@types/node@22.19.15)":
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
 
-  '@jridgewell/gen-mapping@0.3.13':
+  "@jridgewell/gen-mapping@0.3.13":
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/sourcemap-codec": 1.5.5
+      "@jridgewell/trace-mapping": 0.3.31
 
-  '@jridgewell/remapping@2.3.5':
+  "@jridgewell/remapping@2.3.5":
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
 
-  '@jridgewell/resolve-uri@3.1.2': {}
+  "@jridgewell/resolve-uri@3.1.2": {}
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  "@jridgewell/sourcemap-codec@1.5.5": {}
 
-  '@jridgewell/trace-mapping@0.3.31':
+  "@jridgewell/trace-mapping@0.3.31":
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      "@jridgewell/resolve-uri": 3.1.2
+      "@jridgewell/sourcemap-codec": 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2': {}
+  "@js-sdsl/ordered-map@4.4.2": {}
 
-  '@manypkg/find-root@1.1.0':
+  "@manypkg/find-root@1.1.0":
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@types/node': 12.20.55
+      "@babel/runtime": 7.29.2
+      "@types/node": 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
-  '@manypkg/get-packages@1.1.3':
+  "@manypkg/get-packages@1.1.3":
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@changesets/types': 4.1.0
-      '@manypkg/find-root': 1.1.0
+      "@babel/runtime": 7.29.2
+      "@changesets/types": 4.1.0
+      "@manypkg/find-root": 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mermaid-js/parser@1.0.1':
+  "@mermaid-js/parser@1.0.1":
     dependencies:
       langium: 4.2.1
 
-  '@mixmark-io/domino@2.2.0': {}
+  "@mixmark-io/domino@2.2.0": {}
 
-  '@mozilla/readability@0.6.0': {}
+  "@mozilla/readability@0.6.0": {}
 
-  '@nodelib/fs.scandir@2.1.5':
+  "@nodelib/fs.scandir@2.1.5":
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
+      "@nodelib/fs.stat": 2.0.5
       run-parallel: 1.2.0
 
-  '@nodelib/fs.stat@2.0.5': {}
+  "@nodelib/fs.stat@2.0.5": {}
 
-  '@nodelib/fs.walk@1.2.8':
+  "@nodelib/fs.walk@1.2.8":
     dependencies:
-      '@nodelib/fs.scandir': 2.1.5
+      "@nodelib/fs.scandir": 2.1.5
       fastq: 1.20.1
 
-  '@protobufjs/aspromise@1.1.2': {}
+  "@protobufjs/aspromise@1.1.2": {}
 
-  '@protobufjs/base64@1.1.2': {}
+  "@protobufjs/base64@1.1.2": {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  "@protobufjs/codegen@2.0.4": {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  "@protobufjs/eventemitter@1.1.0": {}
 
-  '@protobufjs/fetch@1.1.0':
+  "@protobufjs/fetch@1.1.0":
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
+      "@protobufjs/aspromise": 1.1.2
+      "@protobufjs/inquire": 1.1.0
 
-  '@protobufjs/float@1.0.2': {}
+  "@protobufjs/float@1.0.2": {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  "@protobufjs/inquire@1.1.0": {}
 
-  '@protobufjs/path@1.1.2': {}
+  "@protobufjs/path@1.1.2": {}
 
-  '@protobufjs/pool@1.1.0': {}
+  "@protobufjs/pool@1.1.0": {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  "@protobufjs/utf8@1.1.0": {}
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  "@rolldown/pluginutils@1.0.0-beta.27": {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
+  "@rollup/rollup-android-arm-eabi@4.60.0":
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.0':
+  "@rollup/rollup-android-arm64@4.60.0":
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
+  "@rollup/rollup-darwin-arm64@4.60.0":
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.0':
+  "@rollup/rollup-darwin-x64@4.60.0":
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
+  "@rollup/rollup-freebsd-arm64@4.60.0":
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.0':
+  "@rollup/rollup-freebsd-x64@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+  "@rollup/rollup-linux-arm-musleabihf@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+  "@rollup/rollup-linux-arm64-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
+  "@rollup/rollup-linux-arm64-musl@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+  "@rollup/rollup-linux-loong64-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
+  "@rollup/rollup-linux-loong64-musl@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+  "@rollup/rollup-linux-ppc64-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+  "@rollup/rollup-linux-ppc64-musl@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+  "@rollup/rollup-linux-riscv64-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+  "@rollup/rollup-linux-riscv64-musl@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+  "@rollup/rollup-linux-s390x-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
+  "@rollup/rollup-linux-x64-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
+  "@rollup/rollup-linux-x64-musl@4.60.0":
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.0':
+  "@rollup/rollup-openbsd-x64@4.60.0":
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.0':
+  "@rollup/rollup-openharmony-arm64@4.60.0":
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+  "@rollup/rollup-win32-arm64-msvc@4.60.0":
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+  "@rollup/rollup-win32-ia32-msvc@4.60.0":
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
+  "@rollup/rollup-win32-x64-gnu@4.60.0":
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
+  "@rollup/rollup-win32-x64-msvc@4.60.0":
     optional: true
 
-  '@sinclair/typebox@0.34.49': {}
+  "@sinclair/typebox@0.34.49": {}
 
-  '@standard-schema/spec@1.1.0': {}
+  "@standard-schema/spec@1.1.0": {}
 
-  '@types/babel__core@7.20.5':
+  "@types/babel__core@7.20.5":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      "@types/babel__generator": 7.27.0
+      "@types/babel__template": 7.4.4
+      "@types/babel__traverse": 7.28.0
 
-  '@types/babel__generator@7.27.0':
+  "@types/babel__generator@7.27.0":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@types/babel__template@7.4.4':
+  "@types/babel__template@7.4.4":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
 
-  '@types/babel__traverse@7.28.0':
+  "@types/babel__traverse@7.28.0":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@types/chai@5.2.3':
+  "@types/chai@5.2.3":
     dependencies:
-      '@types/deep-eql': 4.0.2
+      "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
 
-  '@types/d3-array@3.2.2': {}
+  "@types/d3-array@3.2.2": {}
 
-  '@types/d3-axis@3.0.6':
+  "@types/d3-axis@3.0.6":
     dependencies:
-      '@types/d3-selection': 3.0.11
+      "@types/d3-selection": 3.0.11
 
-  '@types/d3-brush@3.0.6':
+  "@types/d3-brush@3.0.6":
     dependencies:
-      '@types/d3-selection': 3.0.11
+      "@types/d3-selection": 3.0.11
 
-  '@types/d3-chord@3.0.6': {}
+  "@types/d3-chord@3.0.6": {}
 
-  '@types/d3-color@3.1.3': {}
+  "@types/d3-color@3.1.3": {}
 
-  '@types/d3-contour@3.0.6':
+  "@types/d3-contour@3.0.6":
     dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/geojson': 7946.0.16
+      "@types/d3-array": 3.2.2
+      "@types/geojson": 7946.0.16
 
-  '@types/d3-delaunay@6.0.4': {}
+  "@types/d3-delaunay@6.0.4": {}
 
-  '@types/d3-dispatch@3.0.7': {}
+  "@types/d3-dispatch@3.0.7": {}
 
-  '@types/d3-drag@3.0.7':
+  "@types/d3-drag@3.0.7":
     dependencies:
-      '@types/d3-selection': 3.0.11
+      "@types/d3-selection": 3.0.11
 
-  '@types/d3-dsv@3.0.7': {}
+  "@types/d3-dsv@3.0.7": {}
 
-  '@types/d3-ease@3.0.2': {}
+  "@types/d3-ease@3.0.2": {}
 
-  '@types/d3-fetch@3.0.7':
+  "@types/d3-fetch@3.0.7":
     dependencies:
-      '@types/d3-dsv': 3.0.7
+      "@types/d3-dsv": 3.0.7
 
-  '@types/d3-force@3.0.10': {}
+  "@types/d3-force@3.0.10": {}
 
-  '@types/d3-format@3.0.4': {}
+  "@types/d3-format@3.0.4": {}
 
-  '@types/d3-geo@3.1.0':
+  "@types/d3-geo@3.1.0":
     dependencies:
-      '@types/geojson': 7946.0.16
+      "@types/geojson": 7946.0.16
 
-  '@types/d3-hierarchy@3.1.7': {}
+  "@types/d3-hierarchy@3.1.7": {}
 
-  '@types/d3-interpolate@3.0.4':
+  "@types/d3-interpolate@3.0.4":
     dependencies:
-      '@types/d3-color': 3.1.3
+      "@types/d3-color": 3.1.3
 
-  '@types/d3-path@3.1.1': {}
+  "@types/d3-path@3.1.1": {}
 
-  '@types/d3-polygon@3.0.2': {}
+  "@types/d3-polygon@3.0.2": {}
 
-  '@types/d3-quadtree@3.0.6': {}
+  "@types/d3-quadtree@3.0.6": {}
 
-  '@types/d3-random@3.0.3': {}
+  "@types/d3-random@3.0.3": {}
 
-  '@types/d3-scale-chromatic@3.1.0': {}
+  "@types/d3-scale-chromatic@3.1.0": {}
 
-  '@types/d3-scale@4.0.9':
+  "@types/d3-scale@4.0.9":
     dependencies:
-      '@types/d3-time': 3.0.4
+      "@types/d3-time": 3.0.4
 
-  '@types/d3-selection@3.0.11': {}
+  "@types/d3-selection@3.0.11": {}
 
-  '@types/d3-shape@3.1.8':
+  "@types/d3-shape@3.1.8":
     dependencies:
-      '@types/d3-path': 3.1.1
+      "@types/d3-path": 3.1.1
 
-  '@types/d3-time-format@4.0.3': {}
+  "@types/d3-time-format@4.0.3": {}
 
-  '@types/d3-time@3.0.4': {}
+  "@types/d3-time@3.0.4": {}
 
-  '@types/d3-timer@3.0.2': {}
+  "@types/d3-timer@3.0.2": {}
 
-  '@types/d3-transition@3.0.9':
+  "@types/d3-transition@3.0.9":
     dependencies:
-      '@types/d3-selection': 3.0.11
+      "@types/d3-selection": 3.0.11
 
-  '@types/d3-zoom@3.0.8':
+  "@types/d3-zoom@3.0.8":
     dependencies:
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-selection': 3.0.11
+      "@types/d3-interpolate": 3.0.4
+      "@types/d3-selection": 3.0.11
 
-  '@types/d3@7.4.3':
+  "@types/d3@7.4.3":
     dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-axis': 3.0.6
-      '@types/d3-brush': 3.0.6
-      '@types/d3-chord': 3.0.6
-      '@types/d3-color': 3.1.3
-      '@types/d3-contour': 3.0.6
-      '@types/d3-delaunay': 6.0.4
-      '@types/d3-dispatch': 3.0.7
-      '@types/d3-drag': 3.0.7
-      '@types/d3-dsv': 3.0.7
-      '@types/d3-ease': 3.0.2
-      '@types/d3-fetch': 3.0.7
-      '@types/d3-force': 3.0.10
-      '@types/d3-format': 3.0.4
-      '@types/d3-geo': 3.1.0
-      '@types/d3-hierarchy': 3.1.7
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-path': 3.1.1
-      '@types/d3-polygon': 3.0.2
-      '@types/d3-quadtree': 3.0.6
-      '@types/d3-random': 3.0.3
-      '@types/d3-scale': 4.0.9
-      '@types/d3-scale-chromatic': 3.1.0
-      '@types/d3-selection': 3.0.11
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-time-format': 4.0.3
-      '@types/d3-timer': 3.0.2
-      '@types/d3-transition': 3.0.9
-      '@types/d3-zoom': 3.0.8
+      "@types/d3-array": 3.2.2
+      "@types/d3-axis": 3.0.6
+      "@types/d3-brush": 3.0.6
+      "@types/d3-chord": 3.0.6
+      "@types/d3-color": 3.1.3
+      "@types/d3-contour": 3.0.6
+      "@types/d3-delaunay": 6.0.4
+      "@types/d3-dispatch": 3.0.7
+      "@types/d3-drag": 3.0.7
+      "@types/d3-dsv": 3.0.7
+      "@types/d3-ease": 3.0.2
+      "@types/d3-fetch": 3.0.7
+      "@types/d3-force": 3.0.10
+      "@types/d3-format": 3.0.4
+      "@types/d3-geo": 3.1.0
+      "@types/d3-hierarchy": 3.1.7
+      "@types/d3-interpolate": 3.0.4
+      "@types/d3-path": 3.1.1
+      "@types/d3-polygon": 3.0.2
+      "@types/d3-quadtree": 3.0.6
+      "@types/d3-random": 3.0.3
+      "@types/d3-scale": 4.0.9
+      "@types/d3-scale-chromatic": 3.1.0
+      "@types/d3-selection": 3.0.11
+      "@types/d3-shape": 3.1.8
+      "@types/d3-time": 3.0.4
+      "@types/d3-time-format": 4.0.3
+      "@types/d3-timer": 3.0.2
+      "@types/d3-transition": 3.0.9
+      "@types/d3-zoom": 3.0.8
 
-  '@types/debug@4.1.13':
+  "@types/debug@4.1.13":
     dependencies:
-      '@types/ms': 2.1.0
+      "@types/ms": 2.1.0
 
-  '@types/deep-eql@4.0.2': {}
+  "@types/deep-eql@4.0.2": {}
 
-  '@types/docker-modem@3.0.6':
+  "@types/docker-modem@3.0.6":
     dependencies:
-      '@types/node': 22.19.15
-      '@types/ssh2': 1.15.5
+      "@types/node": 22.19.15
+      "@types/ssh2": 1.15.5
 
-  '@types/dockerode@3.3.47':
+  "@types/dockerode@3.3.47":
     dependencies:
-      '@types/docker-modem': 3.0.6
-      '@types/node': 22.19.15
-      '@types/ssh2': 1.15.5
+      "@types/docker-modem": 3.0.6
+      "@types/node": 22.19.15
+      "@types/ssh2": 1.15.5
 
-  '@types/dompurify@3.2.0':
+  "@types/dompurify@3.2.0":
     dependencies:
       dompurify: 3.3.3
 
-  '@types/estree-jsx@1.0.5':
+  "@types/estree-jsx@1.0.5":
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
 
-  '@types/estree@1.0.8': {}
+  "@types/estree@1.0.8": {}
 
-  '@types/geojson@7946.0.16': {}
+  "@types/geojson@7946.0.16": {}
 
-  '@types/hast@3.0.4':
+  "@types/hast@3.0.4":
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
-  '@types/jsdom@21.1.7':
+  "@types/jsdom@21.1.7":
     dependencies:
-      '@types/node': 22.19.15
-      '@types/tough-cookie': 4.0.5
+      "@types/node": 22.19.15
+      "@types/tough-cookie": 4.0.5
       parse5: 7.3.0
 
-  '@types/mdast@4.0.4':
+  "@types/mdast@4.0.4":
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
-  '@types/ms@2.1.0': {}
+  "@types/ms@2.1.0": {}
 
-  '@types/node-fetch@2.6.13':
+  "@types/node-fetch@2.6.13":
     dependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
       form-data: 4.0.5
 
-  '@types/node@12.20.55': {}
+  "@types/node@12.20.55": {}
 
-  '@types/node@18.19.130':
+  "@types/node@18.19.130":
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.19.15':
+  "@types/node@22.19.15":
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  "@types/react-dom@19.2.3(@types/react@19.2.14)":
     dependencies:
-      '@types/react': 19.2.14
+      "@types/react": 19.2.14
 
-  '@types/react@19.2.14':
+  "@types/react@19.2.14":
     dependencies:
       csstype: 3.2.3
 
-  '@types/ssh2@1.15.5':
+  "@types/ssh2@1.15.5":
     dependencies:
-      '@types/node': 18.19.130
+      "@types/node": 18.19.130
 
-  '@types/tar-stream@3.1.4':
+  "@types/tar-stream@3.1.4":
     dependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
 
-  '@types/tough-cookie@4.0.5': {}
+  "@types/tough-cookie@4.0.5": {}
 
-  '@types/trusted-types@2.0.7':
+  "@types/trusted-types@2.0.7":
     optional: true
 
-  '@types/turndown@5.0.6': {}
+  "@types/turndown@5.0.6": {}
 
-  '@types/unist@2.0.11': {}
+  "@types/unist@2.0.11": {}
 
-  '@types/unist@3.0.3': {}
+  "@types/unist@3.0.3": {}
 
-  '@ungap/structured-clone@1.3.0': {}
+  "@ungap/structured-clone@1.3.0": {}
 
-  '@upsetjs/venn.js@2.0.0':
+  "@upsetjs/venn.js@2.0.0":
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))':
+  "@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
+      "@babel/core": 7.29.0
+      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
+      "@rolldown/pluginutils": 1.0.0-beta.27
+      "@types/babel__core": 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.9':
+  "@vitest/expect@2.1.9":
     dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      "@vitest/spy": 2.1.9
+      "@vitest/utils": 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/expect@4.1.3':
+  "@vitest/expect@4.1.3":
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.3
-      '@vitest/utils': 4.1.3
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.1.3
+      "@vitest/utils": 4.1.3
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.15))':
+  "@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.15))":
     dependencies:
-      '@vitest/spy': 2.1.9
+      "@vitest/spy": 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.15)
 
-  '@vitest/mocker@4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))':
+  "@vitest/mocker@4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
-      '@vitest/spy': 4.1.3
+      "@vitest/spy": 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@2.1.9':
+  "@vitest/pretty-format@2.1.9":
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/pretty-format@4.1.3':
+  "@vitest/pretty-format@4.1.3":
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@2.1.9':
+  "@vitest/runner@2.1.9":
     dependencies:
-      '@vitest/utils': 2.1.9
+      "@vitest/utils": 2.1.9
       pathe: 1.1.2
 
-  '@vitest/runner@4.1.3':
+  "@vitest/runner@4.1.3":
     dependencies:
-      '@vitest/utils': 4.1.3
+      "@vitest/utils": 4.1.3
       pathe: 2.0.3
 
-  '@vitest/snapshot@2.1.9':
+  "@vitest/snapshot@2.1.9":
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      "@vitest/pretty-format": 2.1.9
       magic-string: 0.30.21
       pathe: 1.1.2
 
-  '@vitest/snapshot@4.1.3':
+  "@vitest/snapshot@4.1.3":
     dependencies:
-      '@vitest/pretty-format': 4.1.3
-      '@vitest/utils': 4.1.3
+      "@vitest/pretty-format": 4.1.3
+      "@vitest/utils": 4.1.3
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@2.1.9':
+  "@vitest/spy@2.1.9":
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/spy@4.1.3': {}
+  "@vitest/spy@4.1.3": {}
 
-  '@vitest/utils@2.1.9':
+  "@vitest/utils@2.1.9":
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      "@vitest/pretty-format": 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@vitest/utils@4.1.3':
+  "@vitest/utils@4.1.3":
     dependencies:
-      '@vitest/pretty-format': 4.1.3
+      "@vitest/pretty-format": 4.1.3
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.11': {}
+  "@xmldom/xmldom@0.8.11": {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -5006,11 +7460,11 @@ snapshots:
 
   chevrotain@11.1.2:
     dependencies:
-      '@chevrotain/cst-dts-gen': 11.1.2
-      '@chevrotain/gast': 11.1.2
-      '@chevrotain/regexp-to-ast': 11.1.2
-      '@chevrotain/types': 11.1.2
-      '@chevrotain/utils': 11.1.2
+      "@chevrotain/cst-dts-gen": 11.1.2
+      "@chevrotain/gast": 11.1.2
+      "@chevrotain/regexp-to-ast": 11.1.2
+      "@chevrotain/types": 11.1.2
+      "@chevrotain/utils": 11.1.2
       lodash-es: 4.17.23
 
   chokidar@3.6.0:
@@ -5102,7 +7556,7 @@ snapshots:
 
   cssstyle@4.6.0:
     dependencies:
-      '@asamuzakjp/css-color': 3.2.0
+      "@asamuzakjp/css-color": 3.2.0
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
@@ -5351,9 +7805,9 @@ snapshots:
 
   dockerode@4.0.10:
     dependencies:
-      '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.14.3
-      '@grpc/proto-loader': 0.7.15
+      "@balena/dockerignore": 1.0.2
+      "@grpc/grpc-js": 1.14.3
+      "@grpc/proto-loader": 0.7.15
       docker-modem: 5.0.7
       protobufjs: 7.5.4
       tar-fs: 2.1.4
@@ -5363,7 +7817,7 @@ snapshots:
 
   dompurify@3.3.3:
     optionalDependencies:
-      '@types/trusted-types': 2.0.7
+      "@types/trusted-types": 2.0.7
 
   dotenv@8.6.0: {}
 
@@ -5417,87 +7871,87 @@ snapshots:
 
   esbuild@0.21.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      "@esbuild/aix-ppc64": 0.21.5
+      "@esbuild/android-arm": 0.21.5
+      "@esbuild/android-arm64": 0.21.5
+      "@esbuild/android-x64": 0.21.5
+      "@esbuild/darwin-arm64": 0.21.5
+      "@esbuild/darwin-x64": 0.21.5
+      "@esbuild/freebsd-arm64": 0.21.5
+      "@esbuild/freebsd-x64": 0.21.5
+      "@esbuild/linux-arm": 0.21.5
+      "@esbuild/linux-arm64": 0.21.5
+      "@esbuild/linux-ia32": 0.21.5
+      "@esbuild/linux-loong64": 0.21.5
+      "@esbuild/linux-mips64el": 0.21.5
+      "@esbuild/linux-ppc64": 0.21.5
+      "@esbuild/linux-riscv64": 0.21.5
+      "@esbuild/linux-s390x": 0.21.5
+      "@esbuild/linux-x64": 0.21.5
+      "@esbuild/netbsd-x64": 0.21.5
+      "@esbuild/openbsd-x64": 0.21.5
+      "@esbuild/sunos-x64": 0.21.5
+      "@esbuild/win32-arm64": 0.21.5
+      "@esbuild/win32-ia32": 0.21.5
+      "@esbuild/win32-x64": 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
+      "@esbuild/aix-ppc64": 0.25.12
+      "@esbuild/android-arm": 0.25.12
+      "@esbuild/android-arm64": 0.25.12
+      "@esbuild/android-x64": 0.25.12
+      "@esbuild/darwin-arm64": 0.25.12
+      "@esbuild/darwin-x64": 0.25.12
+      "@esbuild/freebsd-arm64": 0.25.12
+      "@esbuild/freebsd-x64": 0.25.12
+      "@esbuild/linux-arm": 0.25.12
+      "@esbuild/linux-arm64": 0.25.12
+      "@esbuild/linux-ia32": 0.25.12
+      "@esbuild/linux-loong64": 0.25.12
+      "@esbuild/linux-mips64el": 0.25.12
+      "@esbuild/linux-ppc64": 0.25.12
+      "@esbuild/linux-riscv64": 0.25.12
+      "@esbuild/linux-s390x": 0.25.12
+      "@esbuild/linux-x64": 0.25.12
+      "@esbuild/netbsd-arm64": 0.25.12
+      "@esbuild/netbsd-x64": 0.25.12
+      "@esbuild/openbsd-arm64": 0.25.12
+      "@esbuild/openbsd-x64": 0.25.12
+      "@esbuild/openharmony-arm64": 0.25.12
+      "@esbuild/sunos-x64": 0.25.12
+      "@esbuild/win32-arm64": 0.25.12
+      "@esbuild/win32-ia32": 0.25.12
+      "@esbuild/win32-x64": 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
+      "@esbuild/aix-ppc64": 0.27.4
+      "@esbuild/android-arm": 0.27.4
+      "@esbuild/android-arm64": 0.27.4
+      "@esbuild/android-x64": 0.27.4
+      "@esbuild/darwin-arm64": 0.27.4
+      "@esbuild/darwin-x64": 0.27.4
+      "@esbuild/freebsd-arm64": 0.27.4
+      "@esbuild/freebsd-x64": 0.27.4
+      "@esbuild/linux-arm": 0.27.4
+      "@esbuild/linux-arm64": 0.27.4
+      "@esbuild/linux-ia32": 0.27.4
+      "@esbuild/linux-loong64": 0.27.4
+      "@esbuild/linux-mips64el": 0.27.4
+      "@esbuild/linux-ppc64": 0.27.4
+      "@esbuild/linux-riscv64": 0.27.4
+      "@esbuild/linux-s390x": 0.27.4
+      "@esbuild/linux-x64": 0.27.4
+      "@esbuild/netbsd-arm64": 0.27.4
+      "@esbuild/netbsd-x64": 0.27.4
+      "@esbuild/openbsd-arm64": 0.27.4
+      "@esbuild/openbsd-x64": 0.27.4
+      "@esbuild/openharmony-arm64": 0.27.4
+      "@esbuild/sunos-x64": 0.27.4
+      "@esbuild/win32-arm64": 0.27.4
+      "@esbuild/win32-ia32": 0.27.4
+      "@esbuild/win32-x64": 0.27.4
 
   escalade@3.2.0: {}
 
@@ -5511,7 +7965,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
 
   etag@1.8.1: {}
 
@@ -5569,8 +8023,8 @@ snapshots:
 
   fast-glob@3.3.3:
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
+      "@nodelib/fs.stat": 2.0.5
+      "@nodelib/fs.walk": 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
@@ -5708,9 +8162,9 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.8
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
+      "@types/estree": 1.0.8
+      "@types/hast": 3.0.4
+      "@types/unist": 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -5728,7 +8182,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      "@types/hast": 3.0.4
 
   hono@4.12.12: {}
 
@@ -5938,11 +8392,11 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      "@jridgewell/sourcemap-codec": 1.5.5
 
   mammoth@1.12.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      "@xmldom/xmldom": 0.8.11
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7
@@ -5961,15 +8415,15 @@ snapshots:
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       escape-string-regexp: 5.0.0
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
+      "@types/mdast": 4.0.4
+      "@types/unist": 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
@@ -5985,7 +8439,7 @@ snapshots:
 
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-find-and-replace: 3.0.2
@@ -5993,7 +8447,7 @@ snapshots:
 
   mdast-util-gfm-footnote@2.1.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -6003,7 +8457,7 @@ snapshots:
 
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
@@ -6011,7 +8465,7 @@ snapshots:
 
   mdast-util-gfm-table@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
       mdast-util-from-markdown: 2.0.3
@@ -6021,7 +8475,7 @@ snapshots:
 
   mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -6042,9 +8496,9 @@ snapshots:
 
   mdast-util-mdx-expression@2.0.1:
     dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
+      "@types/estree-jsx": 1.0.5
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -6053,10 +8507,10 @@ snapshots:
 
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
+      "@types/estree-jsx": 1.0.5
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@types/unist": 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -6070,9 +8524,9 @@ snapshots:
 
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
+      "@types/estree-jsx": 1.0.5
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -6081,14 +8535,14 @@ snapshots:
 
   mdast-util-phrasing@4.1.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@ungap/structured-clone": 1.3.0
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -6098,8 +8552,8 @@ snapshots:
 
   mdast-util-to-markdown@2.1.2:
     dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
+      "@types/mdast": 4.0.4
+      "@types/unist": 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
@@ -6110,7 +8564,7 @@ snapshots:
 
   mdast-util-to-string@4.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
 
   media-typer@0.3.0: {}
 
@@ -6120,11 +8574,11 @@ snapshots:
 
   mermaid@11.13.0:
     dependencies:
-      '@braintree/sanitize-url': 7.1.2
-      '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.1
-      '@types/d3': 7.4.3
-      '@upsetjs/venn.js': 2.0.0
+      "@braintree/sanitize-url": 7.1.2
+      "@iconify/utils": 3.1.0
+      "@mermaid-js/parser": 1.0.1
+      "@types/d3": 7.4.3
+      "@upsetjs/venn.js": 2.0.0
       cytoscape: 3.33.1
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
       cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
@@ -6315,7 +8769,7 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      '@types/debug': 4.1.13
+      "@types/debug": 4.1.13
       debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
@@ -6398,8 +8852,8 @@ snapshots:
 
   openai@4.104.0(ws@8.20.0):
     dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
+      "@types/node": 18.19.130
+      "@types/node-fetch": 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
@@ -6440,7 +8894,7 @@ snapshots:
 
   parse-entities@4.0.2:
     dependencies:
-      '@types/unist': 2.0.11
+      "@types/unist": 2.0.11
       character-entities-legacy: 3.0.0
       character-reference-invalid: 2.0.1
       decode-named-character-reference: 1.3.0
@@ -6526,17 +8980,17 @@ snapshots:
 
   protobufjs@7.5.4:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.19.15
+      "@protobufjs/aspromise": 1.1.2
+      "@protobufjs/base64": 1.1.2
+      "@protobufjs/codegen": 2.0.4
+      "@protobufjs/eventemitter": 1.1.0
+      "@protobufjs/fetch": 1.1.0
+      "@protobufjs/float": 1.0.2
+      "@protobufjs/inquire": 1.1.0
+      "@protobufjs/path": 1.1.2
+      "@protobufjs/pool": 1.1.0
+      "@protobufjs/utf8": 1.1.0
+      "@types/node": 22.19.15
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -6577,9 +9031,9 @@ snapshots:
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.14
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      "@types/react": 19.2.14
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
@@ -6626,7 +9080,7 @@ snapshots:
 
   remark-gfm@4.0.1:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
@@ -6637,7 +9091,7 @@ snapshots:
 
   remark-parse@11.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
@@ -6646,15 +9100,15 @@ snapshots:
 
   remark-rehype@11.1.2:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
   remark-stringify@11.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
+      "@types/mdast": 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
@@ -6670,33 +9124,33 @@ snapshots:
 
   rollup@4.60.0:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.0
-      '@rollup/rollup-android-arm64': 4.60.0
-      '@rollup/rollup-darwin-arm64': 4.60.0
-      '@rollup/rollup-darwin-x64': 4.60.0
-      '@rollup/rollup-freebsd-arm64': 4.60.0
-      '@rollup/rollup-freebsd-x64': 4.60.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
-      '@rollup/rollup-linux-arm64-gnu': 4.60.0
-      '@rollup/rollup-linux-arm64-musl': 4.60.0
-      '@rollup/rollup-linux-loong64-gnu': 4.60.0
-      '@rollup/rollup-linux-loong64-musl': 4.60.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
-      '@rollup/rollup-linux-ppc64-musl': 4.60.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
-      '@rollup/rollup-linux-riscv64-musl': 4.60.0
-      '@rollup/rollup-linux-s390x-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-musl': 4.60.0
-      '@rollup/rollup-openbsd-x64': 4.60.0
-      '@rollup/rollup-openharmony-arm64': 4.60.0
-      '@rollup/rollup-win32-arm64-msvc': 4.60.0
-      '@rollup/rollup-win32-ia32-msvc': 4.60.0
-      '@rollup/rollup-win32-x64-gnu': 4.60.0
-      '@rollup/rollup-win32-x64-msvc': 4.60.0
+      "@rollup/rollup-android-arm-eabi": 4.60.0
+      "@rollup/rollup-android-arm64": 4.60.0
+      "@rollup/rollup-darwin-arm64": 4.60.0
+      "@rollup/rollup-darwin-x64": 4.60.0
+      "@rollup/rollup-freebsd-arm64": 4.60.0
+      "@rollup/rollup-freebsd-x64": 4.60.0
+      "@rollup/rollup-linux-arm-gnueabihf": 4.60.0
+      "@rollup/rollup-linux-arm-musleabihf": 4.60.0
+      "@rollup/rollup-linux-arm64-gnu": 4.60.0
+      "@rollup/rollup-linux-arm64-musl": 4.60.0
+      "@rollup/rollup-linux-loong64-gnu": 4.60.0
+      "@rollup/rollup-linux-loong64-musl": 4.60.0
+      "@rollup/rollup-linux-ppc64-gnu": 4.60.0
+      "@rollup/rollup-linux-ppc64-musl": 4.60.0
+      "@rollup/rollup-linux-riscv64-gnu": 4.60.0
+      "@rollup/rollup-linux-riscv64-musl": 4.60.0
+      "@rollup/rollup-linux-s390x-gnu": 4.60.0
+      "@rollup/rollup-linux-x64-gnu": 4.60.0
+      "@rollup/rollup-linux-x64-musl": 4.60.0
+      "@rollup/rollup-openbsd-x64": 4.60.0
+      "@rollup/rollup-openharmony-arm64": 4.60.0
+      "@rollup/rollup-win32-arm64-msvc": 4.60.0
+      "@rollup/rollup-win32-ia32-msvc": 4.60.0
+      "@rollup/rollup-win32-x64-gnu": 4.60.0
+      "@rollup/rollup-win32-x64-msvc": 4.60.0
       fsevents: 2.3.3
 
   roughjs@4.6.6:
@@ -7011,7 +9465,7 @@ snapshots:
 
   turndown@7.2.4:
     dependencies:
-      '@mixmark-io/domino': 2.2.0
+      "@mixmark-io/domino": 2.2.0
 
   tweetnacl@0.14.5: {}
 
@@ -7032,7 +9486,7 @@ snapshots:
 
   unified@11.0.5:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       bail: 2.0.2
       devlop: 1.1.0
       extend: 3.0.2
@@ -7042,24 +9496,24 @@ snapshots:
 
   unist-util-is@6.0.1:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
   unist-util-stringify-position@4.0.0:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
 
   unist-util-visit-parents@6.0.2:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       unist-util-is: 6.0.1
 
   unist-util-visit@5.1.0:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
@@ -7085,12 +9539,12 @@ snapshots:
 
   vfile-message@4.0.3:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       unist-util-stringify-position: 4.0.0
 
   vfile@6.0.3:
     dependencies:
-      '@types/unist': 3.0.3
+      "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
   vite-node@2.1.9(@types/node@22.19.15):
@@ -7101,7 +9555,7 @@ snapshots:
       pathe: 1.1.2
       vite: 5.4.21(@types/node@22.19.15)
     transitivePeerDependencies:
-      - '@types/node'
+      - "@types/node"
       - less
       - lightningcss
       - sass
@@ -7137,7 +9591,7 @@ snapshots:
       postcss: 8.5.8
       rollup: 4.60.0
     optionalDependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
       fsevents: 2.3.3
 
   vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
@@ -7149,20 +9603,20 @@ snapshots:
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
       fsevents: 2.3.3
       tsx: 4.21.0
       yaml: 2.8.3
 
   vitest@2.1.9(@types/node@22.19.15)(jsdom@26.1.0):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.15))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      "@vitest/expect": 2.1.9
+      "@vitest/mocker": 2.1.9(vite@5.4.21(@types/node@22.19.15))
+      "@vitest/pretty-format": 2.1.9
+      "@vitest/runner": 2.1.9
+      "@vitest/snapshot": 2.1.9
+      "@vitest/spy": 2.1.9
+      "@vitest/utils": 2.1.9
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -7177,7 +9631,7 @@ snapshots:
       vite-node: 2.1.9(@types/node@22.19.15)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
       jsdom: 26.1.0
     transitivePeerDependencies:
       - less
@@ -7192,13 +9646,13 @@ snapshots:
 
   vitest@4.1.3(@types/node@22.19.15)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.3
-      '@vitest/mocker': 4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.3
-      '@vitest/runner': 4.1.3
-      '@vitest/snapshot': 4.1.3
-      '@vitest/spy': 4.1.3
-      '@vitest/utils': 4.1.3
+      "@vitest/expect": 4.1.3
+      "@vitest/mocker": 4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
+      "@vitest/pretty-format": 4.1.3
+      "@vitest/runner": 4.1.3
+      "@vitest/snapshot": 4.1.3
+      "@vitest/spy": 4.1.3
+      "@vitest/utils": 4.1.3
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -7213,7 +9667,7 @@ snapshots:
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.15
+      "@types/node": 22.19.15
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,9 @@
       "@agentrail/core": ["packages/core/src/index.ts"],
       "@agentrail/core/providers": ["packages/core/src/llm/providers/index.ts"],
       "@agentrail/capabilities": ["packages/capabilities/src/index.ts"],
-      "@agentrail/capabilities/orchestration/worker": ["packages/capabilities/src/orchestration/worker/index.ts"],
+      "@agentrail/capabilities/orchestration/worker": [
+        "packages/capabilities/src/orchestration/worker/index.ts"
+      ],
       "@agentrail/app": ["packages/app/src/index.ts"],
       "@agentrail/deep-research": ["packages/deep-research/src/index.ts"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "examples/playground-server" },
-    { "path": "examples/playground-ui" }
-  ]
+  "references": [{ "path": "examples/playground-server" }, { "path": "examples/playground-ui" }]
 }


### PR DESCRIPTION
Closes #23.

## Summary

- New `AgentToolCallRecord` type capturing `toolCallId`, `toolName`, `input` (model arguments), and `output` (both `content` blocks and structured `details`) for each tool call a sub-agent makes during a job.
- `ManagedAgentDeliveryResult` and `OrchestrationAgentJob` gain an optional `toolCalls?: AgentToolCallRecord[]` field.
- `subagent-worker.ts` – new `extractToolCallRecords()` helper pairs `ToolCall` blocks in `AssistantMessage` with their `ToolResultMessage` counterparts, capturing both `content` and `details`. Attached to the `ManagedAgentDeliveryResult` returned by `runTurn`.
- `orchestration-manager-helpers.ts` – `normalizeDeliveryResult()` now explicitly forwards `toolCalls` instead of silently dropping it (the live delivery path goes through this helper).
- `orchestration-manager.ts` – all three job-completion paths propagate `toolCalls` so `agent.lastJob.toolCalls` is always populated.
- `wait-agent.ts` – `formatWaitResult` now includes `resolution` (which carries `outputText` and `toolCalls`) in the JSON content text so the parent LLM can actually read the sub-agent's output.

## Test plan

- [x] `normalizeDeliveryResult` passes `toolCalls` through (unit test)
- [x] `OrchestrationManager` stores `toolCalls` in `agent.lastJob` after a successful job
- [x] `OrchestrationManager` stores `undefined` when sub-agent made no tool calls
- [x] `waitForAgents` resolution includes `toolCalls` in `resolution.job`
- [x] `wait_agent` tool content JSON includes `resolution.job.toolCalls`
- [x] `pnpm build:packages && pnpm test && pnpm typecheck` all pass