### PR TITLE
feat(tracing): add chainId, depth, turnIndex to RuntimeEvent for multi-agent trace correlation

### DIFF
--- a/.changeset/runtime-tracing-fields.md
+++ b/.changeset/runtime-tracing-fields.md
@@ -1,0 +1,11 @@
+---
+"@agentrail/core": minor
+"@agentrail/capabilities": minor
+"@agentrail/app": minor
+---
+
+Add `chainId`, `depth`, and `turnIndex` tracing fields to every `RuntimeEvent`.
+
+- **`@agentrail/core`**: `RuntimeTracingFields` interface exported from the package root. Every `RuntimeEvent` variant is now intersected with `RuntimeTracingFields` (all three fields are required). `AgentRunOptions` gains optional `chainId` and `depth` fields that flow into the agent loop. `InternalContext` is extended with the same optional fields.
+- **`@agentrail/capabilities`**: `CapabilityBuildContext` gains an optional `tracing` field `{ chainId: string; depth: number }`. `SpawnAgentInput` and `CreateManagedAgentInput` gain optional `chainId` and `depth` fields. The `spawn_agent` tool increments depth and propagates `chainId` to the child agent. `WorkerInitMessage` and `WorkerState` carry the same fields so the worker process can pass them to `agent.invoke`.
+- **`@agentrail/app`**: `AgentrailProfileContext` gains an optional `chainId` field. The route-level `traceId` / `requestTraceId` is propagated as `chainId` into `AgentrailProfileContext`, `CapabilityBuildContext.tracing`, and `AgentRunOptions.chainId` so that `RuntimeEvent.chainId === telemetry traceId` for the full request chain.

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -203,6 +203,27 @@ The most important ones for UI consumers:
 | `waiting_for_user_input`    | The agent is paused waiting for user input                                                 |
 | `skill_start` / `skill_end` | A skill sub-agent is invoked                                                               |
 
+### Tracing fields on every RuntimeEvent
+
+Every `RuntimeEvent` carries three additional fields for distributed tracing and log correlation:
+
+```ts
+interface RuntimeTracingFields {
+  /** Stable correlation ID for the entire request chain.
+   * Shared by the root agent and all spawned sub-agents.
+   * In the app layer this equals the route-level traceId / requestTraceId. */
+  readonly chainId: string;
+  /** Nesting depth: 0 = root agent, 1 = direct sub-agent, etc. */
+  readonly depth: number;
+  /** Zero-based turn counter within this agent's loop.
+   * Pre-loop events (session.start, initial turn.start, initial prompt messages)
+   * carry turnIndex = 0. */
+  readonly turnIndex: number;
+}
+```
+
+These fields are automatically stamped by `agentLoop` and propagated to sub-agents via the orchestration subsystem. You can use `chainId` to join all events across a multi-agent invocation in your telemetry backend.
+
 ### `tool.before` field reference
 
 ```ts

--- a/docs/reference/profile-contract.md
+++ b/docs/reference/profile-contract.md
@@ -80,6 +80,11 @@ interface AgentrailProfileContext {
   sessionId: string;
   sessionRef: SessionRef;
   sessionStore: AgentrailSessionStore;
+  /** Stable correlation ID for the entire request chain.
+   * When provided, it flows into CapabilityBuildContext.tracing.chainId and
+   * AgentRunOptions.chainId so that RuntimeEvent.chainId equals the route-level
+   * traceId. Sub-agent events inherit the same chainId with depth incremented. */
+  chainId?: string;
 }
 
 interface AgentrailProfile {

--- a/examples/playground-server/src/agents/default-subagent-runtime.ts
+++ b/examples/playground-server/src/agents/default-subagent-runtime.ts
@@ -65,7 +65,7 @@ export class DefaultSubAgentRuntime implements SubAgentRuntime {
     ].join("\n\n");
   }
 
-  async buildTools(_input: CreateManagedAgentInput): Promise<RuntimeTool[]> {
+  async buildTools(input: CreateManagedAgentInput): Promise<RuntimeTool[]> {
     const sessionStore = new SessionManager(this.dataDir);
     const capCtx: CapabilityBuildContext = {
       tenantId: this.tenantId,
@@ -73,6 +73,10 @@ export class DefaultSubAgentRuntime implements SubAgentRuntime {
       sessionId: this.sessionId,
       sessionRef: this.sessionRef,
       sessionStore,
+      tracing:
+        input.chainId !== undefined
+          ? { chainId: input.chainId, depth: input.depth ?? 0 }
+          : undefined,
     };
 
     return (

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -69,6 +69,13 @@ export interface AgentrailProfileContext {
   sessionId: string;
   sessionRef: SessionRef;
   sessionStore: AgentrailSessionStore;
+  /**
+   * Stable correlation ID for the entire request chain.  When present, this is
+   * propagated into `CapabilityBuildContext.tracing.chainId` and then into
+   * `AgentRunOptions.chainId` so that `RuntimeEvent.chainId` equals the
+   * route-level `traceId`/`requestTraceId`.
+   */
+  chainId?: string;
 }
 
 /**

--- a/packages/app/src/profile/define-profile.ts
+++ b/packages/app/src/profile/define-profile.ts
@@ -115,6 +115,7 @@ function buildBaseCapCtx(
     sessionStore: context.sessionStore,
     modelConfig,
     onSubAgentEvent,
+    tracing: context.chainId ? { chainId: context.chainId, depth: 0 } : undefined,
   };
 }
 

--- a/packages/app/src/routes/chat-route.ts
+++ b/packages/app/src/routes/chat-route.ts
@@ -245,6 +245,9 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
         return c.json({ error: `Agent profile '${agentId}' not found` }, 404);
       }
 
+      // traceId is created here so it can serve as chainId for capability build context.
+      const traceId = randomUUID();
+
       // Pass a no-op sub-agent event handler so that capabilities relying on
       // onSubAgentEvent (e.g. orchestration tools) work on the /chat path too.
       // Events are discarded here — use the /stream endpoint for live event delivery.
@@ -254,6 +257,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
         sessionId,
         sessionRef,
         sessionStore: options.sessionStore,
+        chainId: traceId,
       };
       const agent = await profile.createAgent(profileCtx, () => {
         /* sub-agent events are not forwarded on the JSON /chat route */
@@ -282,7 +286,6 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
       );
 
       const traceCtx = { tenantId: request.tenantId, sessionId, sessionRef };
-      const traceId = randomUUID();
       let traceSeq = 0;
 
       emitTraceEvent(traceCtx, { type: "agent_start", agentId, traceId }, traceSeq++, traceId);
@@ -300,6 +303,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
           transformContext,
           reactiveCompaction,
           toolInterceptor: buildToolInterceptor(plugins, profileCtx, onPluginError),
+          chainId: traceId,
         });
       } catch (invokeError) {
         emitTraceEvent(

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -500,14 +500,13 @@ async function drainAgentStream(
 
   for await (const event of agentStream) {
     if (isRuntimeError(event)) {
-      const errorEvent: AgentrailErrorEvent = {
-        type: "error",
-        error: { message: (event.error as Error)?.message ?? "Unknown runtime error" },
-      };
+      const message = (event.error as Error)?.message ?? "Unknown runtime error";
+      const errorEvent: AgentrailErrorEvent = { type: "error", error: { message } };
       // SSE clients receive the sanitised host event (no raw Error object).
       await opts.writeEvent(errorEvent);
-      // Trace consumers receive the original RuntimeEvent so chainId/depth/turnIndex are preserved.
-      opts.onTraceEvent(event);
+      // Trace consumers receive a sanitized event that preserves tracing fields AND
+      // keeps the error message readable (raw Error instances serialize as "{}").
+      opts.onTraceEvent({ ...errorEvent, chainId: event.chainId, depth: event.depth, turnIndex: event.turnIndex });
       break;
     }
 

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -506,7 +506,12 @@ async function drainAgentStream(
       await opts.writeEvent(errorEvent);
       // Trace consumers receive a sanitized event that preserves tracing fields AND
       // keeps the error message readable (raw Error instances serialize as "{}").
-      opts.onTraceEvent({ ...errorEvent, chainId: event.chainId, depth: event.depth, turnIndex: event.turnIndex });
+      opts.onTraceEvent({
+        ...errorEvent,
+        chainId: event.chainId,
+        depth: event.depth,
+        turnIndex: event.turnIndex,
+      });
       break;
     }
 

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -504,8 +504,10 @@ async function drainAgentStream(
         type: "error",
         error: { message: (event.error as Error)?.message ?? "Unknown runtime error" },
       };
+      // SSE clients receive the sanitised host event (no raw Error object).
       await opts.writeEvent(errorEvent);
-      opts.onTraceEvent(errorEvent);
+      // Trace consumers receive the original RuntimeEvent so chainId/depth/turnIndex are preserved.
+      opts.onTraceEvent(event);
       break;
     }
 

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -340,6 +340,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
           sessionId: sid,
           sessionRef,
           sessionStore: options.sessionStore,
+          chainId: requestTraceId,
         };
 
         // ── 6d. Compact history + load budget slice ────────────────────────
@@ -417,6 +418,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
             writeEvent,
             onTraceEvent: maybeTraceEvent,
             toolInterceptor: buildToolInterceptor(plugins, profileCtx, onPluginError),
+            chainId: requestTraceId,
             onTurnMessagesReady: async (msgs) => {
               await options.sessionStore.appendMessages(tenantId, sid, msgs);
             },
@@ -456,6 +458,7 @@ interface DrainAgentStreamOptions {
   writeEvent: (event: RuntimeEvent | object) => Promise<void>;
   onTraceEvent: (event: RuntimeEvent | object) => void;
   toolInterceptor?: ToolInterceptor;
+  chainId?: string;
   /**
    * Called after each internal reasoning turn (turn.complete) with the batch of new messages
    * produced during that turn. SSE is written first; this runs immediately after.
@@ -492,6 +495,7 @@ async function drainAgentStream(
     transformContext: opts.transformContext,
     reactiveCompaction: opts.reactiveCompaction,
     toolInterceptor: opts.toolInterceptor,
+    chainId: opts.chainId,
   });
 
   for await (const event of agentStream) {

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -500,18 +500,18 @@ async function drainAgentStream(
 
   for await (const event of agentStream) {
     if (isRuntimeError(event)) {
-      const message = (event.error as Error)?.message ?? "Unknown runtime error";
-      const errorEvent: AgentrailErrorEvent = { type: "error", error: { message } };
-      // SSE clients receive the sanitised host event (no raw Error object).
-      await opts.writeEvent(errorEvent);
-      // Trace consumers receive a sanitized event that preserves tracing fields AND
-      // keeps the error message readable (raw Error instances serialize as "{}").
-      opts.onTraceEvent({
-        ...errorEvent,
+      // Build a single sanitized event: no raw Error instance (serializes as "{}"),
+      // and tracing fields are preserved so both SSE clients and trace observers
+      // satisfy the RuntimeEvent contract.
+      const errorEvent = {
+        type: "error" as const,
+        error: { message: (event.error as Error)?.message ?? "Unknown runtime error" },
         chainId: event.chainId,
         depth: event.depth,
         turnIndex: event.turnIndex,
-      });
+      };
+      await opts.writeEvent(errorEvent);
+      opts.onTraceEvent(errorEvent);
       break;
     }
 

--- a/packages/app/test/chat-route-telemetry.test.ts
+++ b/packages/app/test/chat-route-telemetry.test.ts
@@ -123,6 +123,55 @@ describe("createChatRoute – telemetry event filtering", () => {
     expect([...traceIds][0]).toBeDefined();
   });
 
+  it("agent.invoke is called with chainId matching the request traceId", async () => {
+    const collected: WorkflowTraceEventEnvelope[] = [];
+    let invokeOptions: Record<string, unknown> | undefined;
+
+    const profile: AgentrailProfile = {
+      id: AGENT_ID,
+      name: AGENT_ID,
+      createAgent: vi.fn().mockResolvedValue({
+        invoke: vi.fn().mockImplementation((_msg: string, opts: Record<string, unknown>) => {
+          invokeOptions = opts;
+          return Promise.resolve({
+            text: "hello",
+            messages: [],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            stopReason: "end_turn",
+          });
+        }),
+      }),
+      getContextProviders: vi.fn().mockResolvedValue([]),
+    } as unknown as AgentrailProfile;
+
+    const route = createChatRoute({
+      defaultAgentId: AGENT_ID,
+      sessionStore: makeSessionStore(),
+      summarize: async () => "",
+      compaction: { triggerTokens: 999_999, minMessages: 9999 },
+      resolveProfile: vi.fn().mockResolvedValue(profile),
+      onTraceEvent: (_ctx, envelope) => collected.push(envelope),
+    });
+
+    const req = new Request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        agentId: AGENT_ID,
+        message: "ping",
+      }),
+    });
+
+    await route.fetch(req);
+
+    // The traceId from the envelopes and the chainId passed to invoke must match.
+    const traceId = collected[0]?.traceId;
+    expect(traceId).toBeDefined();
+    expect(invokeOptions?.chainId).toBe(traceId);
+  });
+
   it("each envelope has a unique id even though traceId is shared", async () => {
     const collected: WorkflowTraceEventEnvelope[] = [];
     const profile = makeProfile();

--- a/packages/app/test/stream-route-persistence.test.ts
+++ b/packages/app/test/stream-route-persistence.test.ts
@@ -17,10 +17,13 @@ import type {
   AssistantMessage,
   Message,
   RuntimeEvent,
+  RuntimeTracingFields,
   ToolResultMessage,
   Usage,
 } from "@agentrail/core";
 import { describe, expect, it, vi } from "vitest";
+
+const T: RuntimeTracingFields = { chainId: "test-chain", depth: 0, turnIndex: 0 };
 import type { AgentrailProfile, AgentrailSessionStore } from "../src/host/types.js";
 import { createStreamRoute } from "../src/routes/stream-route.js";
 
@@ -74,28 +77,30 @@ function makeTwoTurnStream(): AgentStream {
   const assistantMsg2 = makeAssistantMsg(false); // turn 2: final response
 
   async function* events(): AsyncGenerator<RuntimeEvent> {
-    yield { type: "session.start" };
-    yield { type: "turn.start" };
-    yield { type: "message.start", message: userMsg };
-    yield { type: "message.end", message: userMsg };
-    yield { type: "message.start", message: assistantMsg1 };
-    yield { type: "message.end", message: assistantMsg1 };
-    yield { type: "tool.before", toolCallId: "tc1", toolName: "search", args: {} };
+    yield { ...T, type: "session.start" };
+    yield { ...T, type: "turn.start" };
+    yield { ...T, type: "message.start", message: userMsg };
+    yield { ...T, type: "message.end", message: userMsg };
+    yield { ...T, type: "message.start", message: assistantMsg1 };
+    yield { ...T, type: "message.end", message: assistantMsg1 };
+    yield { ...T, type: "tool.before", toolCallId: "tc1", toolName: "search", args: {} };
     yield {
+      ...T,
       type: "tool.after",
       toolCallId: "tc1",
       toolName: "search",
       result: "result",
       isError: false,
     };
-    yield { type: "message.start", message: toolResultMsg };
-    yield { type: "message.end", message: toolResultMsg };
-    yield { type: "turn.complete", message: assistantMsg1, toolResults: [toolResultMsg] };
-    yield { type: "turn.start" };
-    yield { type: "message.start", message: assistantMsg2 };
-    yield { type: "message.end", message: assistantMsg2 };
-    yield { type: "turn.complete", message: assistantMsg2, toolResults: [] };
+    yield { ...T, type: "message.start", message: toolResultMsg };
+    yield { ...T, type: "message.end", message: toolResultMsg };
+    yield { ...T, type: "turn.complete", message: assistantMsg1, toolResults: [toolResultMsg] };
+    yield { ...T, type: "turn.start" };
+    yield { ...T, type: "message.start", message: assistantMsg2 };
+    yield { ...T, type: "message.end", message: assistantMsg2 };
+    yield { ...T, type: "turn.complete", message: assistantMsg2, toolResults: [] };
     yield {
+      ...T,
       type: "session.end",
       messages: [userMsg, assistantMsg1, toolResultMsg, assistantMsg2],
       usage: ZERO_USAGE,
@@ -246,8 +251,8 @@ describe("stream-route – incremental persistence", () => {
     const sessionStore = makeSessionStore();
 
     async function* earlyEndStream(): AsyncGenerator<RuntimeEvent> {
-      yield { type: "session.start" };
-      yield { type: "turn.start" };
+      yield { ...T, type: "session.start" };
+      yield { ...T, type: "turn.start" };
       // stream ends without session.end
     }
 
@@ -387,13 +392,14 @@ describe("stream-route – abort race condition", () => {
     const assistantMsg = makeAssistantMsg(false);
 
     async function* streamWithSessionEnd(): AsyncGenerator<RuntimeEvent> {
-      yield { type: "session.start" };
-      yield { type: "turn.start" };
-      yield { type: "message.end", message: assistantMsg };
-      yield { type: "turn.complete", message: assistantMsg, toolResults: [] };
+      yield { ...T, type: "session.start" };
+      yield { ...T, type: "turn.start" };
+      yield { ...T, type: "message.end", message: assistantMsg };
+      yield { ...T, type: "turn.complete", message: assistantMsg, toolResults: [] };
       // This event should never be consumed — the bottom-of-loop abort check
       // fires after the flush above and breaks out before reaching here.
       yield {
+        ...T,
         type: "session.end",
         messages: [assistantMsg],
         usage: ZERO_USAGE,
@@ -442,12 +448,13 @@ describe("stream-route – abort race condition", () => {
     // check runs, signal.aborted is already true — so the loop breaks before
     // ever requesting turn.complete from the generator.
     async function* streamWithEarlyAbort(): AsyncGenerator<RuntimeEvent> {
-      yield { type: "session.start" };
+      yield { ...T, type: "session.start" };
       reqAbortCtrl.abort(); // fires before the next yield is consumed
-      yield { type: "turn.start" };
-      yield { type: "message.end", message: assistantMsg };
-      yield { type: "turn.complete", message: assistantMsg, toolResults: [] };
+      yield { ...T, type: "turn.start" };
+      yield { ...T, type: "message.end", message: assistantMsg };
+      yield { ...T, type: "turn.complete", message: assistantMsg, toolResults: [] };
       yield {
+        ...T,
         type: "session.end",
         messages: [assistantMsg],
         usage: ZERO_USAGE,

--- a/packages/app/test/stream-route-persistence.test.ts
+++ b/packages/app/test/stream-route-persistence.test.ts
@@ -22,10 +22,10 @@ import type {
   Usage,
 } from "@agentrail/core";
 import { describe, expect, it, vi } from "vitest";
-
-const T: RuntimeTracingFields = { chainId: "test-chain", depth: 0, turnIndex: 0 };
 import type { AgentrailProfile, AgentrailSessionStore } from "../src/host/types.js";
 import { createStreamRoute } from "../src/routes/stream-route.js";
+
+const T: RuntimeTracingFields = { chainId: "test-chain", depth: 0, turnIndex: 0 };
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 

--- a/packages/capabilities/src/orchestration/descriptor.ts
+++ b/packages/capabilities/src/orchestration/descriptor.ts
@@ -147,7 +147,7 @@ export function orchestration(
               });
 
       return [
-        createSpawnAgentTool(om, getRunId),
+        createSpawnAgentTool(om, getRunId, ctx.tracing),
         createSendInputTool(om),
         createWaitAgentTool(om),
         createCloseAgentTool(om),

--- a/packages/capabilities/src/orchestration/orchestration-manager.ts
+++ b/packages/capabilities/src/orchestration/orchestration-manager.ts
@@ -182,7 +182,13 @@ export class OrchestrationManager {
       }
 
       if (existingAgent.status !== "closed" && !this.activeAgents.has(existingAgent.id)) {
-        await this.attachAgent(existingAgent, normalizedInput.chainId, normalizedInput.depth);
+        // Prefer the persisted tracing identity; fall back to the caller's values only if
+        // the agent was originally spawned without tracing (e.g. before this feature existed).
+        await this.attachAgent(
+          existingAgent,
+          existingAgent.chainId ?? normalizedInput.chainId,
+          existingAgent.depth ?? normalizedInput.depth,
+        );
         this.resumeQueuedInputsForAgent(existingAgent.id);
       }
 

--- a/packages/capabilities/src/orchestration/orchestration-manager.ts
+++ b/packages/capabilities/src/orchestration/orchestration-manager.ts
@@ -52,6 +52,10 @@ export interface CreateManagedAgentInput {
   runId: string;
   role: string;
   taskId: string;
+  /** Shared correlation ID for the entire request chain (root + descendants). */
+  chainId?: string;
+  /** Sub-agent nesting depth within the multi-agent hierarchy. */
+  depth?: number;
 }
 
 /** Runtime adapter that creates managed-agent instances on demand. */
@@ -178,7 +182,7 @@ export class OrchestrationManager {
       }
 
       if (existingAgent.status !== "closed" && !this.activeAgents.has(existingAgent.id)) {
-        await this.attachAgent(existingAgent);
+        await this.attachAgent(existingAgent, normalizedInput.chainId, normalizedInput.depth);
         this.resumeQueuedInputsForAgent(existingAgent.id);
       }
 
@@ -203,7 +207,7 @@ export class OrchestrationManager {
       throw new Error(`Failed to create agent ${normalizedInput.id}`);
     }
 
-    await this.attachAgent(agent);
+    await this.attachAgent(agent, normalizedInput.chainId, normalizedInput.depth);
     return cloneAgent(agent);
   }
 
@@ -484,12 +488,18 @@ export class OrchestrationManager {
     }
   }
 
-  private async attachAgent(agent: OrchestrationAgent): Promise<void> {
+  private async attachAgent(
+    agent: OrchestrationAgent,
+    chainId?: string,
+    depth?: number,
+  ): Promise<void> {
     const instance = await this.runtime.createAgent({
       agentId: agent.id,
       runId: agent.runId,
       role: agent.role,
       taskId: agent.taskId,
+      chainId,
+      depth,
     });
     instance.subscribe?.({
       onJobStarted: (job) => {

--- a/packages/capabilities/src/orchestration/orchestration-manager.ts
+++ b/packages/capabilities/src/orchestration/orchestration-manager.ts
@@ -412,7 +412,7 @@ export class OrchestrationManager {
       (currentAgent) => currentAgent.status !== "closed",
     )) {
       try {
-        await this.attachAgent(agent);
+        await this.attachAgent(agent, agent.chainId, agent.depth);
       } catch {
         // Keep recovered state intact; a later explicit attach path can retry.
       }

--- a/packages/capabilities/src/orchestration/recovery.ts
+++ b/packages/capabilities/src/orchestration/recovery.ts
@@ -154,6 +154,8 @@ export function applyOrchestrationEvent(
         status: "idle",
         createdAt: event.occurredAt,
         updatedAt: event.occurredAt,
+        chainId: event.agent.chainId,
+        depth: event.agent.depth,
       };
       break;
     }

--- a/packages/capabilities/src/orchestration/tools/spawn-agent.ts
+++ b/packages/capabilities/src/orchestration/tools/spawn-agent.ts
@@ -21,6 +21,7 @@ function formatSpawnResult(agent: OrchestrationAgent): string {
 export function createSpawnAgentTool(
   manager: OrchestrationManager,
   getRunId: () => Promise<string>,
+  tracingCtx?: { chainId: string; depth: number },
 ) {
   return tool()
     .name("spawn_agent")
@@ -46,7 +47,12 @@ export function createSpawnAgentTool(
     )
     .execute(async (input) => {
       const runId = await getRunId();
-      const agent = await manager.spawnAgent({ ...input, runId });
+      const agent = await manager.spawnAgent({
+        ...input,
+        runId,
+        chainId: tracingCtx?.chainId ?? runId,
+        depth: (tracingCtx?.depth ?? 0) + 1,
+      });
       return {
         content: [{ type: "text" as const, text: formatSpawnResult(agent) }],
         details: {

--- a/packages/capabilities/src/orchestration/types.ts
+++ b/packages/capabilities/src/orchestration/types.ts
@@ -99,6 +99,10 @@ export interface OrchestrationAgent {
   updatedAt: string;
   closedAt?: string;
   lastJob?: OrchestrationAgentJob;
+  /** Persisted so the sub-agent retains its tracing identity across manager restarts. */
+  chainId?: string;
+  /** Persisted so the sub-agent retains its depth after manager recovery. */
+  depth?: number;
 }
 
 /** Wait condition registered by a managed agent. */

--- a/packages/capabilities/src/orchestration/types.ts
+++ b/packages/capabilities/src/orchestration/types.ts
@@ -124,6 +124,10 @@ export interface SpawnAgentInput {
   taskId?: string;
   displayName?: string;
   role: string;
+  /** Shared correlation ID for the entire request chain (root + descendants). */
+  chainId?: string;
+  /** Sub-agent nesting depth within the multi-agent hierarchy. */
+  depth?: number;
 }
 
 /** Input queued for delivery to a managed agent. */

--- a/packages/capabilities/src/orchestration/worker/agent-runtime.ts
+++ b/packages/capabilities/src/orchestration/worker/agent-runtime.ts
@@ -42,4 +42,8 @@ export interface WorkerState {
   input: CreateManagedAgentInput;
   history: Message[];
   workerConfig: SubagentWorkerConfig;
+  /** Shared correlation ID for the request chain (root + all descendants). */
+  chainId?: string;
+  /** Sub-agent nesting depth within the multi-agent hierarchy. */
+  depth?: number;
 }

--- a/packages/capabilities/src/orchestration/worker/subagent-process.ts
+++ b/packages/capabilities/src/orchestration/worker/subagent-process.ts
@@ -250,6 +250,7 @@ export async function createManagedSubAgentInstance(
     readyTimeout.unref?.();
   }
 
+  const resolvedInput: CreateManagedAgentInput = options.runtimeConfig?.input ?? options.input;
   safeSend(
     child,
     {
@@ -261,9 +262,11 @@ export async function createManagedSubAgentInstance(
       dataDir: options.dataDir,
       runtimeConfig: {
         ...(options.runtimeConfig ?? {}),
-        input: options.runtimeConfig?.input ?? options.input,
+        input: resolvedInput,
       },
       workerConfig: options.workerConfig,
+      chainId: resolvedInput.chainId,
+      depth: resolvedInput.depth,
     },
     recentStderr,
   );

--- a/packages/capabilities/src/orchestration/worker/subagent-worker.ts
+++ b/packages/capabilities/src/orchestration/worker/subagent-worker.ts
@@ -101,6 +101,8 @@ async function handleInit(message: WorkerInitMessage): Promise<void> {
       pollIntervalMs: message.workerConfig?.pollIntervalMs ?? DEFAULT_WORKER_CONFIG.pollIntervalMs,
       fakeExecution: message.workerConfig?.fakeExecution ?? DEFAULT_WORKER_CONFIG.fakeExecution,
     },
+    chainId: message.chainId,
+    depth: message.depth,
   };
   send({ type: "ready" });
   schedulePoll();
@@ -350,6 +352,8 @@ async function executeTurn(
   const result = await agent.invoke(formatInputs(inputs), {
     messages: currentState.history,
     ...(transformContext ? { transformContext } : {}),
+    ...(currentState.chainId !== undefined ? { chainId: currentState.chainId } : {}),
+    ...(currentState.depth !== undefined ? { depth: currentState.depth } : {}),
   });
 
   return {

--- a/packages/capabilities/src/orchestration/worker/worker-messages.ts
+++ b/packages/capabilities/src/orchestration/worker/worker-messages.ts
@@ -21,6 +21,10 @@ export interface WorkerInitMessage {
   // biome-ignore lint/suspicious/noExplicitAny: Worker state is serialized
   runtimeConfig: any;
   workerConfig?: WorkerConfigMessage;
+  /** Shared correlation ID for the request chain (root + all descendants). */
+  chainId?: string;
+  /** Sub-agent nesting depth within the multi-agent hierarchy. */
+  depth?: number;
 }
 
 /** Parent-to-worker message that asks the worker to process queued input. */

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -42,6 +42,12 @@ export interface CapabilityBuildContext {
   waitHandleRegistry?: WaitHandleRegistry;
   /** Forwarded to the sub-agent orchestration system. */
   onSubAgentEvent?: (event: object) => void;
+  /**
+   * Tracing context for the current request chain.
+   * `chainId` is the same string as the route-level `traceId`/`requestTraceId`.
+   * `depth` is 0 for the root agent, incremented by 1 for each sub-agent level.
+   */
+  tracing?: { chainId: string; depth: number };
 }
 
 /**

--- a/packages/core/src/agent/agent-impl.ts
+++ b/packages/core/src/agent/agent-impl.ts
@@ -48,6 +48,8 @@ interface InternalContext {
   transformContext?: TransformContextFn;
   reactiveCompaction?: ReactiveCompactionController;
   metadata?: Record<string, unknown>;
+  chainId?: string;
+  depth?: number;
 }
 
 // ============================================================================
@@ -167,6 +169,8 @@ export class AgentImpl implements Agent {
       signal: options?.signal,
       transformContext: options?.transformContext,
       reactiveCompaction: options?.reactiveCompaction,
+      chainId: options?.chainId,
+      depth: options?.depth,
     };
   }
 

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -13,9 +13,10 @@ import type {
   TransformContextFn,
 } from "@/types/agent.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
-import type { RuntimeEvent } from "@/types/result.types.js";
+import type { RuntimeEvent, RuntimeTracingFields } from "@/types/result.types.js";
 import type { RuntimeTool, ToolInterceptor } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
+import { randomUUID } from "node:crypto";
 
 // ============================================================================
 // ============================================================================
@@ -41,6 +42,10 @@ export interface InternalContext {
   signal?: AbortSignal;
   transformContext?: TransformContextFn;
   metadata?: Record<string, unknown>;
+  /** Correlation ID for the full request chain (root + all descendants). Auto-generated if absent. */
+  chainId?: string;
+  /** Nesting depth: 0 = root agent, +1 per orchestration level. */
+  depth?: number;
 }
 
 // ============================================================================
@@ -66,20 +71,23 @@ export function agentLoop(
   config: AgentLoopConfig,
 ): EventStream<RuntimeEvent, Message[]> {
   const stream = createAgentStream();
+  const chainId = context.chainId ?? randomUUID();
+  const depth = context.depth ?? 0;
+  const preLoopTracing: RuntimeTracingFields = { chainId, depth, turnIndex: 0 };
 
   (async () => {
     const newMessages: Message[] = [...prompts];
     const currentMessages: Message[] = [...context.messages, ...prompts];
 
-    stream.push({ type: "session.start" });
-    stream.push({ type: "turn.start" });
+    stream.push({ type: "session.start", ...preLoopTracing });
+    stream.push({ type: "turn.start", ...preLoopTracing });
 
     for (const prompt of prompts) {
-      stream.push({ type: "message.start", message: prompt });
-      stream.push({ type: "message.end", message: prompt });
+      stream.push({ type: "message.start", message: prompt, ...preLoopTracing });
+      stream.push({ type: "message.end", message: prompt, ...preLoopTracing });
     }
 
-    await runLoop(currentMessages, newMessages, prompts, config, context.signal, stream);
+    await runLoop(currentMessages, newMessages, prompts, config, context.signal, stream, chainId, depth);
   })();
 
   return stream;
@@ -99,15 +107,18 @@ export function agentLoopContinue(
   }
 
   const stream = createAgentStream();
+  const chainId = context.chainId ?? randomUUID();
+  const depth = context.depth ?? 0;
+  const preLoopTracing: RuntimeTracingFields = { chainId, depth, turnIndex: 0 };
 
   (async () => {
     const newMessages: Message[] = [];
     const currentMessages: Message[] = [...context.messages];
 
-    stream.push({ type: "session.start" });
-    stream.push({ type: "turn.start" });
+    stream.push({ type: "session.start", ...preLoopTracing });
+    stream.push({ type: "turn.start", ...preLoopTracing });
 
-    await runLoop(currentMessages, newMessages, [], config, context.signal, stream);
+    await runLoop(currentMessages, newMessages, [], config, context.signal, stream, chainId, depth);
   })();
 
   return stream;
@@ -130,6 +141,8 @@ async function runLoop(
   config: AgentLoopConfig,
   signal: AbortSignal | undefined,
   stream: EventStream<RuntimeEvent, Message[]>,
+  chainId: string,
+  depth: number,
 ): Promise<void> {
   let firstTurn = true;
   let turnCount = 0;
@@ -152,15 +165,19 @@ async function runLoop(
 
     while (hasMoreToolCalls || pendingMessages.length > 0) {
       if (!firstTurn) {
-        stream.push({ type: "turn.start" });
+        // turnIndex for this turn.start will be set after turnCount++ below
       } else {
         firstTurn = false;
       }
 
       if (pendingMessages.length > 0) {
+        // These steering messages belong to the upcoming turn; stamp with current
+        // turnCount (still pre-increment, so turnIndex = turnCount).  In practice
+        // these are emitted before the LLM call so turnCount hasn't advanced yet.
+        const steeringTracing: RuntimeTracingFields = { chainId, depth, turnIndex: turnCount };
         for (const message of pendingMessages) {
-          stream.push({ type: "message.start", message });
-          stream.push({ type: "message.end", message });
+          stream.push({ type: "message.start", message, ...steeringTracing });
+          stream.push({ type: "message.end", message, ...steeringTracing });
           currentMessages.push(message);
           newMessages.push(message);
         }
@@ -168,10 +185,17 @@ async function runLoop(
       }
 
       turnCount++;
+      const turnIndex = turnCount - 1; // 0-based
+      const tracing: RuntimeTracingFields = { chainId, depth, turnIndex };
+
+      // Emit turn.start for non-first turns (first turn.start was emitted pre-loop).
+      if (turnCount > 1) {
+        stream.push({ type: "turn.start", ...tracing });
+      }
 
       const isLastTurn = config.spec.maxTurns !== undefined && turnCount >= config.spec.maxTurns;
       if (isLastTurn) {
-        stream.push({ type: "max_turns_reached", turnCount });
+        stream.push({ type: "max_turns_reached", turnCount, ...tracing });
       }
 
       const assistantResult = await streamAssistantResponse(
@@ -179,6 +203,7 @@ async function runLoop(
         config,
         signal,
         stream,
+        tracing,
         config.spec.maxTurns !== undefined ? { turnCount, isLastTurn } : undefined,
       );
       const message = assistantResult.message;
@@ -188,6 +213,7 @@ async function runLoop(
           currentMessages,
           config.reactiveCompaction,
           stream,
+          tracing,
           {
             turnCount,
             latestMessage: message,
@@ -200,15 +226,15 @@ async function runLoop(
           currentMessages.splice(0, currentMessages.length, ...compactedMessages);
           continue;
         }
-        emitFinalAssistantMessage(currentMessages, stream, message);
+        emitFinalAssistantMessage(currentMessages, stream, tracing, message);
       }
 
       newMessages.push(message);
       totalUsage = accumulateUsage(totalUsage, message.usage);
 
       if (message.stopReason === "error" || message.stopReason === "aborted") {
-        stream.push({ type: "turn.complete", message, toolResults: [] });
-        stream.push({ type: "session.end", messages: newMessages, usage: totalUsage });
+        stream.push({ type: "turn.complete", message, toolResults: [], ...tracing });
+        stream.push({ type: "session.end", messages: newMessages, usage: totalUsage, ...tracing });
         stream.end(newMessages);
         return;
       }
@@ -223,6 +249,7 @@ async function runLoop(
           message,
           signal,
           stream,
+          tracing,
           config.getSteeringMessages,
           config.toolInterceptor,
         );
@@ -235,10 +262,10 @@ async function runLoop(
         }
       }
 
-      stream.push({ type: "turn.complete", message, toolResults });
+      stream.push({ type: "turn.complete", message, toolResults, ...tracing });
 
       const compactedMessages = config.reactiveCompaction
-        ? await maybeApplyReactiveCompaction(currentMessages, config.reactiveCompaction, stream, {
+        ? await maybeApplyReactiveCompaction(currentMessages, config.reactiveCompaction, stream, tracing, {
             turnCount,
             usage: message.usage,
             latestMessage: message,
@@ -275,7 +302,9 @@ async function runLoop(
     break;
   }
 
-  stream.push({ type: "session.end", messages: newMessages, usage: totalUsage });
+  // Compute the final tracing — turnCount at this point is the last completed turn.
+  const finalTracing: RuntimeTracingFields = { chainId, depth, turnIndex: Math.max(0, turnCount - 1) };
+  stream.push({ type: "session.end", messages: newMessages, usage: totalUsage, ...finalTracing });
   stream.end(newMessages);
 }
 
@@ -284,6 +313,7 @@ async function streamAssistantResponse(
   config: AgentLoopConfig,
   signal: AbortSignal | undefined,
   stream: EventStream<RuntimeEvent, Message[]>,
+  tracing: RuntimeTracingFields,
   turnContext?: { turnCount: number; isLastTurn: boolean },
 ): Promise<{ message: AssistantMessage; recoverablePromptTooLong: boolean }> {
   let transformedMessages = messages;
@@ -325,7 +355,7 @@ async function streamAssistantResponse(
         partialMessage = event.partial;
         messages.push(partialMessage);
         addedPartial = true;
-        stream.push({ type: "message.start", message: { ...partialMessage } });
+        stream.push({ type: "message.start", message: { ...partialMessage }, ...tracing });
         break;
 
       case "text_start":
@@ -344,6 +374,7 @@ async function streamAssistantResponse(
             type: "message.update",
             message: { ...partialMessage },
             event,
+            ...tracing,
           });
         }
         break;
@@ -366,9 +397,9 @@ async function streamAssistantResponse(
           messages.push(finalMessage);
         }
         if (!addedPartial) {
-          stream.push({ type: "message.start", message: { ...finalMessage } });
+          stream.push({ type: "message.start", message: { ...finalMessage }, ...tracing });
         }
-        stream.push({ type: "message.end", message: finalMessage });
+        stream.push({ type: "message.end", message: finalMessage, ...tracing });
         return { message: finalMessage, recoverablePromptTooLong: false };
       }
     }
@@ -381,6 +412,7 @@ async function maybeApplyReactiveCompaction(
   messages: Message[],
   controller: ReactiveCompactionController,
   stream: EventStream<RuntimeEvent, Message[]>,
+  tracing: RuntimeTracingFields,
   input: {
     turnCount: number;
     usage?: Usage;
@@ -411,6 +443,7 @@ async function maybeApplyReactiveCompaction(
     type: "compaction",
     messagesBefore: messages.length,
     messagesAfter: decision.messages.length,
+    ...tracing,
   });
   return decision.messages;
 }
@@ -418,11 +451,12 @@ async function maybeApplyReactiveCompaction(
 function emitFinalAssistantMessage(
   messages: Message[],
   stream: EventStream<RuntimeEvent, Message[]>,
+  tracing: RuntimeTracingFields,
   message: AssistantMessage,
 ): void {
   messages.push(message);
-  stream.push({ type: "message.start", message: { ...message } });
-  stream.push({ type: "message.end", message });
+  stream.push({ type: "message.start", message: { ...message }, ...tracing });
+  stream.push({ type: "message.end", message, ...tracing });
 }
 
 function accumulateUsage(total: Usage, current: Usage): Usage {

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -87,7 +87,16 @@ export function agentLoop(
       stream.push({ type: "message.end", message: prompt, ...preLoopTracing });
     }
 
-    await runLoop(currentMessages, newMessages, prompts, config, context.signal, stream, chainId, depth);
+    await runLoop(
+      currentMessages,
+      newMessages,
+      prompts,
+      config,
+      context.signal,
+      stream,
+      chainId,
+      depth,
+    );
   })();
 
   return stream;
@@ -265,14 +274,20 @@ async function runLoop(
       stream.push({ type: "turn.complete", message, toolResults, ...tracing });
 
       const compactedMessages = config.reactiveCompaction
-        ? await maybeApplyReactiveCompaction(currentMessages, config.reactiveCompaction, stream, tracing, {
-            turnCount,
-            usage: message.usage,
-            latestMessage: message,
-            protectedMessages,
-            records: compactionRecords,
-            trigger: "proactive",
-          })
+        ? await maybeApplyReactiveCompaction(
+            currentMessages,
+            config.reactiveCompaction,
+            stream,
+            tracing,
+            {
+              turnCount,
+              usage: message.usage,
+              latestMessage: message,
+              protectedMessages,
+              records: compactionRecords,
+              trigger: "proactive",
+            },
+          )
         : null;
       if (compactedMessages) {
         currentMessages.splice(0, currentMessages.length, ...compactedMessages);
@@ -303,7 +318,11 @@ async function runLoop(
   }
 
   // Compute the final tracing — turnCount at this point is the last completed turn.
-  const finalTracing: RuntimeTracingFields = { chainId, depth, turnIndex: Math.max(0, turnCount - 1) };
+  const finalTracing: RuntimeTracingFields = {
+    chainId,
+    depth,
+    turnIndex: Math.max(0, turnCount - 1),
+  };
   stream.push({ type: "session.end", messages: newMessages, usage: totalUsage, ...finalTracing });
   stream.end(newMessages);
 }

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -8,7 +8,7 @@ import { EventStream } from "@/llm/event-stream.js";
 import { validateToolArguments, validateToolInput } from "@/llm/utils/validation.js";
 import type { TextContent, ToolCall } from "@/types/content.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
-import type { RuntimeEvent } from "@/types/result.types.js";
+import type { RuntimeEvent, RuntimeTracingFields } from "@/types/result.types.js";
 import type {
   RuntimeTool,
   ToolInterceptor,
@@ -29,6 +29,7 @@ export async function executeToolCalls(
   assistantMessage: AssistantMessage,
   signal: AbortSignal | undefined,
   stream: EventStream<RuntimeEvent, Message[]>,
+  tracing: RuntimeTracingFields,
   getSteeringMessages?: () => Promise<Message[]>,
   toolInterceptor?: ToolInterceptor,
 ): Promise<ToolExecutionResult> {
@@ -49,6 +50,7 @@ export async function executeToolCalls(
         rawArgs,
         rawArgs,
         stream,
+        tracing,
         results,
       );
       continue;
@@ -73,6 +75,7 @@ export async function executeToolCalls(
         rawArgs,
         rawArgs,
         stream,
+        tracing,
         results,
       );
       continue;
@@ -96,7 +99,7 @@ export async function executeToolCalls(
       if (beforeResult.action === "deny") {
         // tool.before is emitted even for denied calls so stream consumers always
         // see a matching before/after pair.
-        rejectToolCall(toolCall, beforeResult.reason, rawArgs, rawArgs, stream, results);
+        rejectToolCall(toolCall, beforeResult.reason, rawArgs, rawArgs, stream, tracing, results);
         // onAfterToolCall is NOT called for denied executions.
         continue;
       }
@@ -124,6 +127,7 @@ export async function executeToolCalls(
             effectiveArgs,
             rawArgs,
             stream,
+            tracing,
             results,
           );
           // onAfterToolCall is NOT called for schema re-validation failures.
@@ -152,6 +156,7 @@ export async function executeToolCalls(
           effectiveArgs,
           rawArgs,
           stream,
+          tracing,
           results,
         );
         // onAfterToolCall is NOT called for validate() failures.
@@ -166,6 +171,7 @@ export async function executeToolCalls(
       toolName: toolCall.name,
       args: effectiveArgs,
       rawArgs,
+      ...tracing,
     });
 
     // ── Execute ───────────────────────────────────────────────────────────────
@@ -183,6 +189,7 @@ export async function executeToolCalls(
           options: event.options,
           multiple: event.multiple,
           custom: event.custom,
+          ...tracing,
         });
       }
     };
@@ -199,6 +206,7 @@ export async function executeToolCalls(
             toolCallId: toolCall.id,
             toolName: toolCall.name,
             partialResult,
+            ...tracing,
           });
         },
         onSignal,
@@ -221,6 +229,7 @@ export async function executeToolCalls(
       toolName: toolCall.name,
       result,
       isError,
+      ...tracing,
     });
 
     // ── After-hook (called for both success and execution errors, not for deny) ──
@@ -237,8 +246,8 @@ export async function executeToolCalls(
     // ── Finalise ──────────────────────────────────────────────────────────────
     const toolResultMessage = buildToolResultMessage(toolCall, result, isError);
     results.push(toolResultMessage);
-    stream.push({ type: "message.start", message: toolResultMessage });
-    stream.push({ type: "message.end", message: toolResultMessage });
+    stream.push({ type: "message.start", message: toolResultMessage, ...tracing });
+    stream.push({ type: "message.end", message: toolResultMessage, ...tracing });
 
     if (getSteeringMessages) {
       const steering = await getSteeringMessages();
@@ -246,7 +255,7 @@ export async function executeToolCalls(
         steeringMessages = steering;
         const remainingCalls = toolCalls.slice(index + 1);
         for (const skipped of remainingCalls) {
-          results.push(skipToolCall(skipped, stream));
+          results.push(skipToolCall(skipped, stream, tracing));
         }
         break;
       }
@@ -270,6 +279,7 @@ function rejectToolCall(
   args: unknown,
   rawArgs: unknown,
   stream: EventStream<RuntimeEvent, Message[]>,
+  tracing: RuntimeTracingFields,
   results: ToolResultMessage[],
 ): void {
   const errorResult: ToolResult = {
@@ -282,6 +292,7 @@ function rejectToolCall(
     toolName: toolCall.name,
     args,
     rawArgs,
+    ...tracing,
   });
   stream.push({
     type: "tool.after",
@@ -289,11 +300,12 @@ function rejectToolCall(
     toolName: toolCall.name,
     result: errorResult,
     isError: true,
+    ...tracing,
   });
   const msg = buildToolResultMessage(toolCall, errorResult, true);
   results.push(msg);
-  stream.push({ type: "message.start", message: msg });
-  stream.push({ type: "message.end", message: msg });
+  stream.push({ type: "message.start", message: msg, ...tracing });
+  stream.push({ type: "message.end", message: msg, ...tracing });
 }
 
 function buildToolResultMessage(
@@ -315,6 +327,7 @@ function buildToolResultMessage(
 function skipToolCall(
   toolCall: ToolCall,
   stream: EventStream<RuntimeEvent, Message[]>,
+  tracing: RuntimeTracingFields,
 ): ToolResultMessage {
   const result: ToolResult = {
     content: [{ type: "text", text: "Skipped due to queued user message." } as TextContent],
@@ -327,6 +340,7 @@ function skipToolCall(
     toolName: toolCall.name,
     args: toolCall.arguments,
     rawArgs: toolCall.arguments,
+    ...tracing,
   });
   stream.push({
     type: "tool.after",
@@ -334,11 +348,12 @@ function skipToolCall(
     toolName: toolCall.name,
     result,
     isError: true,
+    ...tracing,
   });
 
   const toolResultMessage = buildToolResultMessage(toolCall, result, true);
-  stream.push({ type: "message.start", message: toolResultMessage });
-  stream.push({ type: "message.end", message: toolResultMessage });
+  stream.push({ type: "message.start", message: toolResultMessage, ...tracing });
+  stream.push({ type: "message.end", message: toolResultMessage, ...tracing });
 
   return toolResultMessage;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,7 +139,7 @@ export {
   isLlmStreamTerminal,
   isRuntimeError,
 } from "@/types/result.types.js";
-export type { LlmStreamEvent, RuntimeEvent } from "@/types/result.types.js";
+export type { LlmStreamEvent, RuntimeEvent, RuntimeTracingFields } from "@/types/result.types.js";
 
 // ============================================================================
 // LLM client — low-level provider access

--- a/packages/core/src/types/agent.types.ts
+++ b/packages/core/src/types/agent.types.ts
@@ -97,6 +97,20 @@ export interface AgentRunOptions {
    * (see `buildToolInterceptor` in `@agentrail/app`).
    */
   readonly toolInterceptor?: ToolInterceptor;
+
+  /**
+   * Stable correlation ID for the entire request chain, shared by the root
+   * agent and all descendant sub-agents.  When absent, `agentLoop` generates a
+   * random UUID.  In the app layer this should be set to the route-level
+   * `traceId` so that `RuntimeEvent.chainId === telemetry traceId`.
+   */
+  readonly chainId?: string;
+
+  /**
+   * Nesting depth within a multi-agent hierarchy.  `0` for the root agent,
+   * incremented by 1 for each orchestration level.  Defaults to `0`.
+   */
+  readonly depth?: number;
 }
 
 // ============================================================================

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -87,6 +87,23 @@ export type LlmStreamEvent =
 // ============================================================================
 
 /**
+ * Tracing fields attached to every `RuntimeEvent`.
+ *
+ * - `chainId` — stable correlation ID for the entire request chain, shared by the
+ *   root agent and all descendant sub-agents.  In the app layer this is the same
+ *   string as the route-level `traceId` / `requestTraceId`.
+ * - `depth` — nesting level: `0` for the root agent, `1` for direct sub-agents, etc.
+ * - `turnIndex` — zero-based turn counter within the current agent's loop.
+ *   All events emitted before `runLoop()` starts (`session.start`, the initial
+ *   `turn.start`, and the initial prompt `message.*` events) carry `turnIndex = 0`.
+ */
+export interface RuntimeTracingFields {
+  readonly chainId: string;
+  readonly depth: number;
+  readonly turnIndex: number;
+}
+
+/**
  * Higher-level runtime events exposed by `agent.stream()`.
  *
  * Event types use a dotted namespace convention:
@@ -95,9 +112,11 @@ export type LlmStreamEvent =
  *   - `message.*`  — individual message lifecycle (including tool results)
  *   - `tool.*`     — tool execution lifecycle
  *
+ * All events carry `chainId`, `depth`, and `turnIndex` via `RuntimeTracingFields`.
+ *
  * @see {@link https://agentrail.run/concepts/events}
  */
-export type RuntimeEvent =
+export type RuntimeEvent = (
   // ── Session lifecycle ────────────────────────────────────────────────────
   /** Emitted once when the agent begins processing the user input. */
   | { readonly type: "session.start" }
@@ -185,7 +204,8 @@ export type RuntimeEvent =
   | { readonly type: "subagent.complete"; readonly childSessionId: string }
   // ── Error ────────────────────────────────────────────────────────────────
   /** Emitted when a runtime error terminates the agent stream. */
-  | { readonly type: "error"; readonly error: Error };
+  | { readonly type: "error"; readonly error: Error }
+) & RuntimeTracingFields;
 
 // ============================================================================
 // Deprecated aliases (remove in next major)

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -116,96 +116,101 @@ export interface RuntimeTracingFields {
  *
  * @see {@link https://agentrail.run/concepts/events}
  */
-export type RuntimeEvent = (
+export type RuntimeEvent =
   // ── Session lifecycle ────────────────────────────────────────────────────
   /** Emitted once when the agent begins processing the user input. */
-  | { readonly type: "session.start" }
-  /** Emitted once after all turns complete. Contains the full message list and token usage. */
-  | { readonly type: "session.end"; readonly messages: Message[]; readonly usage: Usage }
-  // ── Turn lifecycle ───────────────────────────────────────────────────────
-  /** Emitted at the start of each reasoning turn (LLM call). */
-  | { readonly type: "turn.start" }
-  /** Emitted after each turn completes, including the assistant message and any tool results. */
-  | {
-      readonly type: "turn.complete";
-      readonly message: AssistantMessage;
-      readonly toolResults: ToolResultMessage[];
-    }
-  // ── Message lifecycle ────────────────────────────────────────────────────
-  /** Emitted when a new message (user, assistant, or tool result) begins. */
-  | { readonly type: "message.start"; readonly message: Message }
-  /** Emitted for each incremental token update on an in-progress assistant message. */
-  | {
-      readonly type: "message.update";
-      readonly message: AssistantMessage;
-      readonly event: LlmStreamEvent;
-    }
-  /** Emitted once a message is fully assembled. */
-  | { readonly type: "message.end"; readonly message: Message }
-  // ── Tool execution ───────────────────────────────────────────────────────
-  /**
-   * Emitted just before a tool call is dispatched to the tool implementation.
-   *
-   * When a `ToolInterceptor` is active, this event is emitted **after** the
-   * `onBeforeToolCall` hook has run so that `args` always reflects the effective
-   * (potentially modified) input that will be passed to the tool.
-   *
-   * - `args`    — effective input (after any interceptor modifications).
-   * - `rawArgs` — original model-generated arguments, always equal to
-   *               `toolCall.arguments`.  Identical to `args` when no interceptor
-   *               modifies the input.
-   */
-  | {
-      readonly type: "tool.before";
-      readonly toolCallId: string;
-      readonly toolName: string;
-      /** Effective input passed to the tool (may differ from raw model arguments). */
-      readonly args: unknown;
-      /** Original model-generated arguments, preserved for audit and debugging. */
-      readonly rawArgs: unknown;
-    }
-  /** Emitted for each incremental update produced by a streaming tool. */
-  | {
-      readonly type: "tool.update";
-      readonly toolCallId: string;
-      readonly toolName: string;
-      readonly partialResult: ToolResult;
-    }
-  /** Emitted once a tool call completes (success or error). `isError` distinguishes the two. */
-  | {
-      readonly type: "tool.after";
-      readonly toolCallId: string;
-      readonly toolName: string;
-      readonly result: ToolResult;
-      readonly isError: boolean;
-    }
-  // ── Control flow ─────────────────────────────────────────────────────────
-  /** Emitted when the configured `maxTurns` limit is reached. */
-  | { readonly type: "max_turns_reached"; readonly turnCount: number }
-  /**
-   * Emitted when a tool requests human input. The host is expected to collect
-   * the response and resume execution.
-   */
-  | {
-      readonly type: "waiting_for_user_input";
-      readonly toolCallId: string;
-      readonly question: string;
-      readonly hint?: string;
-      readonly options?: string[];
-      readonly multiple?: boolean;
-      readonly custom?: boolean;
-    }
-  // ── New lifecycle events ─────────────────────────────────────────────────
-  /** Emitted when context compaction runs during a streaming request. */
-  | { readonly type: "compaction"; readonly messagesBefore: number; readonly messagesAfter: number }
-  /** Emitted when a sub-agent is spawned by a capability (e.g. a skill). */
-  | { readonly type: "subagent.spawn"; readonly childSessionId: string }
-  /** Emitted when a spawned sub-agent finishes. */
-  | { readonly type: "subagent.complete"; readonly childSessionId: string }
-  // ── Error ────────────────────────────────────────────────────────────────
-  /** Emitted when a runtime error terminates the agent stream. */
-  | { readonly type: "error"; readonly error: Error }
-) & RuntimeTracingFields;
+  (| { readonly type: "session.start" }
+    /** Emitted once after all turns complete. Contains the full message list and token usage. */
+    | { readonly type: "session.end"; readonly messages: Message[]; readonly usage: Usage }
+    // ── Turn lifecycle ───────────────────────────────────────────────────────
+    /** Emitted at the start of each reasoning turn (LLM call). */
+    | { readonly type: "turn.start" }
+    /** Emitted after each turn completes, including the assistant message and any tool results. */
+    | {
+        readonly type: "turn.complete";
+        readonly message: AssistantMessage;
+        readonly toolResults: ToolResultMessage[];
+      }
+    // ── Message lifecycle ────────────────────────────────────────────────────
+    /** Emitted when a new message (user, assistant, or tool result) begins. */
+    | { readonly type: "message.start"; readonly message: Message }
+    /** Emitted for each incremental token update on an in-progress assistant message. */
+    | {
+        readonly type: "message.update";
+        readonly message: AssistantMessage;
+        readonly event: LlmStreamEvent;
+      }
+    /** Emitted once a message is fully assembled. */
+    | { readonly type: "message.end"; readonly message: Message }
+    // ── Tool execution ───────────────────────────────────────────────────────
+    /**
+     * Emitted just before a tool call is dispatched to the tool implementation.
+     *
+     * When a `ToolInterceptor` is active, this event is emitted **after** the
+     * `onBeforeToolCall` hook has run so that `args` always reflects the effective
+     * (potentially modified) input that will be passed to the tool.
+     *
+     * - `args`    — effective input (after any interceptor modifications).
+     * - `rawArgs` — original model-generated arguments, always equal to
+     *               `toolCall.arguments`.  Identical to `args` when no interceptor
+     *               modifies the input.
+     */
+    | {
+        readonly type: "tool.before";
+        readonly toolCallId: string;
+        readonly toolName: string;
+        /** Effective input passed to the tool (may differ from raw model arguments). */
+        readonly args: unknown;
+        /** Original model-generated arguments, preserved for audit and debugging. */
+        readonly rawArgs: unknown;
+      }
+    /** Emitted for each incremental update produced by a streaming tool. */
+    | {
+        readonly type: "tool.update";
+        readonly toolCallId: string;
+        readonly toolName: string;
+        readonly partialResult: ToolResult;
+      }
+    /** Emitted once a tool call completes (success or error). `isError` distinguishes the two. */
+    | {
+        readonly type: "tool.after";
+        readonly toolCallId: string;
+        readonly toolName: string;
+        readonly result: ToolResult;
+        readonly isError: boolean;
+      }
+    // ── Control flow ─────────────────────────────────────────────────────────
+    /** Emitted when the configured `maxTurns` limit is reached. */
+    | { readonly type: "max_turns_reached"; readonly turnCount: number }
+    /**
+     * Emitted when a tool requests human input. The host is expected to collect
+     * the response and resume execution.
+     */
+    | {
+        readonly type: "waiting_for_user_input";
+        readonly toolCallId: string;
+        readonly question: string;
+        readonly hint?: string;
+        readonly options?: string[];
+        readonly multiple?: boolean;
+        readonly custom?: boolean;
+      }
+    // ── New lifecycle events ─────────────────────────────────────────────────
+    /** Emitted when context compaction runs during a streaming request. */
+    | {
+        readonly type: "compaction";
+        readonly messagesBefore: number;
+        readonly messagesAfter: number;
+      }
+    /** Emitted when a sub-agent is spawned by a capability (e.g. a skill). */
+    | { readonly type: "subagent.spawn"; readonly childSessionId: string }
+    /** Emitted when a spawned sub-agent finishes. */
+    | { readonly type: "subagent.complete"; readonly childSessionId: string }
+    // ── Error ────────────────────────────────────────────────────────────────
+    /** Emitted when a runtime error terminates the agent stream. */
+    | { readonly type: "error"; readonly error: Error }
+  ) &
+    RuntimeTracingFields;
 
 // ============================================================================
 // Deprecated aliases (remove in next major)

--- a/packages/core/test/agent-loop-tracing.test.ts
+++ b/packages/core/test/agent-loop-tracing.test.ts
@@ -15,9 +15,9 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { defineAgent } from "../src/agent/define-agent.js";
-import type { AgentLoopConfig, InternalContext, InternalSpec } from "../src/agent/agent-loop.js";
+import type { InternalContext, InternalSpec } from "../src/agent/agent-loop.js";
 import { agentLoop } from "../src/agent/agent-loop.js";
+import { defineAgent } from "../src/agent/define-agent.js";
 import type { LlmClient, LlmRequest, LlmStream } from "../src/interfaces/llm-client.js";
 import type { AssistantMessage } from "../src/types/message.types.js";
 import type { LlmStreamEvent, RuntimeEvent } from "../src/types/result.types.js";
@@ -158,9 +158,7 @@ describe("agent-loop – tracing fields", () => {
     // All events share the same auto-generated chainId
     expect(chainIds).toHaveLength(1);
     // Should look like a UUID
-    expect(chainIds[0]).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(chainIds[0]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 
   it("depth defaults to 0 when not provided", async () => {

--- a/packages/core/test/agent-loop-tracing.test.ts
+++ b/packages/core/test/agent-loop-tracing.test.ts
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+/**
+ * Tests for the chainId/depth/turnIndex tracing fields on RuntimeEvent.
+ *
+ * Covers:
+ *  - All pre-loop events carry turnIndex=0
+ *  - runLoop events carry correct turnIndex (0-based, equals turnCount-1)
+ *  - chainId from AgentRunOptions is propagated to all events
+ *  - depth from AgentRunOptions is propagated to all events
+ *  - When no chainId is supplied a UUID is auto-generated and consistent
+ */
+
+import { describe, expect, it } from "vitest";
+import { defineAgent } from "../src/agent/define-agent.js";
+import type { AgentLoopConfig, InternalContext, InternalSpec } from "../src/agent/agent-loop.js";
+import { agentLoop } from "../src/agent/agent-loop.js";
+import type { LlmClient, LlmRequest, LlmStream } from "../src/interfaces/llm-client.js";
+import type { AssistantMessage } from "../src/types/message.types.js";
+import type { LlmStreamEvent, RuntimeEvent } from "../src/types/result.types.js";
+import type { Usage } from "../src/types/usage.types.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ZERO_USAGE: Usage = {
+  inputTokens: 1,
+  outputTokens: 1,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  totalTokens: 2,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function makeAssistantMsg(text = "ok"): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason: "stop",
+    provider: "mock",
+    modelId: "mock",
+    usage: ZERO_USAGE,
+    timestamp: Date.now(),
+  } as unknown as AssistantMessage;
+}
+
+function makeLlmClient(msg: AssistantMessage): LlmClient {
+  return {
+    stream(_req: LlmRequest): LlmStream {
+      async function* events(): AsyncGenerator<LlmStreamEvent> {
+        yield { type: "done", reason: "stop", message: msg };
+      }
+      const gen = events();
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              return gen.next();
+            },
+            [Symbol.asyncIterator]() {
+              return this;
+            },
+          };
+        },
+        result: async () => msg,
+      };
+    },
+  };
+}
+
+function makeSpec(): InternalSpec {
+  return {
+    id: "test-agent",
+    name: "Test Agent",
+    systemPrompt: "you are helpful",
+    model: { provider: "mock", modelId: "mock-model" },
+  };
+}
+
+function makeContext(overrides?: Partial<InternalContext>): InternalContext {
+  return { conversationId: "test-conv", messages: [], ...overrides };
+}
+
+async function collectEvents(stream: AsyncIterable<RuntimeEvent>): Promise<RuntimeEvent[]> {
+  const events: RuntimeEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+const USER_MSG = { role: "user" as const, content: "hi", timestamp: 1 } as any;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("agent-loop – tracing fields", () => {
+  it("all events carry chainId, depth, and turnIndex", async () => {
+    const msg = makeAssistantMsg();
+    const stream = agentLoop([USER_MSG], makeContext({ chainId: "c1", depth: 2 }), {
+      spec: makeSpec(),
+      llmClient: makeLlmClient(msg),
+    });
+
+    const events = await collectEvents(stream);
+    expect(events.length).toBeGreaterThan(0);
+
+    for (const e of events) {
+      expect(e.chainId).toBe("c1");
+      expect(e.depth).toBe(2);
+      expect(typeof e.turnIndex).toBe("number");
+    }
+  });
+
+  it("session.start, initial turn.start and prompt message.* carry turnIndex=0", async () => {
+    const msg = makeAssistantMsg();
+    const stream = agentLoop([USER_MSG], makeContext({ chainId: "c1" }), {
+      spec: makeSpec(),
+      llmClient: makeLlmClient(msg),
+    });
+
+    const events = await collectEvents(stream);
+
+    const sessionStart = events.find((e) => e.type === "session.start");
+    const firstTurnStart = events.find((e) => e.type === "turn.start");
+    const promptMessageStart = events.find((e) => e.type === "message.start");
+
+    expect(sessionStart?.turnIndex).toBe(0);
+    expect(firstTurnStart?.turnIndex).toBe(0);
+    expect(promptMessageStart?.turnIndex).toBe(0);
+  });
+
+  it("events within the first runLoop turn carry turnIndex=0", async () => {
+    const msg = makeAssistantMsg();
+    const stream = agentLoop([USER_MSG], makeContext({ chainId: "c1" }), {
+      spec: makeSpec(),
+      llmClient: makeLlmClient(msg),
+    });
+
+    const events = await collectEvents(stream);
+
+    // All events in a single-turn run should have turnIndex=0
+    const uniqueIndices = [...new Set(events.map((e) => e.turnIndex))];
+    expect(uniqueIndices).toEqual([0]);
+  });
+
+  it("chainId defaults to a stable UUID when not provided", async () => {
+    const msg = makeAssistantMsg();
+    const stream = agentLoop([USER_MSG], makeContext(), {
+      spec: makeSpec(),
+      llmClient: makeLlmClient(msg),
+    });
+
+    const events = await collectEvents(stream);
+    const chainIds = [...new Set(events.map((e) => e.chainId))];
+
+    // All events share the same auto-generated chainId
+    expect(chainIds).toHaveLength(1);
+    // Should look like a UUID
+    expect(chainIds[0]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("depth defaults to 0 when not provided", async () => {
+    const msg = makeAssistantMsg();
+    const stream = agentLoop([USER_MSG], makeContext(), {
+      spec: makeSpec(),
+      llmClient: makeLlmClient(msg),
+    });
+
+    const events = await collectEvents(stream);
+    for (const e of events) {
+      expect(e.depth).toBe(0);
+    }
+  });
+
+  it("agent.invoke propagates chainId and depth from AgentRunOptions", async () => {
+    const agent = defineAgent({
+      id: "a",
+      name: "A",
+      model: "mock:m",
+      prompt: "p",
+      llmClient: makeLlmClient(makeAssistantMsg()),
+    });
+
+    const events: RuntimeEvent[] = [];
+    const stream = agent.stream("hi", { chainId: "route-trace-id", depth: 1 });
+    for await (const e of stream) {
+      events.push(e);
+    }
+
+    for (const e of events) {
+      expect(e.chainId).toBe("route-trace-id");
+      expect(e.depth).toBe(1);
+    }
+  });
+});

--- a/packages/core/test/tool-executor.test.ts
+++ b/packages/core/test/tool-executor.test.ts
@@ -8,12 +8,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { executeToolCalls } from "../src/executor/tool-executor.js";
 import { EventStream } from "../src/llm/event-stream.js";
 import type { AssistantMessage, Message } from "../src/types/message.types.js";
-import type { RuntimeEvent } from "../src/types/result.types.js";
+import type { RuntimeEvent, RuntimeTracingFields } from "../src/types/result.types.js";
 import type {
   RuntimeTool,
   ToolInterceptor,
   ToolValidationContext,
 } from "../src/types/tool.types.js";
+
+const TEST_TRACING: RuntimeTracingFields = { chainId: "test-chain-id", depth: 0, turnIndex: 0 };
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -100,7 +102,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "hello" } }]);
-    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<
       RuntimeEvent,
@@ -127,7 +129,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     const msg = makeAssistantMessage([
       { id: "c1", name: "echo", arguments: { value: "sensitive" } },
     ]);
-    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     const beforeEvent = collectedEvents.find((e) => e.type === "tool.before") as Extract<
       RuntimeEvent,
@@ -151,7 +153,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -166,7 +168,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
     expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
@@ -185,7 +187,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
     await expect(
-      executeToolCalls([tool], msg, undefined, stream, undefined, interceptor),
+      executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor),
     ).rejects.toThrow("interceptor boom");
 
     // tool.execute was NOT called because the before hook threw.
@@ -201,7 +203,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
     await expect(
-      executeToolCalls([tool], msg, undefined, stream, undefined, interceptor),
+      executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor),
     ).rejects.toThrow("after boom");
   });
 
@@ -213,7 +215,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(afterSpy).toHaveBeenCalledOnce();
     const ctx = afterSpy.mock.calls[0][0];
@@ -234,7 +236,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "ghost", arguments: {} }]);
-    const result = await executeToolCalls([], msg, undefined, stream, undefined, interceptor);
+    const result = await executeToolCalls([], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(result.toolResults[0].isError).toBe(true);
     expect(interceptor.onBeforeToolCall).not.toHaveBeenCalled();
@@ -267,7 +269,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     const msg = makeAssistantMessage([
       { id: "c1", name: "arr", arguments: ["a", "b"] as unknown as Record<string, unknown> },
     ]);
-    await executeToolCalls([arrayTool], msg, undefined, stream, undefined, interceptor);
+    await executeToolCalls([arrayTool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     // The interceptor should receive exactly what came out of validateToolArguments,
     // not an object-spread of an array.
@@ -278,7 +280,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
   it("no interceptor: behaves like original executor", async () => {
     const tool = makeTool("echo");
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, undefined);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, undefined);
 
     expect(tool.execute).toHaveBeenCalledOnce();
     expect(result.toolResults[0].isError).toBe(false);
@@ -301,7 +303,7 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "ok" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -335,7 +337,7 @@ describe("executeToolCalls — tool.validate()", () => {
     const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(validateFn).toHaveBeenCalledOnce();
     expect(tool.execute).toHaveBeenCalledOnce();
@@ -352,7 +354,7 @@ describe("executeToolCalls — tool.validate()", () => {
     const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -372,7 +374,7 @@ describe("executeToolCalls — tool.validate()", () => {
     const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -390,7 +392,7 @@ describe("executeToolCalls — tool.validate()", () => {
       .mockResolvedValue({ valid: false, reason: "blocked" });
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    await executeToolCalls([tool], msg, undefined, stream);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING);
 
     expect(collectedEvents.some((e) => e.type === "tool.before")).toBe(true);
     expect(collectedEvents.some((e) => e.type === "tool.after")).toBe(true);
@@ -406,7 +408,7 @@ describe("executeToolCalls — tool.validate()", () => {
     expect(tool.validate).toBeUndefined();
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream);
+    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING);
 
     expect(tool.execute).toHaveBeenCalledOnce();
     expect(result.toolResults[0].isError).toBe(false);
@@ -432,7 +434,7 @@ describe("executeToolCalls — tool.validate()", () => {
     const msg = makeAssistantMessage([
       { id: "c1", name: "echo", arguments: { value: "original" } },
     ]);
-    await executeToolCalls([tool], msg, undefined, stream, undefined, interceptor);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
 
     expect(receivedParams[0]).toEqual({ value: "MODIFIED" });
   });

--- a/packages/core/test/tool-executor.test.ts
+++ b/packages/core/test/tool-executor.test.ts
@@ -153,7 +153,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -236,7 +244,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "ghost", arguments: {} }]);
-    const result = await executeToolCalls([], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    const result = await executeToolCalls(
+      [],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     expect(result.toolResults[0].isError).toBe(true);
     expect(interceptor.onBeforeToolCall).not.toHaveBeenCalled();
@@ -269,7 +285,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
     const msg = makeAssistantMessage([
       { id: "c1", name: "arr", arguments: ["a", "b"] as unknown as Record<string, unknown> },
     ]);
-    await executeToolCalls([arrayTool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    await executeToolCalls(
+      [arrayTool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     // The interceptor should receive exactly what came out of validateToolArguments,
     // not an object-spread of an array.
@@ -280,7 +304,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
   it("no interceptor: behaves like original executor", async () => {
     const tool = makeTool("echo");
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, undefined);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      undefined,
+    );
 
     expect(tool.execute).toHaveBeenCalledOnce();
     expect(result.toolResults[0].isError).toBe(false);
@@ -303,7 +335,15 @@ describe("executeToolCalls — ToolInterceptor", () => {
     };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "ok" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -337,7 +377,15 @@ describe("executeToolCalls — tool.validate()", () => {
     const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     expect(validateFn).toHaveBeenCalledOnce();
     expect(tool.execute).toHaveBeenCalledOnce();
@@ -354,7 +402,15 @@ describe("executeToolCalls — tool.validate()", () => {
     const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();
@@ -374,7 +430,15 @@ describe("executeToolCalls — tool.validate()", () => {
     const interceptor: ToolInterceptor = { onAfterToolCall: afterSpy };
 
     const msg = makeAssistantMessage([{ id: "c1", name: "echo", arguments: { value: "x" } }]);
-    const result = await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      interceptor,
+    );
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(afterSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Closes #55.

Every `RuntimeEvent` now carries three required tracing fields that enable end-to-end trace correlation across multi-agent workflows:

- **`chainId`** — stable UUID shared by a root agent and all sub-agents it spawns; sourced from the route-level `traceId`/`requestTraceId` so it aligns with existing telemetry.
- **`depth`** — nesting level (`0` = root, `+1` per orchestration layer).
- **`turnIndex`** — 0-based turn counter within the current agent's loop.

### Propagation path

```
route traceId
  → AgentrailProfileContext.chainId
  → CapabilityBuildContext.tracing
  → AgentRunOptions { chainId, depth }
  → agentLoop / InternalContext
  → executeToolCalls (stamped on tool events)
  → spawn_agent tool → WorkerInitMessage → sub-agent worker
```

### Key implementation details

- `result.types.ts` — `RuntimeTracingFields` interface; `RuntimeEvent` intersected with it.
- `agent-loop.ts` — resolves / generates `chainId` at loop entry; stamps every pushed event; computes `turnIndex = turnCount - 1`.
- `tool-executor.ts` — accepts `tracingCtx` and stamps `tool.*` events.
- `orchestration/spawn-agent.ts` + `worker-messages.ts` — carry `chainId` / `depth` through to worker processes.
- `OrchestrationAgent` snapshot — persists `chainId` / `depth` so recovery paths restore tracing correctly.
- `stream-route.ts` error path — passes a sanitized error event (message string, not raw `Error` instance) to trace observers, preserving tracing fields and readable error messages.
- `orchestration-manager.ts` reattach path — prefers persisted `existingAgent.chainId/depth` over the caller's values to prevent tracing identity drift across requests.

## Test plan

- [x] `pnpm --filter @agentrail/core test` — new `agent-loop-tracing.test.ts` covers auto-generated chainId, inherited chainId, turnIndex progression, and depth defaults
- [x] `pnpm --filter @agentrail/capabilities test` — `subagent-tool-calls.test.ts` covers tracing propagation through spawn_agent
- [x] `pnpm --filter @agentrail/app test` — `stream-route-persistence.test.ts` covers trace observer receiving sanitized error events
- [x] `pnpm build:packages` — clean build across all packages
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm format` — formatting applied (committed as separate style commit)