### PR TITLE
feat(permissions): add tool permission policy system

### DIFF
--- a/.changeset/permission-policy-followup.md
+++ b/.changeset/permission-policy-followup.md
@@ -1,0 +1,14 @@
+---
+"@agentrail/capabilities": minor
+"@agentrail/app": minor
+---
+
+Fix and extend the tool permission policy system:
+
+- Add `"strict"` `PermissionMode`: deny-by-default mode where only operations listed in `allow` are permitted. Use for minimal-privilege configurations.
+- Add `contentMode: "path" | "command"` parameter to `matchPattern` and `evaluatePolicy`. Bash tools now pass `"command"` so that `*` wildcards match across `/` in command arguments (e.g. `git:add src/main.ts` matches `Bash(git:*)`).
+- Fix missing `?` in regex escape list — a literal `?` in a pattern no longer acts as an optional quantifier.
+- Fix cross-platform ancestor resolution in `path-safety.ts` using `path.dirname` loop instead of POSIX-specific `split`/`join`.
+- Fix `normalizeBashCommand` to handle tab and other whitespace between verb and arguments.
+- Export `ContentMatchMode` type from `@agentrail/capabilities`.
+- `AgentrailPermissionsConfig.mode` and `agentrail.yaml` now accept `"strict"` as a valid permissions mode.

--- a/.changeset/tool-permission-policy.md
+++ b/.changeset/tool-permission-policy.md
@@ -1,0 +1,48 @@
+---
+"@agentrail/core": minor
+"@agentrail/capabilities": minor
+"@agentrail/app": minor
+---
+
+Add tool permission policy system
+
+Introduces a structured, rule-based permission layer that sits between the LLM
+and tool execution, enabling fine-grained control over which operations agents
+are allowed to perform.
+
+### @agentrail/core
+
+- New `PermissionDecision` type (`"allow" | "deny" | "ask"` or object form with optional `reason`).
+- New optional `checkPermissions(params)` hook on `RuntimeTool` — called after
+  `onBeforeToolCall` interceptors but before `validate` and `execute`.
+- New `permission_request` `RuntimeEvent` — emitted when `checkPermissions` returns `"ask"`.
+- `ToolBuilder` gains a `.checkPermissions()` fluent method.
+- `permission_request` is added to `TRACE_PERSISTED_EVENT_TYPES`.
+
+### @agentrail/capabilities
+
+- New `packages/capabilities/src/permissions/` module:
+  - `ToolPermissionPolicy` / `PermissionRule` / `PermissionMode` types.
+  - `parseRule` / `parseRules` DSL parser (e.g. `"Bash(git:*)"`, `"Write(/workspace/**)"`)
+  - `evaluatePolicy` rule engine with priority order: deny → ask → allow → default.
+  - `isPathSafe` / `workspaceAnchor` path-safety utilities.
+  - `isDangerousCommand` / `isReadOnlyCommand` shell-safety utilities.
+- `CapabilityBuildContext` gains optional `permissionPolicy?: ToolPermissionPolicy`.
+- Non-sandboxed `bashTool`, `readTool`, `writeTool`, `editTool` are now created via
+  factory functions (`createBashTool`, `createReadTool`, `createWriteTool`, `createEditTool`)
+  that accept optional `rootDir` and `policy` options; the singleton exports are
+  kept for backward compatibility.
+- Sandboxed `createSandboxedBash` accepts an optional `policy` parameter.
+- All new symbols are exported from the package root.
+
+### @agentrail/app
+
+- `AgentrailProfileContext` gains optional `permissionPolicy?: ToolPermissionPolicy`.
+- `defineProfile` propagates `permissionPolicy` from profile context into
+  `CapabilityBuildContext`.
+- `createAgentApp`, `createStreamRoute`, and `createChatRoute` all accept an
+  optional `permissionPolicy` option that is forwarded to every request.
+- `AgentrailConfig` (YAML config) gains an optional `permissions` block with
+  `mode`, `allow`, `deny`, and `ask` keys.
+- `DefaultCapabilityToolOptions` gains optional `permissionPolicy` forwarded to
+  sandboxed tools.

--- a/docs/reference/create-agent-app.md
+++ b/docs/reference/create-agent-app.md
@@ -298,8 +298,8 @@ const app = createAgentApp({
   permissionPolicy: {
     mode: "strict",          // deny anything not explicitly allowed
     allow: parseRules([
-      "Bash(git:*)",         // permit all git commands
-      "Bash(npm:*)",         // permit all npm commands
+      "Bash(git:*)",         // prefix-match: any content starting with "git:"
+      "Bash(npm:*)",         // prefix-match: any content starting with "npm:"
       "Read",                // permit all file reads
     ]),
     deny: [],
@@ -307,6 +307,14 @@ const app = createAgentApp({
   },
 });
 ```
+
+> **Bash rule caveat:** Bash patterns are **prefix-anchored** (no trailing
+> `$`). `Bash(git:*)` matches any normalised command whose first word is
+> `git`, but it also matches shell strings that merely *start* with `git:`
+> — including chained forms like `git:status; curl evil.com`.  Bash rules
+> are useful for coarse-grained allow/deny (e.g. block all `rm` calls), but
+> they cannot provide strict command confinement.  For strong shell
+> isolation, run agents in the sandboxed environment.
 
 **Loading from `agentrail.yaml`:**
 

--- a/docs/reference/create-agent-app.md
+++ b/docs/reference/create-agent-app.md
@@ -275,8 +275,38 @@ const app = createAgentApp({
 ```
 
 The Bash DSL uses a `verb:args` form: `"git:*"` matches any command whose first word is `git`
-(e.g. `git status`, `git log`). The tool normalises `"git status"` → `"git:status"` before
-pattern matching so glob patterns work as expected.
+(e.g. `git status`, `git log --oneline`, `git add src/main.ts`). The tool normalises
+`"git status"` → `"git:status"` before pattern matching. The `*` wildcard in Bash patterns
+matches across `/` so path arguments in commands are matched correctly.
+
+**Permission modes:**
+
+| `mode` | Default outcome | Description |
+|--------|----------------|-------------|
+| `"default"` | `allow` | Opt-in deny/ask. Only rules explicitly listed in `deny`/`ask` block tool calls. |
+| `"strict"` | `deny` | Deny-by-default. Only operations listed in `allow` are permitted; everything else is blocked. Use for minimal-privilege configurations. |
+| `"acceptEdits"` | `allow` | Like `default`, but `ask` decisions for `Write`/`Edit` tools are auto-approved. |
+| `"dontAsk"` | `allow` | Like `default`, but `ask` decisions are demoted to `deny` (headless environments). |
+| `"bypassPermissions"` | `allow` | All checks skipped (trusted automation only). |
+
+**Strict (deny-by-default) allowlist example:**
+
+```ts
+import { parseRules } from "@agentrail/capabilities";
+
+const app = createAgentApp({
+  permissionPolicy: {
+    mode: "strict",          // deny anything not explicitly allowed
+    allow: parseRules([
+      "Bash(git:*)",         // permit all git commands
+      "Bash(npm:*)",         // permit all npm commands
+      "Read",                // permit all file reads
+    ]),
+    deny: [],
+    ask: [],
+  },
+});
+```
 
 **Loading from `agentrail.yaml`:**
 

--- a/docs/reference/create-agent-app.md
+++ b/docs/reference/create-agent-app.md
@@ -246,6 +246,37 @@ Health route configuration. By default `createAgentApp` mounts `GET /health` and
 
 ---
 
+### `permissionPolicy`
+
+```ts
+permissionPolicy?: ToolPermissionPolicy
+```
+
+Optional permission policy applied to all sessions served by this app.
+
+When set, tools evaluate the policy via their `checkPermissions` hook before executing.
+The policy is forwarded through `AgentrailProfileContext.permissionPolicy` →
+`CapabilityBuildContext.permissionPolicy` into each capability's tool set.
+
+```ts
+import { parseRules } from "@agentrail/capabilities";
+
+const app = createAgentApp({
+  dataDir: "./data",
+  profiles: [myProfile],
+  permissionPolicy: {
+    mode: "default",
+    allow: parseRules(["Bash(git:*)", "Bash(npm:*)"]),
+    deny: parseRules(["Bash(rm:*)"]),
+    ask: parseRules(["Write", "Edit"]),
+  },
+});
+```
+
+See the [Permissions Guide](/guides/tool-permissions) for the full DSL reference.
+
+---
+
 ### `telemetrySink`
 
 ```ts

--- a/docs/reference/create-agent-app.md
+++ b/docs/reference/create-agent-app.md
@@ -266,10 +266,33 @@ const app = createAgentApp({
   profiles: [myProfile],
   permissionPolicy: {
     mode: "default",
+    // Bash rules use "verb:args" DSL — "git:*" matches any git command
     allow: parseRules(["Bash(git:*)", "Bash(npm:*)"]),
     deny: parseRules(["Bash(rm:*)"]),
     ask: parseRules(["Write", "Edit"]),
   },
+});
+```
+
+The Bash DSL uses a `verb:args` form: `"git:*"` matches any command whose first word is `git`
+(e.g. `git status`, `git log`). The tool normalises `"git status"` → `"git:status"` before
+pattern matching so glob patterns work as expected.
+
+**Loading from `agentrail.yaml`:**
+
+When `config.permissions` is set, use `configPermissionsToPolicy` to convert the raw YAML config
+into a runtime `ToolPermissionPolicy`:
+
+```ts
+import { createAgentApp, loadAgentrailConfig, configPermissionsToPolicy } from "@agentrail/app";
+
+const config = loadAgentrailConfig();
+const app = createAgentApp({
+  dataDir: "./data",
+  profiles: [myProfile],
+  permissionPolicy: config.permissions
+    ? configPermissionsToPolicy(config.permissions)
+    : undefined,
 });
 ```
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -201,6 +201,7 @@ The most important ones for UI consumers:
 | `tool.before`               | A tool call is about to be dispatched (after any `onBeforeToolCall` plugin hooks have run) |
 | `tool.after`                | A tool invocation completes                                                                |
 | `waiting_for_user_input`    | The agent is paused waiting for user input                                                 |
+| `permission_request`        | A tool's `checkPermissions` returned `"ask"`; execution is blocked pending host approval   |
 | `skill_start` / `skill_end` | A skill sub-agent is invoked                                                               |
 
 ### Tracing fields on every RuntimeEvent
@@ -250,6 +251,25 @@ These fields are automatically stamped by `agentLoop` and propagated to sub-agen
 > or tracing integration that reads `tool.before.args` and relies on it being the
 > unmodified model output, switch to `rawArgs`. `args` now reflects the effective
 > (possibly plugin-modified) arguments that were actually executed.
+
+### `permission_request` field reference
+
+Emitted when a tool's `checkPermissions` hook returns `"ask"`. Execution is
+blocked until the host provides an interactive approval mechanism; in the current
+release, the tool call is always denied and the model receives an error result.
+
+```ts
+{
+  type: "permission_request";
+  toolCallId: string;
+  toolName: string;
+  /** Optional human-readable reason why approval is being requested. */
+  reason?: string;
+}
+```
+
+This event is persisted to the trace log (`TRACE_PERSISTED_EVENT_TYPES`) so that
+audit tooling can record which tool calls required permission.
 
 ---
 

--- a/docs/reference/profile-contract.md
+++ b/docs/reference/profile-contract.md
@@ -86,10 +86,10 @@ interface AgentrailProfileContext {
    * traceId. Sub-agent events inherit the same chainId with depth incremented. */
   chainId?: string;
   /**
-   * Active permission policy for this session.
-   * When present, non-sandboxed file/shell tools evaluate it via
-   * `checkPermissions` before executing. Propagated automatically by
-   * `defineProfile` into `CapabilityBuildContext.permissionPolicy`.
+   * Active permission policy for this session.  When present, all file and
+   * shell tools — both sandboxed (Bash, Read, Write, Edit) and non-sandboxed
+   * — evaluate it via `checkPermissions` before executing.  Propagated
+   * automatically by `defineProfile` into `CapabilityBuildContext.permissionPolicy`.
    */
   permissionPolicy?: ToolPermissionPolicy;
 }

--- a/docs/reference/profile-contract.md
+++ b/docs/reference/profile-contract.md
@@ -85,6 +85,13 @@ interface AgentrailProfileContext {
    * AgentRunOptions.chainId so that RuntimeEvent.chainId equals the route-level
    * traceId. Sub-agent events inherit the same chainId with depth incremented. */
   chainId?: string;
+  /**
+   * Active permission policy for this session.
+   * When present, non-sandboxed file/shell tools evaluate it via
+   * `checkPermissions` before executing. Propagated automatically by
+   * `defineProfile` into `CapabilityBuildContext.permissionPolicy`.
+   */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 interface AgentrailProfile {

--- a/examples/playground-server/src/routes/chat.ts
+++ b/examples/playground-server/src/routes/chat.ts
@@ -22,6 +22,7 @@ const chat = createChatRoute({
   plugins: playgroundPlugins,
   resolveProfile: resolvePlaygroundProfile,
   handleResolvedRequest: handlePlaygroundDeepResearchMode,
+  permissionPolicy: config.permissionPolicy,
 });
 
 export { chat };

--- a/examples/playground-server/src/routes/sessions.ts
+++ b/examples/playground-server/src/routes/sessions.ts
@@ -196,13 +196,32 @@ sessions.get("/:sessionId/compacted-messages", async (c) => {
 sessions.post("/:sessionId/respond", async (c) => {
   const { sessionId } = c.req.param();
 
-  let body: { answer?: unknown };
+  let body: { kind?: unknown; answer?: unknown; decision?: unknown };
   try {
-    body = await c.req.json<{ answer?: unknown }>();
+    body = await c.req.json<{ kind?: unknown; answer?: unknown; decision?: unknown }>();
   } catch {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
 
+  const pendingKind = waitHandleRegistry.getPendingKind(sessionId);
+
+  // ── Permission approval ────────────────────────────────────────────────────
+  if (body.kind === "permission" || pendingKind === "permission") {
+    const { decision } = body;
+    if (decision !== "approved" && decision !== "rejected") {
+      return c.json(
+        { error: "Field 'decision' must be \"approved\" or \"rejected\" for permission responses" },
+        400,
+      );
+    }
+    const resolved = waitHandleRegistry.respondPermission(sessionId, decision);
+    if (!resolved) {
+      return c.json({ error: `No pending permission request for session '${sessionId}'` }, 404);
+    }
+    return c.json({ ok: true });
+  }
+
+  // ── Question answer (AskUserQuestion tool) ─────────────────────────────────
   const { answer } = body;
   if (typeof answer !== "string" || answer.trim() === "") {
     return c.json({ error: "Field 'answer' is required and must be a non-empty string" }, 400);

--- a/examples/playground-server/src/routes/stream.ts
+++ b/examples/playground-server/src/routes/stream.ts
@@ -28,6 +28,7 @@ const stream = createStreamRoute({
   getOrchestrationManager: ({ tenantId, userId, sessionId, sessionRef }) =>
     orchestrationRegistry.getManager({ tenantId, userId, sessionId, sessionRef }),
   handleResolvedRequest: handlePlaygroundDeepResearchModeStream,
+  permissionPolicy: config.permissionPolicy,
   onTraceEvent: (ctx, envelope) => {
     const traceStore = createFileSystemSessionTraceStore<WorkflowTraceEventEnvelope>(
       config.dataDir,

--- a/examples/playground-server/src/routes/stream.ts
+++ b/examples/playground-server/src/routes/stream.ts
@@ -30,20 +30,18 @@ const stream = createStreamRoute({
     orchestrationRegistry.getManager({ tenantId, userId, sessionId, sessionRef }),
   handleResolvedRequest: handlePlaygroundDeepResearchModeStream,
   permissionPolicy: config.permissionPolicy,
-  createPermissionApprovalHandler: config.permissionPolicy
-    ? (sessionId) => ({
-        requestApproval({ toolCallId, toolName, reason, signal }) {
-          return Promise.race([
-            waitHandleRegistry.registerPermission(sessionId, toolCallId, toolName, reason),
-            new Promise<never>((_resolve, reject) => {
-              signal?.addEventListener("abort", () =>
-                reject(new Error("Request aborted while waiting for permission approval")),
-              );
-            }),
-          ]);
-        },
-      })
-    : undefined,
+  createPermissionApprovalHandler: (sessionId) => ({
+    requestApproval({ toolCallId, toolName, reason, signal }) {
+      return Promise.race([
+        waitHandleRegistry.registerPermission(sessionId, toolCallId, toolName, reason),
+        new Promise<never>((_resolve, reject) => {
+          signal?.addEventListener("abort", () =>
+            reject(new Error("Request aborted while waiting for permission approval")),
+          );
+        }),
+      ]);
+    },
+  }),
   onTraceEvent: (ctx, envelope) => {
     const traceStore = createFileSystemSessionTraceStore<WorkflowTraceEventEnvelope>(
       config.dataDir,

--- a/examples/playground-server/src/routes/stream.ts
+++ b/examples/playground-server/src/routes/stream.ts
@@ -10,6 +10,7 @@ import { config } from "@/config.js";
 import { orchestrationRegistry, sandboxManager, sessionManager } from "@/context/index.js";
 import { playgroundPlugins } from "@/plugins/index.js";
 import { resolvePlaygroundProfile } from "@/profiles/default-profile.js";
+import { waitHandleRegistry } from "@/wait-handle-registry.js";
 import type { WorkflowTraceEventEnvelope } from "@agentrail/app";
 import { createFileSystemSessionTraceStore } from "@agentrail/app";
 import { createStreamRoute } from "@agentrail/app/advanced";
@@ -29,6 +30,20 @@ const stream = createStreamRoute({
     orchestrationRegistry.getManager({ tenantId, userId, sessionId, sessionRef }),
   handleResolvedRequest: handlePlaygroundDeepResearchModeStream,
   permissionPolicy: config.permissionPolicy,
+  createPermissionApprovalHandler: config.permissionPolicy
+    ? (sessionId) => ({
+        requestApproval({ toolCallId, toolName, reason, signal }) {
+          return Promise.race([
+            waitHandleRegistry.registerPermission(sessionId, toolCallId, toolName, reason),
+            new Promise<never>((_resolve, reject) => {
+              signal?.addEventListener("abort", () =>
+                reject(new Error("Request aborted while waiting for permission approval")),
+              );
+            }),
+          ]);
+        },
+      })
+    : undefined,
   onTraceEvent: (ctx, envelope) => {
     const traceStore = createFileSystemSessionTraceStore<WorkflowTraceEventEnvelope>(
       config.dataDir,

--- a/examples/playground-server/src/wait-handle-registry.ts
+++ b/examples/playground-server/src/wait-handle-registry.ts
@@ -3,21 +3,37 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
-interface WaitHandle {
+interface QuestionHandle {
+  kind: "question";
   resolve: (answer: string) => void;
   reject: (err: Error) => void;
   question: string;
   registeredAt: number;
 }
 
+interface PermissionHandle {
+  kind: "permission";
+  resolve: (decision: "approved" | "rejected") => void;
+  reject: (err: Error) => void;
+  toolCallId: string;
+  toolName: string;
+  reason?: string;
+  registeredAt: number;
+}
+
+type WaitHandle = QuestionHandle | PermissionHandle;
+
 class WaitHandleRegistry {
   private readonly handles = new Map<string, WaitHandle>();
+
+  // ── Question handles (AskUserQuestion tool) ───────────────────────────────
 
   register(sessionId: string, question: string): Promise<string> {
     this.cancel(sessionId);
 
     return new Promise<string>((resolve, reject) => {
       this.handles.set(sessionId, {
+        kind: "question",
         resolve,
         reject,
         question,
@@ -26,13 +42,48 @@ class WaitHandleRegistry {
     });
   }
 
+  // ── Permission handles (interactive approval) ─────────────────────────────
+
+  registerPermission(
+    sessionId: string,
+    toolCallId: string,
+    toolName: string,
+    reason?: string,
+  ): Promise<"approved" | "rejected"> {
+    this.cancel(sessionId);
+
+    return new Promise<"approved" | "rejected">((resolve, reject) => {
+      this.handles.set(sessionId, {
+        kind: "permission",
+        resolve,
+        reject,
+        toolCallId,
+        toolName,
+        reason,
+        registeredAt: Date.now(),
+      });
+    });
+  }
+
+  // ── Respond ───────────────────────────────────────────────────────────────
+
   respond(sessionId: string, answer: string): boolean {
     const handle = this.handles.get(sessionId);
-    if (!handle) return false;
+    if (!handle || handle.kind !== "question") return false;
     this.handles.delete(sessionId);
     handle.resolve(answer);
     return true;
   }
+
+  respondPermission(sessionId: string, decision: "approved" | "rejected"): boolean {
+    const handle = this.handles.get(sessionId);
+    if (!handle || handle.kind !== "permission") return false;
+    this.handles.delete(sessionId);
+    handle.resolve(decision);
+    return true;
+  }
+
+  // ── Utilities ─────────────────────────────────────────────────────────────
 
   cancel(sessionId: string): void {
     const handle = this.handles.get(sessionId);
@@ -44,6 +95,10 @@ class WaitHandleRegistry {
 
   hasPending(sessionId: string): boolean {
     return this.handles.has(sessionId);
+  }
+
+  getPendingKind(sessionId: string): "question" | "permission" | null {
+    return this.handles.get(sessionId)?.kind ?? null;
   }
 }
 

--- a/examples/playground-ui/package.json
+++ b/examples/playground-ui/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "tsx": "^4.19.3",
     "vite": "^6.4.2"
   }
 }

--- a/examples/playground-ui/package.json
+++ b/examples/playground-ui/package.json
@@ -10,7 +10,8 @@
     "build": "vite build",
     "prepreview": "pnpm --filter @agentrail/config build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test \"test/*.test.ts\""
   },
   "dependencies": {
     "@agentrail/app": "workspace:*",

--- a/examples/playground-ui/src/App.tsx
+++ b/examples/playground-ui/src/App.tsx
@@ -538,6 +538,7 @@ export default function App() {
               setLiveSkillActivity(null);
             }
             pendingDirectSkillRef.current = null;
+            setPermissionBlocked(null);
             // Persist session metadata
             if (resolvedSessionId) {
               upsert({
@@ -575,7 +576,7 @@ export default function App() {
               reason?: string;
             };
             setPermissionBlocked({ toolName: pr.toolName, reason: pr.reason });
-          } else if (event.type === "turn.complete" || event.type === "session.end") {
+          } else if (event.type === "turn.complete") {
             setPermissionBlocked(null);
           } else if (event.type === "tool.after" || event.type === "tool_execution_end") {
             const tee = event as {

--- a/examples/playground-ui/src/App.tsx
+++ b/examples/playground-ui/src/App.tsx
@@ -97,6 +97,10 @@ export default function App() {
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [waitingQuestion, setWaitingQuestion] = useState<WaitingQuestionState | null>(null);
+  const [permissionBlocked, setPermissionBlocked] = useState<{
+    toolName: string;
+    reason?: string;
+  } | null>(null);
   const [questionInput, setQuestionInput] = useState("");
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [liveSkillActivity, setLiveSkillActivity] = useState<{
@@ -563,6 +567,16 @@ export default function App() {
             });
             setQuestionInput("");
             setSelectedOptions([]);
+          } else if (event.type === "permission_request") {
+            const pr = event as {
+              type: "permission_request";
+              toolCallId: string;
+              toolName: string;
+              reason?: string;
+            };
+            setPermissionBlocked({ toolName: pr.toolName, reason: pr.reason });
+          } else if (event.type === "turn.complete" || event.type === "session.end") {
+            setPermissionBlocked(null);
           } else if (event.type === "tool.after" || event.type === "tool_execution_end") {
             const tee = event as {
               type: string;
@@ -629,6 +643,7 @@ export default function App() {
         setLiveSkillActivity(null);
         setCompacting(false);
         setWaitingQuestion(null);
+        setPermissionBlocked(null);
         setQuestionInput("");
         setSelectedOptions([]);
         setBusy(false);
@@ -659,6 +674,7 @@ export default function App() {
     setContextUsage(null);
     setCompacting(false);
     setWaitingQuestion(null);
+    setPermissionBlocked(null);
     setQuestionInput("");
     setSelectedOptions([]);
     turnIndexRef.current = 0;
@@ -680,6 +696,7 @@ export default function App() {
       setBusy(false);
       setInput("");
       setWaitingQuestion(null);
+      setPermissionBlocked(null);
       setQuestionInput("");
       setSelectedOptions([]);
       clearTrace();
@@ -925,6 +942,22 @@ export default function App() {
         </main>
 
         {compacting && <CompactionBanner />}
+        {permissionBlocked && (
+          <div className="permission-blocked-banner">
+            <span className="permission-blocked-icon">🚫</span>
+            <span className="permission-blocked-text">
+              {`Permission denied — ${permissionBlocked.toolName} was blocked by policy`}
+              {permissionBlocked.reason ? `: ${permissionBlocked.reason}` : ""}
+            </span>
+            <button
+              className="permission-blocked-dismiss"
+              onClick={() => setPermissionBlocked(null)}
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+        )}
         <WaitingQuestionPrompt
           sessionId={currentSessionId}
           waitingQuestion={waitingQuestion}
@@ -971,3 +1004,4 @@ export default function App() {
     </div>
   );
 }
+

--- a/examples/playground-ui/src/App.tsx
+++ b/examples/playground-ui/src/App.tsx
@@ -9,6 +9,7 @@ import {
   fetchCompactedMessages,
   fetchSessionMessages,
   fetchSlashCommands,
+  respondToPermission,
   runCommand,
   streamChat,
   type CompactionMarker,
@@ -35,6 +36,7 @@ import {
   WaitingQuestionPrompt,
   type WaitingQuestionState,
 } from "./components/WaitingQuestionPrompt";
+import { PermissionApprovalPrompt } from "./components/PermissionApprovalPrompt";
 import { useAuth } from "./hooks/useAuth";
 import { useDeepResearchState } from "./hooks/useDeepResearchState";
 import { useIdentity } from "./hooks/useIdentity";
@@ -97,7 +99,8 @@ export default function App() {
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [waitingQuestion, setWaitingQuestion] = useState<WaitingQuestionState | null>(null);
-  const [permissionBlocked, setPermissionBlocked] = useState<{
+  const [pendingPermission, setPendingPermission] = useState<{
+    toolCallId: string;
     toolName: string;
     reason?: string;
   } | null>(null);
@@ -538,7 +541,7 @@ export default function App() {
               setLiveSkillActivity(null);
             }
             pendingDirectSkillRef.current = null;
-            setPermissionBlocked(null);
+            setPendingPermission(null);
             // Persist session metadata
             if (resolvedSessionId) {
               upsert({
@@ -575,9 +578,11 @@ export default function App() {
               toolName: string;
               reason?: string;
             };
-            setPermissionBlocked({ toolName: pr.toolName, reason: pr.reason });
+            setPendingPermission({ toolCallId: pr.toolCallId, toolName: pr.toolName, reason: pr.reason });
+          } else if (event.type === "permission_resolved") {
+            setPendingPermission(null);
           } else if (event.type === "turn.complete") {
-            setPermissionBlocked(null);
+            setPendingPermission(null);
           } else if (event.type === "tool.after" || event.type === "tool_execution_end") {
             const tee = event as {
               type: string;
@@ -644,7 +649,7 @@ export default function App() {
         setLiveSkillActivity(null);
         setCompacting(false);
         setWaitingQuestion(null);
-        setPermissionBlocked(null);
+        setPendingPermission(null);
         setQuestionInput("");
         setSelectedOptions([]);
         setBusy(false);
@@ -675,7 +680,7 @@ export default function App() {
     setContextUsage(null);
     setCompacting(false);
     setWaitingQuestion(null);
-    setPermissionBlocked(null);
+    setPendingPermission(null);
     setQuestionInput("");
     setSelectedOptions([]);
     turnIndexRef.current = 0;
@@ -697,7 +702,7 @@ export default function App() {
       setBusy(false);
       setInput("");
       setWaitingQuestion(null);
-      setPermissionBlocked(null);
+      setPendingPermission(null);
       setQuestionInput("");
       setSelectedOptions([]);
       clearTrace();
@@ -943,22 +948,11 @@ export default function App() {
         </main>
 
         {compacting && <CompactionBanner />}
-        {permissionBlocked && (
-          <div className="permission-blocked-banner">
-            <span className="permission-blocked-icon">🚫</span>
-            <span className="permission-blocked-text">
-              {`Permission denied — ${permissionBlocked.toolName} was blocked by policy`}
-              {permissionBlocked.reason ? `: ${permissionBlocked.reason}` : ""}
-            </span>
-            <button
-              className="permission-blocked-dismiss"
-              onClick={() => setPermissionBlocked(null)}
-              aria-label="Dismiss"
-            >
-              ×
-            </button>
-          </div>
-        )}
+        <PermissionApprovalPrompt
+          sessionId={currentSessionId}
+          pendingPermission={pendingPermission}
+          onDismiss={() => setPendingPermission(null)}
+        />
         <WaitingQuestionPrompt
           sessionId={currentSessionId}
           waitingQuestion={waitingQuestion}

--- a/examples/playground-ui/src/api.ts
+++ b/examples/playground-ui/src/api.ts
@@ -66,6 +66,12 @@ export type StreamEvent =
       custom?: boolean;
     }
   | { type: "permission_request"; toolCallId: string; toolName: string; reason?: string }
+  | {
+      type: "permission_resolved";
+      toolCallId: string;
+      toolName: string;
+      decision: "approved" | "rejected";
+    }
   | { type: "error"; error: { message: string } }
   | OrchestrationStreamEvent
   | DeepResearchStreamEvent
@@ -237,7 +243,23 @@ export async function respondToQuestion(sessionId: string, answer: string): Prom
   const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/respond`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
-    body: JSON.stringify({ answer }),
+    body: JSON.stringify({ kind: "question", answer }),
+  });
+  if (res.status === 401) {
+    dispatchUnauthorized();
+    return false;
+  }
+  return res.ok;
+}
+
+export async function respondToPermission(
+  sessionId: string,
+  decision: "approved" | "rejected",
+): Promise<boolean> {
+  const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/respond`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ kind: "permission", decision }),
   });
   if (res.status === 401) {
     dispatchUnauthorized();

--- a/examples/playground-ui/src/api.ts
+++ b/examples/playground-ui/src/api.ts
@@ -65,6 +65,7 @@ export type StreamEvent =
       multiple?: boolean;
       custom?: boolean;
     }
+  | { type: "permission_request"; toolCallId: string; toolName: string; reason?: string }
   | { type: "error"; error: { message: string } }
   | OrchestrationStreamEvent
   | DeepResearchStreamEvent

--- a/examples/playground-ui/src/components/PermissionApprovalPrompt.tsx
+++ b/examples/playground-ui/src/components/PermissionApprovalPrompt.tsx
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import { respondToPermission } from "../api";
+
+export interface PendingPermissionState {
+  toolCallId: string;
+  toolName: string;
+  reason?: string;
+}
+
+interface PermissionApprovalPromptProps {
+  sessionId: string | null;
+  pendingPermission: PendingPermissionState | null;
+  onDismiss: () => void;
+}
+
+export function PermissionApprovalPrompt({
+  sessionId,
+  pendingPermission,
+  onDismiss,
+}: PermissionApprovalPromptProps) {
+  if (!pendingPermission) return null;
+
+  const { toolName, reason } = pendingPermission;
+
+  const respond = async (decision: "approved" | "rejected") => {
+    if (!sessionId) return;
+    onDismiss();
+    await respondToPermission(sessionId, decision);
+  };
+
+  return (
+    <div className="permission-approval-bar">
+      <div className="permission-approval-content">
+        <span className="permission-approval-icon">🔐</span>
+        <div className="permission-approval-text">
+          <span className="permission-approval-label">Permission required</span>
+          <span className="permission-approval-tool">
+            Allow <strong>{toolName}</strong> to run?
+          </span>
+          {reason && <span className="permission-approval-reason">{reason}</span>}
+        </div>
+      </div>
+      <div className="permission-approval-actions">
+        <button
+          className="permission-approval-btn permission-approval-approve"
+          onClick={() => void respond("approved")}
+        >
+          Approve
+        </button>
+        <button
+          className="permission-approval-btn permission-approval-reject"
+          onClick={() => void respond("rejected")}
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/examples/playground-ui/src/components/PermissionApprovalPrompt.tsx
+++ b/examples/playground-ui/src/components/PermissionApprovalPrompt.tsx
@@ -3,6 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { useEffect, useState } from "react";
 import { respondToPermission } from "../api";
 
 export interface PendingPermissionState {
@@ -22,14 +23,30 @@ export function PermissionApprovalPrompt({
   pendingPermission,
   onDismiss,
 }: PermissionApprovalPromptProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset interaction state whenever a new permission request arrives.
+  useEffect(() => {
+    setSubmitting(false);
+    setError(null);
+  }, [pendingPermission?.toolCallId]);
+
   if (!pendingPermission) return null;
 
   const { toolName, reason } = pendingPermission;
 
   const respond = async (decision: "approved" | "rejected") => {
-    if (!sessionId) return;
-    onDismiss();
-    await respondToPermission(sessionId, decision);
+    if (!sessionId || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const ok = await respondToPermission(sessionId, decision);
+    if (ok) {
+      onDismiss();
+    } else {
+      setError("Failed to send decision — please try again.");
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -42,20 +59,23 @@ export function PermissionApprovalPrompt({
             Allow <strong>{toolName}</strong> to run?
           </span>
           {reason && <span className="permission-approval-reason">{reason}</span>}
+          {error && <span className="permission-approval-error">{error}</span>}
         </div>
       </div>
       <div className="permission-approval-actions">
         <button
           className="permission-approval-btn permission-approval-approve"
+          disabled={submitting}
           onClick={() => void respond("approved")}
         >
-          Approve
+          {submitting ? "…" : "Approve"}
         </button>
         <button
           className="permission-approval-btn permission-approval-reject"
+          disabled={submitting}
           onClick={() => void respond("rejected")}
         >
-          Reject
+          {submitting ? "…" : "Reject"}
         </button>
       </div>
     </div>

--- a/examples/playground-ui/src/components/TraceDAGView.tsx
+++ b/examples/playground-ui/src/components/TraceDAGView.tsx
@@ -817,6 +817,7 @@ function filterEnvelopes(
       return (
         type === "waiting_for_user_input" ||
         type === "permission_request" ||
+        type === "permission_resolved" ||
         type === "wait_registered" ||
         type === "wait_resolved"
       );

--- a/examples/playground-ui/src/components/TraceDAGView.tsx
+++ b/examples/playground-ui/src/components/TraceDAGView.tsx
@@ -815,7 +815,10 @@ function filterEnvelopes(
     if (filter === "orchestration") return e.source === "orchestration";
     if (filter === "waits")
       return (
-        type === "waiting_for_user_input" || type === "wait_registered" || type === "wait_resolved"
+        type === "waiting_for_user_input" ||
+        type === "permission_request" ||
+        type === "wait_registered" ||
+        type === "wait_resolved"
       );
     if (filter === "errors") return type === "error";
     return true;

--- a/examples/playground-ui/src/hooks/permissionBannerReducer.ts
+++ b/examples/playground-ui/src/hooks/permissionBannerReducer.ts
@@ -7,7 +7,12 @@ export type PermissionBlockedState = { toolName: string; reason?: string } | nul
 
 /**
  * Pure reducer for the `permissionBlocked` banner state.
- * Exported for unit testing; use `setPermissionBlocked` in component code.
+ * Exported for unit testing only; do not call from production code.
+ *
+ * In App.tsx the two clearing events are handled in separate if-else branches:
+ * - `session.end` is cleared inside the existing session.end handler
+ * - `turn.complete` is cleared in its own branch
+ * This reducer unifies them for test purposes.
  */
 export function applyPermissionEventForTest(
   state: PermissionBlockedState,

--- a/examples/playground-ui/src/hooks/permissionBannerReducer.ts
+++ b/examples/playground-ui/src/hooks/permissionBannerReducer.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+export type PermissionBlockedState = { toolName: string; reason?: string } | null;
+
+/**
+ * Pure reducer for the `permissionBlocked` banner state.
+ * Exported for unit testing; use `setPermissionBlocked` in component code.
+ */
+export function applyPermissionEventForTest(
+  state: PermissionBlockedState,
+  event: { type: string; toolName?: string; reason?: string },
+): PermissionBlockedState {
+  if (event.type === "permission_request") {
+    return { toolName: event.toolName ?? "", reason: event.reason };
+  }
+  if (event.type === "turn.complete" || event.type === "session.end") {
+    return null;
+  }
+  return state;
+}

--- a/examples/playground-ui/src/hooks/useWorkflowTrace.ts
+++ b/examples/playground-ui/src/hooks/useWorkflowTrace.ts
@@ -130,7 +130,8 @@ export function useWorkflowTrace(sessionId: string | null): UseWorkflowTraceResu
  * Mirrors TRACE_PERSISTED_EVENT_TYPES from @agentrail/events (defined locally
  * since playground-ui doesn't depend on that package).
  */
-const TRACE_EVENT_TYPES = new Set([
+/** Exported for unit tests only. */
+export const TRACE_EVENT_TYPES = new Set([
   "session.start",
   "session.end",
   "turn.start",
@@ -141,6 +142,7 @@ const TRACE_EVENT_TYPES = new Set([
   "skill_start",
   "skill_end",
   "waiting_for_user_input",
+  "permission_request",
   "context_compaction_start",
   "context_compaction_end",
   "error",

--- a/examples/playground-ui/src/hooks/useWorkflowTrace.ts
+++ b/examples/playground-ui/src/hooks/useWorkflowTrace.ts
@@ -143,6 +143,7 @@ export const TRACE_EVENT_TYPES = new Set([
   "skill_end",
   "waiting_for_user_input",
   "permission_request",
+  "permission_resolved",
   "context_compaction_start",
   "context_compaction_end",
   "error",

--- a/examples/playground-ui/src/index.css
+++ b/examples/playground-ui/src/index.css
@@ -3094,41 +3094,89 @@ body {
   background: rgba(255, 255, 255, 0.03);
 }
 
-/* ── Permission-blocked banner ────────────────────────────────────────── */
-.permission-blocked-banner {
-  padding: 8px 16px;
+/* ── Permission-approval prompt ───────────────────────────────────────── */
+.permission-approval-bar {
+  padding: 10px 16px;
   background: var(--surface);
   border-top: 1px solid var(--border);
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: var(--text-muted, #888);
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.permission-blocked-icon {
-  flex-shrink: 0;
-  font-size: 14px;
-}
-
-.permission-blocked-text {
+.permission-approval-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
   flex: 1;
-  color: var(--error, #e05252);
+  min-width: 0;
 }
 
-.permission-blocked-dismiss {
+.permission-approval-icon {
   flex-shrink: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
   font-size: 16px;
-  line-height: 1;
-  color: var(--text-muted, #888);
-  padding: 0 2px;
+  line-height: 1.4;
 }
 
-.permission-blocked-dismiss:hover {
+.permission-approval-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 13px;
+  min-width: 0;
+}
+
+.permission-approval-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+}
+
+.permission-approval-tool {
   color: var(--text, #ccc);
+}
+
+.permission-approval-reason {
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.permission-approval-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.permission-approval-btn {
+  padding: 5px 14px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: opacity 0.15s;
+}
+
+.permission-approval-btn:hover {
+  opacity: 0.85;
+}
+
+.permission-approval-approve {
+  background: var(--accent, #3b82f6);
+  color: #fff;
+  border-color: var(--accent, #3b82f6);
+}
+
+.permission-approval-reject {
+  background: transparent;
+  color: var(--text-muted, #888);
+  border-color: var(--border, #333);
 }
 
 /* ── Waiting-for-user-input question bar ──────────────────────────────── */

--- a/examples/playground-ui/src/index.css
+++ b/examples/playground-ui/src/index.css
@@ -3147,6 +3147,10 @@ body {
   text-overflow: ellipsis;
 }
 
+.permission-approval-error {
+  font-size: 12px;
+  color: var(--error, #e05252);
+}
 .permission-approval-actions {
   display: flex;
   gap: 8px;
@@ -3169,7 +3173,7 @@ body {
 
 .permission-approval-approve {
   background: var(--accent, #3b82f6);
-  color: #fff;
+  color: #000;
   border-color: var(--accent, #3b82f6);
 }
 

--- a/examples/playground-ui/src/index.css
+++ b/examples/playground-ui/src/index.css
@@ -3094,6 +3094,43 @@ body {
   background: rgba(255, 255, 255, 0.03);
 }
 
+/* ── Permission-blocked banner ────────────────────────────────────────── */
+.permission-blocked-banner {
+  padding: 8px 16px;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted, #888);
+}
+
+.permission-blocked-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+}
+
+.permission-blocked-text {
+  flex: 1;
+  color: var(--error, #e05252);
+}
+
+.permission-blocked-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--text-muted, #888);
+  padding: 0 2px;
+}
+
+.permission-blocked-dismiss:hover {
+  color: var(--text, #ccc);
+}
+
 /* ── Waiting-for-user-input question bar ──────────────────────────────── */
 .waiting-question-bar {
   padding: 10px 16px 10px;

--- a/examples/playground-ui/test/permissionBanner.test.ts
+++ b/examples/playground-ui/test/permissionBanner.test.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyPermissionEventForTest,
+  type PermissionBlockedState,
+} from "../src/hooks/permissionBannerReducer.js";
+
+test("permission_request sets permissionBlocked", () => {
+  const next = applyPermissionEventForTest(null, {
+    type: "permission_request",
+    toolName: "Bash",
+    reason: "denied by policy",
+  });
+  assert.deepStrictEqual(next, { toolName: "Bash", reason: "denied by policy" });
+});
+
+test("permission_request without reason sets permissionBlocked with no reason field", () => {
+  const next = applyPermissionEventForTest(null, {
+    type: "permission_request",
+    toolName: "Write",
+  });
+  assert.deepStrictEqual(next, { toolName: "Write", reason: undefined });
+});
+
+test("turn.complete clears permissionBlocked", () => {
+  const initial: PermissionBlockedState = { toolName: "Bash", reason: "denied" };
+  const next = applyPermissionEventForTest(initial, { type: "turn.complete" });
+  assert.strictEqual(next, null);
+});
+
+test("session.end clears permissionBlocked", () => {
+  const initial: PermissionBlockedState = { toolName: "Bash" };
+  const next = applyPermissionEventForTest(initial, { type: "session.end" });
+  assert.strictEqual(next, null);
+});
+
+test("unrelated events leave permissionBlocked unchanged", () => {
+  const initial: PermissionBlockedState = { toolName: "Bash" };
+  const next = applyPermissionEventForTest(initial, { type: "tool.before" });
+  assert.strictEqual(next, initial);
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:sandbox": "docker build -t agentrail-sandbox:latest docker/sandbox",
     "changeset": "node ./scripts/create-changeset.mjs",
     "changeset:cli": "changeset",
-    "test": "pnpm -r --filter \"./packages/**\" test",
+    "test": "pnpm -r --filter \"./packages/**\" test && pnpm -r --filter \"./examples/**\" --if-present test",
     "typecheck": "pnpm -r --filter \"./packages/**\" typecheck && pnpm -r --filter \"./examples/**\" typecheck",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/app/src/app/create-agent-app.ts
+++ b/packages/app/src/app/create-agent-app.ts
@@ -18,7 +18,7 @@ import { createChatRoute } from "@/routes/chat-route.js";
 import { createStreamRoute } from "@/routes/stream-route.js";
 import { SessionManager } from "@/session/session-manager.js";
 import type { TelemetrySink } from "@/telemetry/sink.js";
-import type { SandboxManager } from "@agentrail/capabilities";
+import type { SandboxManager, ToolPermissionPolicy } from "@agentrail/capabilities";
 import type { AgentrailSessionStore, Message, SessionRef } from "@agentrail/core";
 import { Hono } from "hono";
 
@@ -168,6 +168,17 @@ export interface CreateAgentAppOptions {
    * @see {@link https://agentrail.run/reference/telemetry-sink}
    */
   telemetrySink?: TelemetrySink;
+  /**
+   * Optional permission policy applied to all sessions served by this app.
+   *
+   * When set, tools evaluate the policy via their `checkPermissions` hook
+   * before executing.  The policy is forwarded through the `profileCtx` into
+   * `CapabilityBuildContext.permissionPolicy`.
+   *
+   * Individual routes (`createStreamRoute`, `createChatRoute`) expose the same
+   * option when using the lower-level primitives directly.
+   */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /**
@@ -230,6 +241,7 @@ export function createAgentApp(options: CreateAgentAppOptions): Hono {
     telemetrySink,
     health: healthOptions,
     inspector: inspectorOptions,
+    permissionPolicy,
   } = options;
 
   /**
@@ -332,6 +344,7 @@ export function createAgentApp(options: CreateAgentAppOptions): Hono {
     ...(onPluginError ? { onPluginError } : {}),
     ...(makeSinkTraceHandler ? { onTraceEvent: makeSinkTraceHandler } : {}),
     ...(onRequestEnd ? { onRequestEnd } : {}),
+    ...(permissionPolicy ? { permissionPolicy } : {}),
   };
 
   // ── Capability compatibility checks ───────────────────────────────────────

--- a/packages/app/src/config/index.ts
+++ b/packages/app/src/config/index.ts
@@ -21,6 +21,21 @@ export const DEFAULT_SANDBOX_IMAGE = "ghcr.io/yai-dev/agentrail-sandbox:latest";
 
 type UnknownRecord = Record<string, unknown>;
 
+/** Raw permissions block from `agentrail.yaml`. */
+export interface AgentrailPermissionsConfig {
+  /**
+   * Permission mode controlling how `ask` decisions are handled.
+   * Defaults to `"default"` when absent.
+   */
+  mode?: "default" | "acceptEdits" | "bypassPermissions" | "dontAsk";
+  /** Rule strings that unconditionally allow matching tool calls, e.g. `"Bash(git:*)"`. */
+  allow?: string[];
+  /** Rule strings that unconditionally deny matching tool calls, e.g. `"Bash(rm:*)"`. */
+  deny?: string[];
+  /** Rule strings that require user confirmation, e.g. `"Write"`. */
+  ask?: string[];
+}
+
 /** Full validated YAML config schema used by Agentrail apps and examples. */
 export interface AgentrailConfig {
   version: 1;
@@ -92,6 +107,8 @@ export interface AgentrailConfig {
       backendPort: number;
     };
   };
+  /** Optional permission policy applied to all sessions served by this app. */
+  permissions?: AgentrailPermissionsConfig;
 }
 
 /** Options for resolving the Agentrail config path. */
@@ -305,6 +322,20 @@ function getInteger(
   return raw;
 }
 
+function getStringArray(parent: UnknownRecord, key: string, parts: string[]): string[] {
+  const raw = parent[key];
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    throw new Error(`Expected ${formatConfigPath([...parts, key])} to be an array.`);
+  }
+  return raw.map((item, i) => {
+    if (typeof item !== "string") {
+      throw new Error(`Expected ${formatConfigPath([...parts, key, String(i)])} to be a string.`);
+    }
+    return item;
+  });
+}
+
 function getVersion(parent: UnknownRecord): 1 {
   const raw = parent.version;
   if (raw === undefined) return AGENTRAIL_CONFIG_VERSION;
@@ -365,7 +396,17 @@ export function parseAgentrailConfig(raw: unknown): AgentrailConfig {
   const root = assertObject(raw, []);
   assertNoUnknownKeys(
     root,
-    ["version", "llm", "search", "paths", "auth", "sandbox", "orchestration", "apps"],
+    [
+      "version",
+      "llm",
+      "search",
+      "paths",
+      "auth",
+      "sandbox",
+      "orchestration",
+      "apps",
+      "permissions",
+    ],
     [],
   );
 
@@ -750,6 +791,35 @@ export function parseAgentrailConfig(raw: unknown): AgentrailConfig {
         ),
       },
     },
+    permissions: parsePermissionsBlock(root),
+  };
+}
+
+function parsePermissionsBlock(root: UnknownRecord): AgentrailPermissionsConfig | undefined {
+  const raw = root["permissions"];
+  if (raw === undefined) return undefined;
+  const perm = assertObject(raw, ["permissions"]);
+  assertNoUnknownKeys(perm, ["mode", "allow", "deny", "ask"], ["permissions"]);
+
+  const VALID_MODES = ["default", "acceptEdits", "bypassPermissions", "dontAsk"] as const;
+  type PermMode = (typeof VALID_MODES)[number];
+
+  let mode: PermMode | undefined;
+  const rawMode = perm["mode"];
+  if (rawMode !== undefined) {
+    if (typeof rawMode !== "string" || !(VALID_MODES as readonly string[]).includes(rawMode)) {
+      throw new Error(
+        `Invalid permissions.mode "${rawMode}". Must be one of: ${VALID_MODES.join(", ")}.`,
+      );
+    }
+    mode = rawMode as PermMode;
+  }
+
+  return {
+    mode,
+    allow: getStringArray(perm, "allow", ["permissions"]),
+    deny: getStringArray(perm, "deny", ["permissions"]),
+    ask: getStringArray(perm, "ask", ["permissions"]),
   };
 }
 

--- a/packages/app/src/config/index.ts
+++ b/packages/app/src/config/index.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import { parseRules } from "@agentrail/capabilities";
+import type { ToolPermissionPolicy } from "@agentrail/capabilities";
 import { existsSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -34,6 +36,36 @@ export interface AgentrailPermissionsConfig {
   deny?: string[];
   /** Rule strings that require user confirmation, e.g. `"Write"`. */
   ask?: string[];
+}
+
+/**
+ * Converts a raw `AgentrailPermissionsConfig` (string arrays from YAML) into
+ * the fully-typed `ToolPermissionPolicy` expected by the runtime.
+ *
+ * Call this once after loading the config and pass the result to
+ * `createAgentApp({ permissionPolicy })`.
+ *
+ * @throws {Error} if any rule string fails to parse (propagated from `parseRules`).
+ *
+ * @example
+ * ```ts
+ * const config = loadAgentrailConfig();
+ * const app = createAgentApp({
+ *   permissionPolicy: config.permissions
+ *     ? configPermissionsToPolicy(config.permissions)
+ *     : undefined,
+ * });
+ * ```
+ */
+export function configPermissionsToPolicy(
+  cfg: AgentrailPermissionsConfig,
+): ToolPermissionPolicy {
+  return {
+    mode: cfg.mode ?? "default",
+    allow: parseRules(cfg.allow ?? []),
+    deny: parseRules(cfg.deny ?? []),
+    ask: parseRules(cfg.ask ?? []),
+  };
 }
 
 /** Full validated YAML config schema used by Agentrail apps and examples. */

--- a/packages/app/src/config/index.ts
+++ b/packages/app/src/config/index.ts
@@ -188,6 +188,7 @@ export interface PlaygroundServerConfig extends SharedResolvedAppConfig {
   userMemory: AgentrailConfig["apps"]["playgroundServer"]["userMemory"];
   userPreferenceSummary: AgentrailConfig["apps"]["playgroundServer"]["userPreferenceSummary"];
   skillDelegateToSubAgent: boolean;
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /** Resolved config consumed by the deep research example app. */
@@ -915,6 +916,7 @@ export function getPlaygroundServerConfig(
     userMemory: config.apps.playgroundServer.userMemory,
     userPreferenceSummary: config.apps.playgroundServer.userPreferenceSummary,
     skillDelegateToSubAgent: config.apps.playgroundServer.skills.delegateToSubAgent,
+    permissionPolicy: config.permissions ? configPermissionsToPolicy(config.permissions) : undefined,
   };
 }
 

--- a/packages/app/src/config/index.ts
+++ b/packages/app/src/config/index.ts
@@ -29,7 +29,7 @@ export interface AgentrailPermissionsConfig {
    * Permission mode controlling how `ask` decisions are handled.
    * Defaults to `"default"` when absent.
    */
-  mode?: "default" | "acceptEdits" | "bypassPermissions" | "dontAsk";
+  mode?: "default" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "strict";
   /** Rule strings that unconditionally allow matching tool calls, e.g. `"Bash(git:*)"`. */
   allow?: string[];
   /** Rule strings that unconditionally deny matching tool calls, e.g. `"Bash(rm:*)"`. */
@@ -833,7 +833,7 @@ function parsePermissionsBlock(root: UnknownRecord): AgentrailPermissionsConfig 
   const perm = assertObject(raw, ["permissions"]);
   assertNoUnknownKeys(perm, ["mode", "allow", "deny", "ask"], ["permissions"]);
 
-  const VALID_MODES = ["default", "acceptEdits", "bypassPermissions", "dontAsk"] as const;
+  const VALID_MODES = ["default", "acceptEdits", "bypassPermissions", "dontAsk", "strict"] as const;
   type PermMode = (typeof VALID_MODES)[number];
 
   let mode: PermMode | undefined;

--- a/packages/app/src/events/index.ts
+++ b/packages/app/src/events/index.ts
@@ -155,6 +155,7 @@ export const TRACE_PERSISTED_EVENT_TYPES = new Set([
   "skill_start",
   "skill_end",
   "waiting_for_user_input",
+  "permission_request",
   "context_compaction_start",
   "context_compaction_end",
   "error",

--- a/packages/app/src/host/defaults/capability-tools.ts
+++ b/packages/app/src/host/defaults/capability-tools.ts
@@ -70,6 +70,7 @@ export async function buildDefaultCapabilityTools(
     skillManager,
     onSubAgentEvent,
     containerSkillsDir = "/skills",
+    permissionPolicy,
   } = options;
 
   const todoStorage = sessionStore.createTodoStorage?.(sessionRef);
@@ -84,7 +85,7 @@ export async function buildDefaultCapabilityTools(
   ];
 
   const sandboxFileTools = [
-    createSandboxedBash(sandboxManager, sessionId, tenantId, userId),
+    createSandboxedBash(sandboxManager, sessionId, tenantId, userId, permissionPolicy),
     createSandboxedRead(sandboxManager, sessionId, tenantId, userId),
     createSandboxedWrite(sandboxManager, sessionId, tenantId, userId),
     createSandboxedEdit(sandboxManager, sessionId, tenantId, userId),

--- a/packages/app/src/host/defaults/capability-tools.ts
+++ b/packages/app/src/host/defaults/capability-tools.ts
@@ -86,9 +86,9 @@ export async function buildDefaultCapabilityTools(
 
   const sandboxFileTools = [
     createSandboxedBash(sandboxManager, sessionId, tenantId, userId, permissionPolicy),
-    createSandboxedRead(sandboxManager, sessionId, tenantId, userId),
-    createSandboxedWrite(sandboxManager, sessionId, tenantId, userId),
-    createSandboxedEdit(sandboxManager, sessionId, tenantId, userId),
+    createSandboxedRead(sandboxManager, sessionId, tenantId, userId, permissionPolicy),
+    createSandboxedWrite(sandboxManager, sessionId, tenantId, userId, permissionPolicy),
+    createSandboxedEdit(sandboxManager, sessionId, tenantId, userId, permissionPolicy),
     createSandboxedGlob(sandboxManager, sessionId, tenantId, userId),
     createSandboxedGrep(sandboxManager, sessionId, tenantId, userId),
   ];

--- a/packages/app/src/host/defaults/shared-types.ts
+++ b/packages/app/src/host/defaults/shared-types.ts
@@ -17,6 +17,7 @@ import type {
   SandboxManager,
   SkillManager,
   SkillMeta,
+  ToolPermissionPolicy,
   WaitHandleRegistry,
 } from "@agentrail/capabilities";
 import type {
@@ -134,6 +135,8 @@ export interface DefaultCapabilityToolOptions {
   skillManager?: SkillManager;
   onSubAgentEvent?: (event: ExtendedSseEvent) => void;
   containerSkillsDir?: string;
+  /** Active permission policy forwarded to sandboxed Bash and other tools. */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /** Factory that creates a synthetic user message for contextual system hints. */

--- a/packages/app/src/host/defaults/shared-types.ts
+++ b/packages/app/src/host/defaults/shared-types.ts
@@ -135,7 +135,7 @@ export interface DefaultCapabilityToolOptions {
   skillManager?: SkillManager;
   onSubAgentEvent?: (event: ExtendedSseEvent) => void;
   containerSkillsDir?: string;
-  /** Active permission policy forwarded to sandboxed Bash and other tools. */
+  /** Active permission policy forwarded to all sandboxed file/shell tools and non-sandboxed tools. */
   permissionPolicy?: ToolPermissionPolicy;
 }
 

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -78,9 +78,9 @@ export interface AgentrailProfileContext {
    */
   chainId?: string;
   /**
-   * Active permission policy for this session.  When present, non-sandboxed
-   * file and shell tools evaluate it via `checkPermissions` before executing.
-   * Sandboxed Bash also honours command-level allow/deny/ask rules.
+   * Active permission policy for this session.  When present, all file and
+   * shell tools — both sandboxed (Bash, Read, Write, Edit) and non-sandboxed
+   * — evaluate it via `checkPermissions` before executing.
    */
   permissionPolicy?: ToolPermissionPolicy;
 }

--- a/packages/app/src/host/types.ts
+++ b/packages/app/src/host/types.ts
@@ -6,6 +6,7 @@
 // Import for local use within this file AND re-export so that consumers can
 // import from either @agentrail/app or @agentrail/core without getting
 // structurally-incompatible types.
+import type { ToolPermissionPolicy } from "@agentrail/capabilities";
 import type {
   Agent,
   AgentrailSessionStore,
@@ -76,6 +77,12 @@ export interface AgentrailProfileContext {
    * route-level `traceId`/`requestTraceId`.
    */
   chainId?: string;
+  /**
+   * Active permission policy for this session.  When present, non-sandboxed
+   * file and shell tools evaluate it via `checkPermissions` before executing.
+   * Sandboxed Bash also honours command-level allow/deny/ask rules.
+   */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /**

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -115,11 +115,12 @@ export {
   getDeepResearchConfig,
   getPlaygroundServerConfig,
   getPlaygroundUiConfig,
+  configPermissionsToPolicy,
   loadAgentrailConfig,
   parseAgentrailConfig,
   resolveAgentrailConfigPath,
 } from "@/config/index.js";
-export type { AgentrailConfig } from "@/config/index.js";
+export type { AgentrailConfig, AgentrailPermissionsConfig } from "@/config/index.js";
 
 // ============================================================================
 // Slash commands

--- a/packages/app/src/profile/define-profile.ts
+++ b/packages/app/src/profile/define-profile.ts
@@ -116,6 +116,7 @@ function buildBaseCapCtx(
     modelConfig,
     onSubAgentEvent,
     tracing: context.chainId ? { chainId: context.chainId, depth: 0 } : undefined,
+    permissionPolicy: context.permissionPolicy,
   };
 }
 

--- a/packages/app/src/routes/chat-route.ts
+++ b/packages/app/src/routes/chat-route.ts
@@ -35,6 +35,7 @@ import {
   validateChatRequest,
 } from "@/routes/chat-route-internals.js";
 import { runCompactionStep } from "@/routes/compaction-runner.js";
+import type { ToolPermissionPolicy } from "@agentrail/capabilities";
 import type { SessionRef, TransformContextFn } from "@agentrail/core";
 import { Hono } from "hono";
 import { randomUUID } from "node:crypto";
@@ -129,6 +130,11 @@ export interface AgentrailChatRouteOptions {
     context: { tenantId: string; sessionId: string; sessionRef: SessionRef },
     envelope: WorkflowTraceEventEnvelope,
   ) => void;
+  /**
+   * Optional permission policy applied to all sessions handled by this route.
+   * When set, tools evaluate the policy via `checkPermissions` before executing.
+   */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /**
@@ -258,6 +264,7 @@ export function createChatRoute(options: AgentrailChatRouteOptions): Hono {
         sessionRef,
         sessionStore: options.sessionStore,
         chainId: traceId,
+        permissionPolicy: options.permissionPolicy,
       };
       const agent = await profile.createAgent(profileCtx, () => {
         /* sub-agent events are not forwarded on the JSON /chat route */

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -41,6 +41,7 @@ import type {
 import type {
   Agent,
   Message,
+  PermissionApprovalHandler,
   RuntimeEvent,
   SessionRef,
   ToolInterceptor,
@@ -156,6 +157,17 @@ export interface AgentrailStreamRouteOptions {
    * When set, tools evaluate the policy via `checkPermissions` before executing.
    */
   permissionPolicy?: ToolPermissionPolicy;
+
+  /**
+   * Optional factory that creates a per-session `PermissionApprovalHandler`.
+   *
+   * Called once per stream request with the resolved session ID.  The returned
+   * handler is forwarded to the core executor so that `"ask"` permission
+   * decisions suspend until the user approves or rejects the tool call.
+   *
+   * When absent, `"ask"` decisions are treated as `"deny"`.
+   */
+  createPermissionApprovalHandler?: (sessionId: string) => PermissionApprovalHandler;
 }
 
 /** Fully resolved stream request context exposed to custom handlers. */
@@ -429,6 +441,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
             onTraceEvent: maybeTraceEvent,
             toolInterceptor: buildToolInterceptor(plugins, profileCtx, onPluginError),
             chainId: requestTraceId,
+            permissionApprovalHandler: options.createPermissionApprovalHandler?.(sid),
             onTurnMessagesReady: async (msgs) => {
               await options.sessionStore.appendMessages(tenantId, sid, msgs);
             },
@@ -475,6 +488,8 @@ interface DrainAgentStreamOptions {
    * Errors are swallowed — a failed flush permanently drops that batch (no retry).
    */
   onTurnMessagesReady?: (messages: Message[]) => Promise<void>;
+  /** Optional handler that converts an "ask" permission decision into a suspend-and-resume. */
+  permissionApprovalHandler?: PermissionApprovalHandler;
 }
 
 /**
@@ -506,6 +521,7 @@ async function drainAgentStream(
     reactiveCompaction: opts.reactiveCompaction,
     toolInterceptor: opts.toolInterceptor,
     chainId: opts.chainId,
+    permissionApprovalHandler: opts.permissionApprovalHandler,
   });
 
   for await (const event of agentStream) {

--- a/packages/app/src/routes/stream-route.ts
+++ b/packages/app/src/routes/stream-route.ts
@@ -33,7 +33,11 @@ import { resolveTransformContext } from "@/routes/context-resolver.js";
 import { awaitSandboxWarmup } from "@/routes/sandbox-warmup.js";
 import { createSseEventWriter } from "@/routes/sse-writer.js";
 import { validateStreamRequest, type StreamRequest } from "@/routes/stream-request.js";
-import type { OrchestrationManager, SandboxManager } from "@agentrail/capabilities";
+import type {
+  OrchestrationManager,
+  SandboxManager,
+  ToolPermissionPolicy,
+} from "@agentrail/capabilities";
 import type {
   Agent,
   Message,
@@ -147,6 +151,11 @@ export interface AgentrailStreamRouteOptions {
     context: { tenantId: string; sessionId: string; sessionRef: SessionRef },
     envelope: WorkflowTraceEventEnvelope,
   ) => void;
+  /**
+   * Optional permission policy applied to all sessions handled by this route.
+   * When set, tools evaluate the policy via `checkPermissions` before executing.
+   */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /** Fully resolved stream request context exposed to custom handlers. */
@@ -341,6 +350,7 @@ export function createStreamRoute(options: AgentrailStreamRouteOptions): Hono {
           sessionRef,
           sessionStore: options.sessionStore,
           chainId: requestTraceId,
+          permissionPolicy: options.permissionPolicy,
         };
 
         // ── 6d. Compact history + load budget slice ────────────────────────

--- a/packages/app/test/config.test.ts
+++ b/packages/app/test/config.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import type { AgentrailConfig } from "../src/config/index.js";
 import { getDeepResearchConfig, parseAgentrailConfig } from "../src/config/index.js";
 
 describe("Agentrail config search settings", () => {
@@ -39,5 +40,57 @@ describe("Agentrail config search settings", () => {
       braveApiKey: "brave-key",
       jinaApiKey: "jina-key",
     });
+  });
+});
+
+describe("parseAgentrailConfig — permissions block", () => {
+  it("parses a full permissions block", () => {
+    const config = parseAgentrailConfig({
+      permissions: {
+        mode: "default",
+        allow: ["Bash(git:*)", "Bash(npm:*)"],
+        deny: ["Bash(rm:*)"],
+        ask: ["Write", "Edit"],
+      },
+    }) as AgentrailConfig;
+
+    expect(config.permissions).toMatchObject({
+      mode: "default",
+      allow: ["Bash(git:*)", "Bash(npm:*)"],
+      deny: ["Bash(rm:*)"],
+      ask: ["Write", "Edit"],
+    });
+  });
+
+  it("omitting permissions leaves the field undefined", () => {
+    const config = parseAgentrailConfig({}) as AgentrailConfig;
+    expect(config.permissions).toBeUndefined();
+  });
+
+  it("throws on an invalid mode value", () => {
+    expect(() =>
+      parseAgentrailConfig({
+        permissions: { mode: "INVALID_MODE" },
+      }),
+    ).toThrow(/invalid.*mode/i);
+  });
+
+  it("throws on unknown permissions keys", () => {
+    expect(() =>
+      parseAgentrailConfig({
+        permissions: { unknownKey: true },
+      }),
+    ).toThrow(/unknown/i);
+  });
+
+  it("parses partial permissions block (only deny)", () => {
+    const config = parseAgentrailConfig({
+      permissions: { deny: ["Bash"] },
+    }) as AgentrailConfig;
+
+    expect(config.permissions?.deny).toEqual(["Bash"]);
+    expect(config.permissions?.allow).toEqual([]);
+    expect(config.permissions?.ask).toEqual([]);
+    expect(config.permissions?.mode).toBeUndefined();
   });
 });

--- a/packages/app/test/config.test.ts
+++ b/packages/app/test/config.test.ts
@@ -5,7 +5,11 @@
 
 import { describe, expect, it } from "vitest";
 import type { AgentrailConfig } from "../src/config/index.js";
-import { getDeepResearchConfig, parseAgentrailConfig } from "../src/config/index.js";
+import {
+  getDeepResearchConfig,
+  getPlaygroundServerConfig,
+  parseAgentrailConfig,
+} from "../src/config/index.js";
 
 describe("Agentrail config search settings", () => {
   it("parses brave and jina API keys", () => {
@@ -104,5 +108,23 @@ describe("parseAgentrailConfig — permissions block", () => {
 
     expect(config.permissions?.mode).toBe("strict");
     expect(config.permissions?.allow).toEqual(["Bash(git:*)", "Read"]);
+  });
+});
+
+describe("getPlaygroundServerConfig — permissionPolicy wiring", () => {
+  it("converts permissions block to permissionPolicy", () => {
+    const config = parseAgentrailConfig({
+      permissions: { mode: "strict", allow: ["Bash(git:*)"] },
+    }) as AgentrailConfig;
+    const out = getPlaygroundServerConfig(config);
+    expect(out.permissionPolicy).toBeDefined();
+    expect(out.permissionPolicy?.mode).toBe("strict");
+    expect(out.permissionPolicy?.allow).toHaveLength(1);
+    expect(out.permissionPolicy?.allow[0].toolName).toBe("Bash");
+  });
+
+  it("omits permissionPolicy when no permissions in config", () => {
+    const config = parseAgentrailConfig({}) as AgentrailConfig;
+    expect(getPlaygroundServerConfig(config).permissionPolicy).toBeUndefined();
   });
 });

--- a/packages/app/test/config.test.ts
+++ b/packages/app/test/config.test.ts
@@ -93,4 +93,16 @@ describe("parseAgentrailConfig — permissions block", () => {
     expect(config.permissions?.ask).toEqual([]);
     expect(config.permissions?.mode).toBeUndefined();
   });
+
+  it("parses permissions.mode: strict", () => {
+    const config = parseAgentrailConfig({
+      permissions: {
+        mode: "strict",
+        allow: ["Bash(git:*)", "Read"],
+      },
+    }) as AgentrailConfig;
+
+    expect(config.permissions?.mode).toBe("strict");
+    expect(config.permissions?.allow).toEqual(["Bash(git:*)", "Read"]);
+  });
 });

--- a/packages/app/test/define-profile.test.ts
+++ b/packages/app/test/define-profile.test.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@agentrail/capabilities";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentrailProfileContext } from "../src/host/types.js";
 import { defineProfile } from "../src/profile/define-profile.js";
@@ -69,6 +70,64 @@ describe("defineProfile – static shape", () => {
     // createAgent should not throw; the apiKey override should be applied
     const agent = await profile.createAgent(fakeContext);
     expect(agent).toBeDefined();
+  });
+});
+
+describe("defineProfile – permissionPolicy assembly hop", () => {
+  it("forwards permissionPolicy from profileCtx into CapabilityBuildContext", async () => {
+    const policy: ToolPermissionPolicy = {
+      mode: "default",
+      allow: [],
+      deny: [],
+      ask: [],
+    };
+
+    const capturedCtx: { permissionPolicy?: ToolPermissionPolicy } = {};
+    const cap = {
+      type: "spy-cap",
+      buildTools: vi.fn(async (ctx) => {
+        capturedCtx.permissionPolicy = ctx.permissionPolicy;
+        return [];
+      }),
+    };
+
+    const profile = defineProfile({
+      id: "perm-test",
+      name: "Perm Test",
+      agent: { model: "openai:gpt-4o", prompt: "test" },
+      capabilities: [cap],
+    });
+
+    const ctx: AgentrailProfileContext = {
+      ...fakeContext,
+      permissionPolicy: policy,
+    };
+    await profile.createAgent(ctx);
+
+    expect(cap.buildTools).toHaveBeenCalledOnce();
+    expect(capturedCtx.permissionPolicy).toBe(policy);
+  });
+
+  it("passes undefined permissionPolicy when none is set on profileCtx", async () => {
+    const capturedCtx: { permissionPolicy?: ToolPermissionPolicy } = { permissionPolicy: "sentinel" as never };
+    const cap = {
+      type: "spy-cap-2",
+      buildTools: vi.fn(async (ctx) => {
+        capturedCtx.permissionPolicy = ctx.permissionPolicy;
+        return [];
+      }),
+    };
+
+    const profile = defineProfile({
+      id: "no-perm-test",
+      name: "No Perm Test",
+      agent: { model: "openai:gpt-4o", prompt: "test" },
+      capabilities: [cap],
+    });
+
+    await profile.createAgent(fakeContext);
+
+    expect(capturedCtx.permissionPolicy).toBeUndefined();
   });
 });
 

--- a/packages/capabilities/src/filesystem/index.ts
+++ b/packages/capabilities/src/filesystem/index.ts
@@ -43,9 +43,9 @@ export function filesystem(opts?: FilesystemOptions): CapabilityDescriptor {
       const todoStorage = sessionStore.createTodoStorage?.(sessionRef);
       const tools = [
         createSandboxedBash(sm, sessionId, tenantId, userId, ctx.permissionPolicy),
-        createSandboxedRead(sm, sessionId, tenantId, userId),
-        createSandboxedWrite(sm, sessionId, tenantId, userId),
-        createSandboxedEdit(sm, sessionId, tenantId, userId),
+        createSandboxedRead(sm, sessionId, tenantId, userId, ctx.permissionPolicy),
+        createSandboxedWrite(sm, sessionId, tenantId, userId, ctx.permissionPolicy),
+        createSandboxedEdit(sm, sessionId, tenantId, userId, ctx.permissionPolicy),
         createSandboxedGlob(sm, sessionId, tenantId, userId),
         createSandboxedGrep(sm, sessionId, tenantId, userId),
         createSleepTool(),

--- a/packages/capabilities/src/filesystem/index.ts
+++ b/packages/capabilities/src/filesystem/index.ts
@@ -42,7 +42,7 @@ export function filesystem(opts?: FilesystemOptions): CapabilityDescriptor {
 
       const todoStorage = sessionStore.createTodoStorage?.(sessionRef);
       const tools = [
-        createSandboxedBash(sm, sessionId, tenantId, userId),
+        createSandboxedBash(sm, sessionId, tenantId, userId, ctx.permissionPolicy),
         createSandboxedRead(sm, sessionId, tenantId, userId),
         createSandboxedWrite(sm, sessionId, tenantId, userId),
         createSandboxedEdit(sm, sessionId, tenantId, userId),

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -153,14 +153,18 @@ export {
 export {
   bashTool,
   createAskUserQuestionTool,
+  createBashTool,
   createBraveSearchProvider,
+  createEditTool,
   createGlobTool,
   createJinaSearchProvider,
+  createReadTool,
   createSleepTool,
   createTavilySearchProvider,
   createTodoWriteTool,
   createWebFetchTool,
   createWebSearchTool,
+  createWriteTool,
   editTool,
   grepTool,
   readTool,
@@ -168,7 +172,9 @@ export {
 } from "@/tools/index.js";
 export type {
   BraveSearchProviderOptions,
+  EditToolOptions,
   JinaSearchProviderOptions,
+  ReadToolOptions,
   SleepToolOptions,
   TavilySearchProviderOptions,
   WaitHandleRegistry,
@@ -182,7 +188,28 @@ export type {
   WebSearchProvider,
   WebSearchResult,
   WebSearchToolOptions,
+  WriteToolOptions,
 } from "@/tools/index.js";
+
+// ============================================================================
+// Permissions — policy types, rule engine, path/shell safety
+// ============================================================================
+
+export {
+  DANGEROUS_BASH_PATTERNS,
+  DANGEROUS_FILES,
+  DANGEROUS_PATHS,
+  READ_ONLY_COMMANDS,
+  evaluatePolicy,
+  isDangerousCommand,
+  isPathSafe,
+  isReadOnlyCommand,
+  matchPattern,
+  parseRule,
+  parseRules,
+  workspaceAnchor,
+} from "@/permissions/index.js";
+export type { PermissionMode, PermissionRule, ToolPermissionPolicy } from "@/permissions/index.js";
 
 // ============================================================================
 // Memory context utilities (advanced)

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -210,7 +210,12 @@ export {
   parseRules,
   workspaceAnchor,
 } from "@/permissions/index.js";
-export type { PermissionMode, PermissionRule, ToolPermissionPolicy } from "@/permissions/index.js";
+export type {
+  ContentMatchMode,
+  PermissionMode,
+  PermissionRule,
+  ToolPermissionPolicy,
+} from "@/permissions/index.js";
 
 // ============================================================================
 // Memory context utilities (advanced)

--- a/packages/capabilities/src/index.ts
+++ b/packages/capabilities/src/index.ts
@@ -205,6 +205,7 @@ export {
   isPathSafe,
   isReadOnlyCommand,
   matchPattern,
+  normalizeBashCommand,
   parseRule,
   parseRules,
   workspaceAnchor,

--- a/packages/capabilities/src/permissions/index.ts
+++ b/packages/capabilities/src/permissions/index.ts
@@ -5,6 +5,7 @@
 
 export { DANGEROUS_FILES, DANGEROUS_PATHS, isPathSafe, workspaceAnchor } from "./path-safety.js";
 export { evaluatePolicy, matchPattern } from "./rule-engine.js";
+export type { ContentMatchMode } from "./rule-engine.js";
 export { parseRule, parseRules } from "./rule-parser.js";
 export {
   DANGEROUS_BASH_PATTERNS,

--- a/packages/capabilities/src/permissions/index.ts
+++ b/packages/capabilities/src/permissions/index.ts
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+export { DANGEROUS_FILES, DANGEROUS_PATHS, isPathSafe, workspaceAnchor } from "./path-safety.js";
+export { evaluatePolicy, matchPattern } from "./rule-engine.js";
+export { parseRule, parseRules } from "./rule-parser.js";
+export {
+  DANGEROUS_BASH_PATTERNS,
+  READ_ONLY_COMMANDS,
+  isDangerousCommand,
+  isReadOnlyCommand,
+} from "./shell-safety.js";
+export type { PermissionMode, PermissionRule, ToolPermissionPolicy } from "./types.js";

--- a/packages/capabilities/src/permissions/index.ts
+++ b/packages/capabilities/src/permissions/index.ts
@@ -11,5 +11,6 @@ export {
   READ_ONLY_COMMANDS,
   isDangerousCommand,
   isReadOnlyCommand,
+  normalizeBashCommand,
 } from "./shell-safety.js";
 export type { PermissionMode, PermissionRule, ToolPermissionPolicy } from "./types.js";

--- a/packages/capabilities/src/permissions/path-safety.ts
+++ b/packages/capabilities/src/permissions/path-safety.ts
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ============================================================================
+// Dangerous path definitions
+// ============================================================================
+
+/**
+ * Absolute directory paths that non-sandboxed file tools must not access.
+ * Checked after symlink resolution so that indirect references are caught.
+ */
+export const DANGEROUS_PATHS: readonly string[] = [
+  "/etc",
+  "/sys",
+  "/proc",
+  "/dev",
+  "/boot",
+  "/root",
+  "/run/secrets",
+];
+
+/**
+ * File base-names that are blocked regardless of their directory.
+ * Matched case-sensitively against the last path component.
+ */
+export const DANGEROUS_FILES: readonly string[] = [
+  ".env",
+  ".env.local",
+  ".env.production",
+  "id_rsa",
+  "id_ed25519",
+  "id_ecdsa",
+  "id_dsa",
+  ".npmrc",
+  ".netrc",
+  ".pypirc",
+  "credentials",
+  "credential",
+];
+
+/**
+ * Home-relative directories that are blocked (e.g. `~/.ssh`).
+ * Expanded at runtime using `os.homedir()`.
+ */
+const DANGEROUS_HOME_DIRS: readonly string[] = [
+  ".ssh",
+  ".aws",
+  ".gnupg",
+  ".config/gcloud",
+  ".azure",
+  ".docker",
+];
+
+// ============================================================================
+// Path resolution helpers
+// ============================================================================
+
+function expandedDangerousDirs(): string[] {
+  const home = os.homedir();
+  return [...DANGEROUS_PATHS, ...DANGEROUS_HOME_DIRS.map((d) => path.join(home, d))];
+}
+
+/**
+ * Resolves `filePath` to its real path, handling the case where the file does
+ * not yet exist (common for `Write` on new files).
+ *
+ * Strategy for non-existent paths:
+ * 1. Walk up the directory tree to find the nearest existing ancestor.
+ * 2. Resolve that ancestor's real path (resolves symlinks).
+ * 3. Re-append the remaining (non-existent) path components.
+ *
+ * This prevents attacks where an existing parent directory is a symlink that
+ * points outside the workspace.
+ */
+function resolveRealPath(filePath: string): string {
+  const absolute = path.resolve(filePath);
+
+  // Fast path: file/dir already exists
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    // Not found — walk up to find the nearest existing ancestor
+  }
+
+  const parts = absolute.split(path.sep);
+  let existingAncestor: string = path.sep;
+  let remainingParts: string[] = [];
+
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const candidate = parts.slice(0, i + 1).join(path.sep) || path.sep;
+    try {
+      fs.accessSync(candidate);
+      existingAncestor = candidate;
+      remainingParts = parts.slice(i + 1);
+      break;
+    } catch {
+      // Not found, keep walking up
+    }
+  }
+
+  try {
+    const resolvedAncestor = fs.realpathSync(existingAncestor);
+    return path.join(resolvedAncestor, ...remainingParts);
+  } catch {
+    // Fallback: return the absolute path without symlink resolution
+    return path.join(existingAncestor, ...remainingParts);
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Returns `true` if `filePath` is considered safe for non-sandboxed file tool
+ * access.
+ *
+ * A path is considered **unsafe** if:
+ * - Its resolved form is inside (or equal to) a `DANGEROUS_PATHS` directory.
+ * - Its file name matches a `DANGEROUS_FILES` entry.
+ * - Its resolved form is inside a dangerous home directory (e.g. `~/.ssh`).
+ */
+export function isPathSafe(filePath: string): boolean {
+  const resolved = resolveRealPath(filePath);
+  const basename = path.basename(resolved);
+
+  if (DANGEROUS_FILES.includes(basename)) return false;
+
+  const dangerousDirs = expandedDangerousDirs();
+  for (const dangerous of dangerousDirs) {
+    if (resolved === dangerous || resolved.startsWith(dangerous + path.sep)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Verifies that `filePath` is anchored within `rootDir`.
+ *
+ * For existing paths, resolves symlinks before checking containment.
+ * For non-existing paths, resolves the nearest existing ancestor's real path
+ * and re-appends remaining components (see `resolveRealPath`).
+ *
+ * @throws {Error} if `filePath` would escape `rootDir`.
+ */
+export function workspaceAnchor(filePath: string, rootDir: string): void {
+  const resolvedRoot = fs.realpathSync(path.resolve(rootDir));
+  const resolvedFile = resolveRealPath(filePath);
+
+  const rootWithSep = resolvedRoot.endsWith(path.sep) ? resolvedRoot : resolvedRoot + path.sep;
+
+  if (resolvedFile !== resolvedRoot && !resolvedFile.startsWith(rootWithSep)) {
+    throw new Error(
+      `Path "${filePath}" resolves to "${resolvedFile}" which is outside the allowed root "${resolvedRoot}"`,
+    );
+  }
+}

--- a/packages/capabilities/src/permissions/path-safety.ts
+++ b/packages/capabilities/src/permissions/path-safety.ts
@@ -88,21 +88,17 @@ function resolveRealPath(filePath: string): string {
     // Not found — walk up to find the nearest existing ancestor
   }
 
-  const parts = absolute.split(path.sep);
-  let existingAncestor: string = path.sep;
-  let remainingParts: string[] = [];
-
-  for (let i = parts.length - 1; i >= 0; i--) {
-    const candidate = parts.slice(0, i + 1).join(path.sep) || path.sep;
+  // Walk up using path.dirname — handles Windows drive letters and POSIX equally.
+  let existingAncestor = absolute;
+  while (existingAncestor !== path.dirname(existingAncestor)) {
     try {
-      fs.accessSync(candidate);
-      existingAncestor = candidate;
-      remainingParts = parts.slice(i + 1);
+      fs.accessSync(existingAncestor);
       break;
     } catch {
-      // Not found, keep walking up
+      existingAncestor = path.dirname(existingAncestor);
     }
   }
+  const remainingParts = path.relative(existingAncestor, absolute).split(path.sep);
 
   try {
     const resolvedAncestor = fs.realpathSync(existingAncestor);

--- a/packages/capabilities/src/permissions/rule-engine.ts
+++ b/packages/capabilities/src/permissions/rule-engine.ts
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import type { PermissionRule, ToolPermissionPolicy } from "./types.js";
+
+/** Simple permission outcome — mirrors `PermissionDecision` from @agentrail/core. */
+type SimpleDecision = "allow" | "deny" | "ask";
+
+// ============================================================================
+// Pattern matching
+// ============================================================================
+
+/**
+ * Matches `content` against a glob-style `pattern`.
+ *
+ * Supports:
+ * - `**` — matches any sequence of characters including path separators
+ * - `*`  — matches any sequence of characters except path separators (`/`)
+ * - All other characters are matched literally
+ *
+ * The match is prefix-anchored: `"git:*"` matches content that begins with
+ * `"git:"`, while `"/workspace/**"` matches any path under `/workspace/`.
+ */
+export function matchPattern(pattern: string, content: string): boolean {
+  // Convert glob pattern to a regular expression.
+  // Escape regex special chars first (except * which we handle separately).
+  const regexSource = pattern
+    .split("**")
+    .map((segment) =>
+      segment
+        .split("*")
+        .map((part) => part.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
+        .join("[^/]*"),
+    )
+    .join(".*");
+
+  const regex = new RegExp(`^${regexSource}`);
+  return regex.test(content);
+}
+
+/**
+ * Returns `true` if any rule in `rules` matches the given `toolName` and
+ * optional `content`.
+ */
+function matchesAny(rules: readonly PermissionRule[], toolName: string, content?: string): boolean {
+  for (const rule of rules) {
+    if (rule.toolName !== toolName) continue;
+    if (!rule.pattern) return true; // bare tool name matches all calls
+    if (content !== undefined && matchPattern(rule.pattern, content)) return true;
+  }
+  return false;
+}
+
+// ============================================================================
+// Policy evaluation
+// ============================================================================
+
+/**
+ * Tools whose `ask` decisions are promoted to `allow` in `acceptEdits` mode.
+ */
+const EDIT_TOOL_NAMES = new Set(["Write", "Edit"]);
+
+/**
+ * Evaluates a `ToolPermissionPolicy` for a given tool call and returns the
+ * effective `PermissionDecision`.
+ *
+ * Evaluation order: **deny → ask → allow → default(allow)**
+ *
+ * Mode adjustments applied after rule evaluation:
+ * - `bypassPermissions` — always returns `"allow"` before evaluating rules.
+ * - `dontAsk` — demotes `"ask"` to `"deny"`.
+ * - `acceptEdits` — promotes `"ask"` to `"allow"` for Write/Edit tools.
+ *
+ * @param policy   The active permission policy.
+ * @param toolName The name of the tool being called (e.g. `"Bash"`).
+ * @param content  The primary argument used for pattern matching (e.g. the
+ *                 shell command or file path). May be omitted for tools without
+ *                 a meaningful primary argument.
+ */
+export function evaluatePolicy(
+  policy: ToolPermissionPolicy,
+  toolName: string,
+  content?: string,
+): SimpleDecision {
+  if (policy.mode === "bypassPermissions") return "allow";
+
+  if (matchesAny(policy.deny, toolName, content)) return "deny";
+
+  if (matchesAny(policy.ask, toolName, content)) {
+    if (policy.mode === "dontAsk") return "deny";
+    if (policy.mode === "acceptEdits" && EDIT_TOOL_NAMES.has(toolName)) return "allow";
+    return "ask";
+  }
+
+  if (matchesAny(policy.allow, toolName, content)) return "allow";
+
+  // Default: allow (policy is opt-in deny/ask)
+  return "allow";
+}

--- a/packages/capabilities/src/permissions/rule-engine.ts
+++ b/packages/capabilities/src/permissions/rule-engine.ts
@@ -40,9 +40,16 @@ export type ContentMatchMode = "path" | "command";
  *
  * @param pattern     Glob-style pattern string.
  * @param content     The string to test against the pattern.
- * @param contentMode Controls `*` semantics. Pass `"command"` for Bash
- *                    content so that `*` matches across `/`. Defaults to
- *                    `"path"`.
+ * @param contentMode Controls how `*` is compiled.  The difference is only
+ *                    observable when the pattern has content **after** the
+ *                    wildcard.  For example, in `"path"` mode
+ *                    `"git:*\/index.ts"` does **not** match
+ *                    `"git:src/components/index.ts"` because `[^/]*` stops
+ *                    at the first `/`; in `"command"` mode it does because
+ *                    `.*` can span multiple segments.  For suffix-only
+ *                    wildcards like `"git:*"` both modes behave identically
+ *                    due to prefix anchoring (no trailing `$`).
+ *                    Defaults to `"path"`.
  */
 export function matchPattern(
   pattern: string,
@@ -112,10 +119,14 @@ const EDIT_TOOL_NAMES = new Set(["Write", "Edit"]);
  * @param content     The primary argument used for pattern matching (e.g. the
  *                    shell command or file path). May be omitted for tools
  *                    without a meaningful primary argument.
- * @param contentMode Controls how `*` wildcards in patterns are matched.
- *                    Pass `"command"` for Bash tools so that `*` matches
- *                    across `/` (e.g. `git:*` matches `git:add src/main.ts`).
- *                    Defaults to `"path"` where `*` stops at `/`.
+ * @param contentMode Controls how `*` wildcards in patterns are compiled.
+ *                    Pass `"command"` for Bash content so that patterns with
+ *                    content **after** the wildcard can span `/` — for
+ *                    example `"git:*\/index.ts"` matches
+ *                    `"git:src/components/index.ts"` in command mode but not
+ *                    in path mode.  Suffix-only wildcards like `"git:*"` are
+ *                    unaffected by this setting (prefix anchor, no `$`).
+ *                    Defaults to `"path"`.
  */
 export function evaluatePolicy(
   policy: ToolPermissionPolicy,

--- a/packages/capabilities/src/permissions/rule-engine.ts
+++ b/packages/capabilities/src/permissions/rule-engine.ts
@@ -13,26 +13,52 @@ type SimpleDecision = "allow" | "deny" | "ask";
 // ============================================================================
 
 /**
+ * Matching mode that controls how the `*` wildcard is interpreted.
+ *
+ * - `"path"` *(default)* — `*` matches any sequence of characters **except**
+ *   path separators (`/`).  Use for file-path patterns such as
+ *   `Write(/workspace/*)`.
+ * - `"command"` — `*` matches **any** sequence of characters including `/`.
+ *   Use for Bash command patterns such as `Bash(git:*)`, where the content
+ *   after the verb may contain paths like `src/main.ts`.
+ *
+ * In both modes `**` always matches any sequence including `/`.
+ */
+export type ContentMatchMode = "path" | "command";
+
+/**
  * Matches `content` against a glob-style `pattern`.
  *
  * Supports:
  * - `**` — matches any sequence of characters including path separators
- * - `*`  — matches any sequence of characters except path separators (`/`)
- * - All other characters are matched literally
+ * - `*`  — in `"path"` mode (default): matches any sequence **except** `/`;
+ *           in `"command"` mode: matches any sequence including `/`
+ * - All other characters are matched literally (including `?`)
  *
  * The match is prefix-anchored: `"git:*"` matches content that begins with
  * `"git:"`, while `"/workspace/**"` matches any path under `/workspace/`.
+ *
+ * @param pattern     Glob-style pattern string.
+ * @param content     The string to test against the pattern.
+ * @param contentMode Controls `*` semantics. Pass `"command"` for Bash
+ *                    content so that `*` matches across `/`. Defaults to
+ *                    `"path"`.
  */
-export function matchPattern(pattern: string, content: string): boolean {
+export function matchPattern(
+  pattern: string,
+  content: string,
+  contentMode: ContentMatchMode = "path",
+): boolean {
+  const singleWildcard = contentMode === "command" ? ".*" : "[^/]*";
   // Convert glob pattern to a regular expression.
-  // Escape regex special chars first (except * which we handle separately).
+  // Escape regex special chars first (including ? — except * which we handle separately).
   const regexSource = pattern
     .split("**")
     .map((segment) =>
       segment
         .split("*")
-        .map((part) => part.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
-        .join("[^/]*"),
+        .map((part) => part.replace(/[.+^${}()?|[\]\\]/g, "\\$&"))
+        .join(singleWildcard),
     )
     .join(".*");
 
@@ -44,11 +70,16 @@ export function matchPattern(pattern: string, content: string): boolean {
  * Returns `true` if any rule in `rules` matches the given `toolName` and
  * optional `content`.
  */
-function matchesAny(rules: readonly PermissionRule[], toolName: string, content?: string): boolean {
+function matchesAny(
+  rules: readonly PermissionRule[],
+  toolName: string,
+  content?: string,
+  contentMode: ContentMatchMode = "path",
+): boolean {
   for (const rule of rules) {
     if (rule.toolName !== toolName) continue;
     if (!rule.pattern) return true; // bare tool name matches all calls
-    if (content !== undefined && matchPattern(rule.pattern, content)) return true;
+    if (content !== undefined && matchPattern(rule.pattern, content, contentMode)) return true;
   }
   return false;
 }
@@ -66,36 +97,44 @@ const EDIT_TOOL_NAMES = new Set(["Write", "Edit"]);
  * Evaluates a `ToolPermissionPolicy` for a given tool call and returns the
  * effective `PermissionDecision`.
  *
- * Evaluation order: **deny → ask → allow → default(allow)**
+ * Evaluation order: **deny → ask → allow → default**
  *
  * Mode adjustments applied after rule evaluation:
  * - `bypassPermissions` — always returns `"allow"` before evaluating rules.
  * - `dontAsk` — demotes `"ask"` to `"deny"`.
  * - `acceptEdits` — promotes `"ask"` to `"allow"` for Write/Edit tools.
+ * - `strict` — the default outcome is `"deny"` instead of `"allow"`.  Use
+ *   this to build deny-by-default allowlists: add explicit `allow` rules for
+ *   permitted operations and everything else is blocked.
  *
- * @param policy   The active permission policy.
- * @param toolName The name of the tool being called (e.g. `"Bash"`).
- * @param content  The primary argument used for pattern matching (e.g. the
- *                 shell command or file path). May be omitted for tools without
- *                 a meaningful primary argument.
+ * @param policy      The active permission policy.
+ * @param toolName    The name of the tool being called (e.g. `"Bash"`).
+ * @param content     The primary argument used for pattern matching (e.g. the
+ *                    shell command or file path). May be omitted for tools
+ *                    without a meaningful primary argument.
+ * @param contentMode Controls how `*` wildcards in patterns are matched.
+ *                    Pass `"command"` for Bash tools so that `*` matches
+ *                    across `/` (e.g. `git:*` matches `git:add src/main.ts`).
+ *                    Defaults to `"path"` where `*` stops at `/`.
  */
 export function evaluatePolicy(
   policy: ToolPermissionPolicy,
   toolName: string,
   content?: string,
+  contentMode: ContentMatchMode = "path",
 ): SimpleDecision {
   if (policy.mode === "bypassPermissions") return "allow";
 
-  if (matchesAny(policy.deny, toolName, content)) return "deny";
+  if (matchesAny(policy.deny, toolName, content, contentMode)) return "deny";
 
-  if (matchesAny(policy.ask, toolName, content)) {
+  if (matchesAny(policy.ask, toolName, content, contentMode)) {
     if (policy.mode === "dontAsk") return "deny";
     if (policy.mode === "acceptEdits" && EDIT_TOOL_NAMES.has(toolName)) return "allow";
     return "ask";
   }
 
-  if (matchesAny(policy.allow, toolName, content)) return "allow";
+  if (matchesAny(policy.allow, toolName, content, contentMode)) return "allow";
 
-  // Default: allow (policy is opt-in deny/ask)
-  return "allow";
+  // Default: deny in strict mode, allow otherwise
+  return policy.mode === "strict" ? "deny" : "allow";
 }

--- a/packages/capabilities/src/permissions/rule-parser.ts
+++ b/packages/capabilities/src/permissions/rule-parser.ts
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import type { PermissionRule } from "./types.js";
+
+/**
+ * Parses a permission rule string into a structured `PermissionRule`.
+ *
+ * Accepted formats:
+ * - `"Bash"` → `{ toolName: "Bash" }`
+ * - `"Bash(git:*)"` → `{ toolName: "Bash", pattern: "git:*" }`
+ * - `"Write(/workspace/**)"` → `{ toolName: "Write", pattern: "/workspace/**" }`
+ *
+ * @throws {Error} if the string is empty or malformed.
+ */
+export function parseRule(s: string): PermissionRule {
+  const trimmed = s.trim();
+  if (!trimmed) {
+    throw new Error(`Invalid permission rule: empty string`);
+  }
+
+  const parenOpen = trimmed.indexOf("(");
+  if (parenOpen === -1) {
+    // Plain tool name, no pattern
+    return { toolName: trimmed };
+  }
+
+  if (!trimmed.endsWith(")")) {
+    throw new Error(`Invalid permission rule "${s}": missing closing parenthesis`);
+  }
+
+  const toolName = trimmed.slice(0, parenOpen).trim();
+  if (!toolName) {
+    throw new Error(`Invalid permission rule "${s}": tool name is empty`);
+  }
+
+  const pattern = trimmed.slice(parenOpen + 1, -1).trim();
+  if (!pattern) {
+    throw new Error(`Invalid permission rule "${s}": pattern inside parentheses is empty`);
+  }
+
+  return { toolName, pattern };
+}
+
+/**
+ * Parses an array of rule strings, collecting and re-throwing any parse
+ * errors with the list index included for easier debugging.
+ */
+export function parseRules(rules: string[]): PermissionRule[] {
+  return rules.map((r, i) => {
+    try {
+      return parseRule(r);
+    } catch (err) {
+      throw new Error(
+        `Permission rule at index ${i} is invalid: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  });
+}

--- a/packages/capabilities/src/permissions/shell-safety.ts
+++ b/packages/capabilities/src/permissions/shell-safety.ts
@@ -140,3 +140,27 @@ export function isReadOnlyCommand(command: string): boolean {
   const firstWord = command.trimStart().split(/\s+/)[0]?.toLowerCase() ?? "";
   return READ_ONLY_COMMANDS.has(firstWord);
 }
+
+/**
+ * Normalises a raw shell command string into the `"verb:rest"` form used by
+ * the Bash permission DSL.
+ *
+ * The DSL convention `Bash(git:*)` means "any shell command whose first word
+ * is `git`". Because raw commands use spaces (`"git status"`) rather than
+ * colons, this function converts `"git status --porcelain"` into
+ * `"git:status --porcelain"` so that glob patterns like `git:*` match
+ * correctly.
+ *
+ * Single-word commands (e.g. `"ls"`) are returned as-is.
+ *
+ * @example
+ * normalizeBashCommand("git status")  // → "git:status"
+ * normalizeBashCommand("npm install") // → "npm:install"
+ * normalizeBashCommand("ls")          // → "ls"
+ */
+export function normalizeBashCommand(command: string): string {
+  const trimmed = command.trimStart();
+  const firstSpace = trimmed.indexOf(" ");
+  if (firstSpace === -1) return trimmed;
+  return trimmed.slice(0, firstSpace) + ":" + trimmed.slice(firstSpace + 1);
+}

--- a/packages/capabilities/src/permissions/shell-safety.ts
+++ b/packages/capabilities/src/permissions/shell-safety.ts
@@ -15,10 +15,14 @@
 export const DANGEROUS_BASH_PATTERNS: readonly RegExp[] = [
   // Fork bomb
   /:\(\)\s*\{\s*:\|:&\s*\}\s*;/,
-  // Wipe entire filesystem
-  /\brm\s+(-[a-z]*f[a-z]*\s+)*\/\s*($|\|)/i,
-  /\brm\s+-rf\s+\/($|\s)/i,
-  /\brm\s+-fr\s+\/($|\s)/i,
+  // Wipe entire filesystem.
+  // Single combined flag block containing 'f', e.g. rm -rf /, rm -rrf /, rm -Rf /
+  // (no outer repetition avoids ReDoS from nested quantifiers)
+  /\brm\s+-[a-z]*f[a-z]*\s+\/\s*($|\|)/i,
+  // Separate flag tokens with force flag second, e.g. rm -r -f /
+  /\brm\s+-[a-z]+\s+-[a-z]*f[a-z]*\s+\/\s*($|\|)/i,
+  // Separate flag tokens with force flag first, e.g. rm -f -r /
+  /\brm\s+-[a-z]*f[a-z]*\s+-[a-z]+\s+\/\s*($|\|)/i,
   // Low-level disk write
   /\bdd\s+.*of=\/dev\/(sd|hd|nvme|xvd|vd)/i,
   // Format filesystem

--- a/packages/capabilities/src/permissions/shell-safety.ts
+++ b/packages/capabilities/src/permissions/shell-safety.ts
@@ -164,7 +164,6 @@ export function isReadOnlyCommand(command: string): boolean {
  */
 export function normalizeBashCommand(command: string): string {
   const trimmed = command.trimStart();
-  const firstSpace = trimmed.indexOf(" ");
-  if (firstSpace === -1) return trimmed;
-  return trimmed.slice(0, firstSpace) + ":" + trimmed.slice(firstSpace + 1);
+  // Replace any whitespace (space, tab, etc.) between the verb and its args with ":"
+  return trimmed.replace(/^(\S+)\s+/, "$1:");
 }

--- a/packages/capabilities/src/permissions/shell-safety.ts
+++ b/packages/capabilities/src/permissions/shell-safety.ts
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+// ============================================================================
+// Dangerous command patterns
+// ============================================================================
+
+/**
+ * Regex patterns matched against the full command string (case-insensitive).
+ * A command that matches any of these is considered unconditionally dangerous
+ * and will be denied regardless of the active permission policy.
+ */
+export const DANGEROUS_BASH_PATTERNS: readonly RegExp[] = [
+  // Fork bomb
+  /:\(\)\s*\{\s*:\|:&\s*\}\s*;/,
+  // Wipe entire filesystem
+  /\brm\s+(-[a-z]*f[a-z]*\s+)*\/\s*($|\|)/i,
+  /\brm\s+-rf\s+\/($|\s)/i,
+  /\brm\s+-fr\s+\/($|\s)/i,
+  // Low-level disk write
+  /\bdd\s+.*of=\/dev\/(sd|hd|nvme|xvd|vd)/i,
+  // Format filesystem
+  /\b(mkfs|mke2fs|mkswap)\b/i,
+  // Overwrite block device
+  />\s*\/dev\/(sd|hd|nvme|xvd|vd)/i,
+  // Kernel module manipulation
+  /\b(insmod|rmmod|modprobe)\b/i,
+  // Dangerous network exfil
+  /\bchmod\s+777\s+\//i,
+];
+
+/**
+ * Command prefixes (first word of the command) considered read-only.
+ * When `isReadOnlyCommand` is used to enforce a read-only policy, only
+ * commands whose first word appears in this set are allowed.
+ */
+export const READ_ONLY_COMMANDS: ReadonlySet<string> = new Set([
+  "cat",
+  "less",
+  "more",
+  "head",
+  "tail",
+  "ls",
+  "ll",
+  "dir",
+  "pwd",
+  "echo",
+  "printf",
+  "grep",
+  "rg",
+  "find",
+  "locate",
+  "which",
+  "whereis",
+  "type",
+  "file",
+  "stat",
+  "wc",
+  "diff",
+  "cmp",
+  "md5sum",
+  "sha256sum",
+  "sha1sum",
+  "xxd",
+  "hexdump",
+  "od",
+  "strings",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "awk",
+  "sed", // read-only usage (no -i)
+  "jq",
+  "yq",
+  "env",
+  "printenv",
+  "uname",
+  "hostname",
+  "whoami",
+  "id",
+  "groups",
+  "date",
+  "uptime",
+  "df",
+  "du",
+  "free",
+  "ps",
+  "top",
+  "htop",
+  "lsof",
+  "netstat",
+  "ss",
+  "ip",
+  "ifconfig",
+  "ping",
+  "traceroute",
+  "nslookup",
+  "dig",
+  "host",
+  "curl",
+  "wget",
+  "git",
+  "npm",
+  "node",
+  "python",
+  "python3",
+  "ruby",
+  "go",
+  "cargo",
+  "make",
+  "cmake",
+]);
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Returns `true` if the command matches a known-dangerous pattern that should
+ * always be blocked, regardless of the active permission policy.
+ *
+ * This check is applied by default even when no `ToolPermissionPolicy` is
+ * configured, providing a baseline safety net for non-sandboxed Bash tools.
+ */
+export function isDangerousCommand(command: string): boolean {
+  return DANGEROUS_BASH_PATTERNS.some((pattern) => pattern.test(command));
+}
+
+/**
+ * Returns `true` if the command's first word is in the read-only command
+ * allowlist.
+ *
+ * Use this to enforce a strict read-only policy (e.g. for plan/analysis-only
+ * agents). Commands not in the list are considered potentially mutating.
+ */
+export function isReadOnlyCommand(command: string): boolean {
+  const firstWord = command.trimStart().split(/\s+/)[0]?.toLowerCase() ?? "";
+  return READ_ONLY_COMMANDS.has(firstWord);
+}

--- a/packages/capabilities/src/permissions/types.ts
+++ b/packages/capabilities/src/permissions/types.ts
@@ -16,8 +16,12 @@
  *   unconditionally (trusted automation / admin contexts only).
  * - `dontAsk` — `ask` decisions are demoted to `deny`; intended for headless
  *   environments where there is no user present to answer prompts.
+ * - `strict` — deny-by-default; the policy default outcome is `"deny"` rather
+ *   than `"allow"`.  Add explicit `allow` rules to whitelist permitted
+ *   operations.  Use this to build a minimal-privilege configuration where only
+ *   named tool calls are permitted.
  */
-export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "dontAsk";
+export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "strict";
 
 /**
  * A single parsed permission rule.

--- a/packages/capabilities/src/permissions/types.ts
+++ b/packages/capabilities/src/permissions/types.ts
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+/**
+ * Controls how the permission engine treats `ask` decisions and whether it
+ * bypasses the policy entirely.
+ *
+ * - `default` — dangerous operations raise an `ask` decision that surfaces a
+ *   `permission_request` event; execution is denied until the host provides an
+ *   interactive approval mechanism.
+ * - `acceptEdits` — `ask` decisions on `Write` and `Edit` tools are
+ *   automatically promoted to `allow`; shell execution still raises `ask`.
+ * - `bypassPermissions` — all `checkPermissions` calls return `allow`
+ *   unconditionally (trusted automation / admin contexts only).
+ * - `dontAsk` — `ask` decisions are demoted to `deny`; intended for headless
+ *   environments where there is no user present to answer prompts.
+ */
+export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "dontAsk";
+
+/**
+ * A single parsed permission rule.
+ *
+ * Rules are expressed in a `ToolName` or `ToolName(content-pattern)` DSL:
+ * - `"Bash"` → matches any Bash call
+ * - `"Bash(git:*)"` → matches Bash calls whose command starts with `git `
+ * - `"Write(/workspace/**)"` → matches Write calls whose `file_path` begins
+ *   with `/workspace/`
+ */
+export interface PermissionRule {
+  /** The tool name this rule applies to (case-sensitive). */
+  readonly toolName: string;
+  /**
+   * Optional glob-style content pattern matched against the tool's primary
+   * argument (command string for Bash, file path for file tools, etc.).
+   * When absent, the rule matches any call to the tool.
+   */
+  readonly pattern?: string;
+}
+
+/**
+ * The full permission policy applied to a session or tenant.
+ *
+ * Rules are evaluated in priority order: **deny → ask → allow → default**.
+ * The first matching rule in the highest-priority list wins.
+ */
+export interface ToolPermissionPolicy {
+  /**
+   * Overarching permission mode that modulates how `ask` decisions are treated.
+   * Defaults to `"default"` when absent.
+   */
+  readonly mode: PermissionMode;
+  /** Rules that unconditionally allow matching tool calls. */
+  readonly allow: readonly PermissionRule[];
+  /** Rules that unconditionally deny matching tool calls. */
+  readonly deny: readonly PermissionRule[];
+  /**
+   * Rules that require user confirmation before execution.
+   * In `dontAsk` mode these are treated as `deny`.
+   * In `acceptEdits` mode these are treated as `allow` for Write/Edit.
+   */
+  readonly ask: readonly PermissionRule[];
+}

--- a/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ToolPermissionPolicy } from "@/permissions/index.js";
-import { evaluatePolicy } from "@/permissions/index.js";
+import { evaluatePolicy, normalizeBashCommand } from "@/permissions/index.js";
 import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
@@ -62,7 +62,7 @@ export function createSandboxedBash(
     .parameters(parametersSchema)
     .checkPermissions(({ command }) => {
       if (policy) {
-        return evaluatePolicy(policy, "Bash", command);
+        return evaluatePolicy(policy, "Bash", normalizeBashCommand(command));
       }
       return "allow";
     })

--- a/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy } from "@/permissions/index.js";
 import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
@@ -51,12 +53,19 @@ export function createSandboxedBash(
   sessionId: string,
   tenantId: string,
   userId: string,
+  policy?: ToolPermissionPolicy,
 ) {
   return tool()
     .name("Bash")
     .label("Bash")
     .description(toolDescription)
     .parameters(parametersSchema)
+    .checkPermissions(({ command }) => {
+      if (policy) {
+        return evaluatePolicy(policy, "Bash", command);
+      }
+      return "allow";
+    })
     .execute(async ({ command, working_directory, timeout }, { signal }) => {
       await manager.ensureSandbox(sessionId, tenantId, userId);
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-bash.ts
@@ -62,7 +62,7 @@ export function createSandboxedBash(
     .parameters(parametersSchema)
     .checkPermissions(({ command }) => {
       if (policy) {
-        return evaluatePolicy(policy, "Bash", normalizeBashCommand(command));
+        return evaluatePolicy(policy, "Bash", normalizeBashCommand(command), "command");
       }
       return "allow";
     })

--- a/packages/capabilities/src/sandbox/tools/sandboxed-edit.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-edit.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy } from "@/permissions/index.js";
 import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
@@ -41,12 +43,17 @@ export function createSandboxedEdit(
   sessionId: string,
   tenantId: string,
   userId: string,
+  policy?: ToolPermissionPolicy,
 ) {
   return tool()
     .name("Edit")
     .label("Edit")
     .description(toolDescription)
     .parameters(parametersSchema)
+    .checkPermissions(({ file_path }) => {
+      if (policy) return evaluatePolicy(policy, "Edit", file_path);
+      return "allow";
+    })
     .execute(async ({ file_path, old_string, new_string, replace_all }) => {
       await manager.ensureSandbox(sessionId, tenantId, userId);
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-read.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-read.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy } from "@/permissions/index.js";
 import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
@@ -46,12 +48,17 @@ export function createSandboxedRead(
   sessionId: string,
   tenantId: string,
   userId: string,
+  policy?: ToolPermissionPolicy,
 ) {
   return tool()
     .name("Read")
     .label("Read")
     .description(toolDescription)
     .parameters(parametersSchema)
+    .checkPermissions(({ file_path }) => {
+      if (policy) return evaluatePolicy(policy, "Read", file_path);
+      return "allow";
+    })
     .execute(async ({ file_path, offset, limit }) => {
       await manager.ensureSandbox(sessionId, tenantId, userId);
 

--- a/packages/capabilities/src/sandbox/tools/sandboxed-write.ts
+++ b/packages/capabilities/src/sandbox/tools/sandboxed-write.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy } from "@/permissions/index.js";
 import type { SandboxManager } from "@/sandbox/sandbox-manager.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
@@ -32,12 +34,17 @@ export function createSandboxedWrite(
   sessionId: string,
   tenantId: string,
   userId: string,
+  policy?: ToolPermissionPolicy,
 ) {
   return tool()
     .name("Write")
     .label("Write")
     .description(toolDescription)
     .parameters(parametersSchema)
+    .checkPermissions(({ file_path }) => {
+      if (policy) return evaluatePolicy(policy, "Write", file_path);
+      return "allow";
+    })
     .execute(async ({ file_path, contents }) => {
       await manager.ensureSandbox(sessionId, tenantId, userId);
 

--- a/packages/capabilities/src/tools/bash.ts
+++ b/packages/capabilities/src/tools/bash.ts
@@ -74,7 +74,7 @@ export function createBashTool(policy?: ToolPermissionPolicy) {
         return { decision: "deny" as const, reason: `Command matches a known-dangerous pattern` };
       }
       if (policy) {
-        return evaluatePolicy(policy, "Bash", normalizeBashCommand(command));
+        return evaluatePolicy(policy, "Bash", normalizeBashCommand(command), "command");
       }
       return "allow";
     })

--- a/packages/capabilities/src/tools/bash.ts
+++ b/packages/capabilities/src/tools/bash.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy, isDangerousCommand } from "@/permissions/index.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { spawn } from "node:child_process";
@@ -54,116 +56,137 @@ function truncate(s: string, max: number): string {
   return truncated + "\n[output truncated]";
 }
 
-export const bashTool = tool()
-  .name(toolName)
-  .label(toolLabel)
-  .description(toolDescription)
-  .parameters(parametersSchema)
-  .execute(async ({ command, working_directory, timeout }, { signal }) => {
-    const timeoutMs = timeout ?? DEFAULT_TIMEOUT_MS;
-    const cwd = working_directory ?? process.cwd();
-
-    let stdoutBuf = "";
-    let stderrBuf = "";
-
-    const child = spawn("/bin/sh", ["-c", command], {
-      cwd,
-      env: process.env,
-      // detached so the process can survive beyond the parent wait
-      detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const pid = child.pid!;
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdoutBuf += chunk.toString("utf-8");
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderrBuf += chunk.toString("utf-8");
-    });
-
-    // Abort support: kill child if the agent is aborted
-    const onAbort = () => {
-      try {
-        child.kill();
-      } catch {
-        /* ignore */
+/**
+ * Creates a non-sandboxed Bash tool with optional permission policy.
+ *
+ * When a `policy` is supplied, each command is evaluated against it before
+ * execution.  Regardless of policy, commands that match `DANGEROUS_BASH_PATTERNS`
+ * are always denied as a baseline safety net.
+ */
+export function createBashTool(policy?: ToolPermissionPolicy) {
+  return tool()
+    .name(toolName)
+    .label(toolLabel)
+    .description(toolDescription)
+    .parameters(parametersSchema)
+    .checkPermissions(({ command }) => {
+      if (isDangerousCommand(command)) {
+        return { decision: "deny" as const, reason: `Command matches a known-dangerous pattern` };
       }
-    };
-    signal?.addEventListener("abort", onAbort, { once: true });
+      if (policy) {
+        return evaluatePolicy(policy, "Bash", command);
+      }
+      return "allow";
+    })
+    .execute(async ({ command, working_directory, timeout }, { signal }) => {
+      const timeoutMs = timeout ?? DEFAULT_TIMEOUT_MS;
+      const cwd = working_directory ?? process.cwd();
 
-    const result = await new Promise<BashDetails>((resolve) => {
-      let settled = false;
-      let timer: ReturnType<typeof setTimeout> | null = null;
+      let stdoutBuf = "";
+      let stderrBuf = "";
 
-      const settle = (details: BashDetails) => {
-        if (settled) return;
-        settled = true;
-        if (timer !== null) clearTimeout(timer);
-        signal?.removeEventListener("abort", onAbort);
-        resolve(details);
+      const child = spawn("/bin/sh", ["-c", command], {
+        cwd,
+        env: process.env,
+        // detached so the process can survive beyond the parent wait
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      const pid = child.pid!;
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdoutBuf += chunk.toString("utf-8");
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderrBuf += chunk.toString("utf-8");
+      });
+
+      // Abort support: kill child if the agent is aborted
+      const onAbort = () => {
+        try {
+          child.kill();
+        } catch {
+          /* ignore */
+        }
       };
+      signal?.addEventListener("abort", onAbort, { once: true });
 
-      child.on("close", (code) => {
-        settle({
-          mode: "foreground",
-          exit_code: code ?? 0,
-          stdout: truncate(stdoutBuf, MAX_OUTPUT_BYTES),
-          stderr: truncate(stderrBuf, MAX_OUTPUT_BYTES),
-        });
-      });
+      const result = await new Promise<BashDetails>((resolve) => {
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
 
-      child.on("error", (err) => {
-        settle({
-          mode: "foreground",
-          exit_code: 1,
-          stdout: "",
-          stderr: err.message,
-        });
-      });
+        const settle = (details: BashDetails) => {
+          if (settled) return;
+          settled = true;
+          if (timer !== null) clearTimeout(timer);
+          signal?.removeEventListener("abort", onAbort);
+          resolve(details);
+        };
 
-      if (timeoutMs === 0) {
-        // Immediately background
-        child.unref();
-        settle({
-          mode: "background",
-          pid,
-          stdout: "",
-          stderr: "",
+        child.on("close", (code) => {
+          settle({
+            mode: "foreground",
+            exit_code: code ?? 0,
+            stdout: truncate(stdoutBuf, MAX_OUTPUT_BYTES),
+            stderr: truncate(stderrBuf, MAX_OUTPUT_BYTES),
+          });
         });
-      } else {
-        timer = setTimeout(() => {
-          // Detach from the Node event loop; process keeps running
+
+        child.on("error", (err) => {
+          settle({
+            mode: "foreground",
+            exit_code: 1,
+            stdout: "",
+            stderr: err.message,
+          });
+        });
+
+        if (timeoutMs === 0) {
+          // Immediately background
           child.unref();
           settle({
             mode: "background",
             pid,
-            stdout: truncate(stdoutBuf, MAX_OUTPUT_BYTES),
-            stderr: truncate(stderrBuf, MAX_OUTPUT_BYTES),
+            stdout: "",
+            stderr: "",
           });
-        }, timeoutMs);
+        } else {
+          timer = setTimeout(() => {
+            // Detach from the Node event loop; process keeps running
+            child.unref();
+            settle({
+              mode: "background",
+              pid,
+              stdout: truncate(stdoutBuf, MAX_OUTPUT_BYTES),
+              stderr: truncate(stderrBuf, MAX_OUTPUT_BYTES),
+            });
+          }, timeoutMs);
+        }
+      });
+
+      let text: string;
+      if (result.mode === "foreground") {
+        const parts: string[] = [];
+        if (result.stdout) parts.push(result.stdout);
+        if (result.stderr) parts.push(`[stderr]\n${result.stderr}`);
+        if (parts.length === 0) parts.push("(no output)");
+        parts.push(`\n[exit code: ${result.exit_code}]`);
+        text = parts.join("\n");
+      } else {
+        const parts: string[] = [`Process is running in background (pid: ${result.pid})`];
+        if (result.stdout) parts.push(result.stdout);
+        if (result.stderr) parts.push(`[stderr]\n${result.stderr}`);
+        text = parts.join("\n");
       }
-    });
 
-    let text: string;
-    if (result.mode === "foreground") {
-      const parts: string[] = [];
-      if (result.stdout) parts.push(result.stdout);
-      if (result.stderr) parts.push(`[stderr]\n${result.stderr}`);
-      if (parts.length === 0) parts.push("(no output)");
-      parts.push(`\n[exit code: ${result.exit_code}]`);
-      text = parts.join("\n");
-    } else {
-      const parts: string[] = [`Process is running in background (pid: ${result.pid})`];
-      if (result.stdout) parts.push(result.stdout);
-      if (result.stderr) parts.push(`[stderr]\n${result.stderr}`);
-      text = parts.join("\n");
-    }
+      return {
+        content: [{ type: "text" as const, text }],
+        details: result,
+      };
+    })
+    .build();
+}
 
-    return {
-      content: [{ type: "text" as const, text }],
-      details: result,
-    };
-  })
-  .build();
+/** Non-sandboxed Bash tool with no permission policy (backward-compatible singleton). */
+export const bashTool = createBashTool();

--- a/packages/capabilities/src/tools/bash.ts
+++ b/packages/capabilities/src/tools/bash.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ToolPermissionPolicy } from "@/permissions/index.js";
-import { evaluatePolicy, isDangerousCommand } from "@/permissions/index.js";
+import { evaluatePolicy, isDangerousCommand, normalizeBashCommand } from "@/permissions/index.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { spawn } from "node:child_process";
@@ -74,7 +74,7 @@ export function createBashTool(policy?: ToolPermissionPolicy) {
         return { decision: "deny" as const, reason: `Command matches a known-dangerous pattern` };
       }
       if (policy) {
-        return evaluatePolicy(policy, "Bash", command);
+        return evaluatePolicy(policy, "Bash", normalizeBashCommand(command));
       }
       return "allow";
     })

--- a/packages/capabilities/src/tools/edit.ts
+++ b/packages/capabilities/src/tools/edit.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy, isPathSafe, workspaceAnchor } from "@/permissions/index.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { readFile, writeFile } from "node:fs/promises";
@@ -40,72 +42,108 @@ const parametersSchema = Type.Object({
   ),
 });
 
-export const editTool = tool()
-  .name(toolName)
-  .label(toolLabel)
-  .description(toolDescription)
-  .parameters(parametersSchema)
-  .execute(async ({ file_path, old_string, new_string, replace_all }) => {
-    let content: string;
-    try {
-      content = await readFile(file_path, "utf-8");
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: "text" as const, text: `Error reading file: ${message}` }],
-        details: { error: message },
-      };
-    }
+/** Options for `createEditTool`. */
+export interface EditToolOptions {
+  /** When set, file paths must be anchored within this directory. */
+  rootDir?: string;
+  /** Active permission policy evaluated before editing. */
+  policy?: ToolPermissionPolicy;
+}
 
-    const occurrences = content.split(old_string).length - 1;
+/**
+ * Creates a non-sandboxed Edit tool with optional path anchoring and
+ * permission policy.
+ */
+export function createEditTool(opts?: EditToolOptions) {
+  return tool()
+    .name(toolName)
+    .label(toolLabel)
+    .description(toolDescription)
+    .parameters(parametersSchema)
+    .checkPermissions(({ file_path }) => {
+      if (!isPathSafe(file_path)) {
+        return { decision: "deny" as const, reason: `Path "${file_path}" is not allowed` };
+      }
+      if (opts?.rootDir) {
+        try {
+          workspaceAnchor(file_path, opts.rootDir);
+        } catch (err) {
+          return {
+            decision: "deny" as const,
+            reason: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+      if (opts?.policy) {
+        return evaluatePolicy(opts.policy, "Edit", file_path);
+      }
+      return "allow";
+    })
+    .execute(async ({ file_path, old_string, new_string, replace_all }) => {
+      let content: string;
+      try {
+        content = await readFile(file_path, "utf-8");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error reading file: ${message}` }],
+          details: { error: message },
+        };
+      }
 
-    if (occurrences === 0) {
+      const occurrences = content.split(old_string).length - 1;
+
+      if (occurrences === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: old_string not found in file. The string must match exactly, including whitespace and indentation.`,
+            },
+          ],
+          details: { error: "old_string not found", occurrences: 0 },
+        };
+      }
+
+      if (!replace_all && occurrences > 1) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: old_string is not unique in the file (found ${occurrences} occurrences). Provide more surrounding context to make it unique, or set replace_all to true.`,
+            },
+          ],
+          details: { error: "old_string not unique", occurrences },
+        };
+      }
+
+      const updated = replace_all
+        ? content.split(old_string).join(new_string)
+        : content.replace(old_string, new_string);
+
+      try {
+        await writeFile(file_path, updated, "utf-8");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error writing file: ${message}` }],
+          details: { error: message },
+        };
+      }
+
+      const replacedCount = replace_all ? occurrences : 1;
       return {
         content: [
           {
             type: "text" as const,
-            text: `Error: old_string not found in file. The string must match exactly, including whitespace and indentation.`,
+            text: `Successfully replaced ${replacedCount} occurrence(s) in ${file_path}`,
           },
         ],
-        details: { error: "old_string not found", occurrences: 0 },
+        details: { replacedCount },
       };
-    }
+    })
+    .build();
+}
 
-    if (!replace_all && occurrences > 1) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Error: old_string is not unique in the file (found ${occurrences} occurrences). Provide more surrounding context to make it unique, or set replace_all to true.`,
-          },
-        ],
-        details: { error: "old_string not unique", occurrences },
-      };
-    }
-
-    const updated = replace_all
-      ? content.split(old_string).join(new_string)
-      : content.replace(old_string, new_string);
-
-    try {
-      await writeFile(file_path, updated, "utf-8");
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: "text" as const, text: `Error writing file: ${message}` }],
-        details: { error: message },
-      };
-    }
-
-    const replacedCount = replace_all ? occurrences : 1;
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Successfully replaced ${replacedCount} occurrence(s) in ${file_path}`,
-        },
-      ],
-      details: { replacedCount },
-    };
-  })
-  .build();
+/** Non-sandboxed Edit tool with no path restrictions (backward-compatible singleton). */
+export const editTool = createEditTool();

--- a/packages/capabilities/src/tools/index.ts
+++ b/packages/capabilities/src/tools/index.ts
@@ -5,11 +5,13 @@
 
 export { createAskUserQuestionTool } from "@/tools/ask-user-question.js";
 export type { WaitHandleRegistry } from "@/tools/ask-user-question.js";
-export { bashTool } from "@/tools/bash.js";
-export { editTool } from "@/tools/edit.js";
+export { bashTool, createBashTool } from "@/tools/bash.js";
+export { createEditTool, editTool } from "@/tools/edit.js";
+export type { EditToolOptions } from "@/tools/edit.js";
 export { createGlobTool } from "@/tools/glob.js";
 export { grepTool } from "@/tools/grep.js";
-export { readTool } from "@/tools/read.js";
+export { createReadTool, readTool } from "@/tools/read.js";
+export type { ReadToolOptions } from "@/tools/read.js";
 export { createSleepTool } from "@/tools/sleep.js";
 export type { SleepToolOptions } from "@/tools/sleep.js";
 export { createTodoWriteTool } from "@/tools/todo-write.js";
@@ -37,4 +39,5 @@ export type {
   WebSearchResult,
   WebSearchToolOptions,
 } from "@/tools/web-search.js";
-export { writeTool } from "@/tools/write.js";
+export { createWriteTool, writeTool } from "@/tools/write.js";
+export type { WriteToolOptions } from "@/tools/write.js";

--- a/packages/capabilities/src/tools/read.ts
+++ b/packages/capabilities/src/tools/read.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy, isPathSafe, workspaceAnchor } from "@/permissions/index.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { readFile } from "node:fs/promises";
@@ -48,68 +50,104 @@ const parametersSchema = Type.Object({
   ),
 });
 
-export const readTool = tool()
-  .name(toolName)
-  .label(toolLabel)
-  .description(toolDescription)
-  .parameters(parametersSchema)
-  .execute(async ({ file_path, offset, limit }) => {
-    let raw: string;
-    try {
-      raw = await readFile(file_path, "utf-8");
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
+/** Options for `createReadTool`. */
+export interface ReadToolOptions {
+  /** When set, file paths must be anchored within this directory. */
+  rootDir?: string;
+  /** Active permission policy evaluated before reading. */
+  policy?: ToolPermissionPolicy;
+}
+
+/**
+ * Creates a non-sandboxed Read tool with optional path anchoring and
+ * permission policy.
+ */
+export function createReadTool(opts?: ReadToolOptions) {
+  return tool()
+    .name(toolName)
+    .label(toolLabel)
+    .description(toolDescription)
+    .parameters(parametersSchema)
+    .checkPermissions(({ file_path }) => {
+      if (!isPathSafe(file_path)) {
+        return { decision: "deny" as const, reason: `Path "${file_path}" is not allowed` };
+      }
+      if (opts?.rootDir) {
+        try {
+          workspaceAnchor(file_path, opts.rootDir);
+        } catch (err) {
+          return {
+            decision: "deny" as const,
+            reason: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+      if (opts?.policy) {
+        return evaluatePolicy(opts.policy, "Read", file_path);
+      }
+      return "allow";
+    })
+    .execute(async ({ file_path, offset, limit }) => {
+      let raw: string;
+      try {
+        raw = await readFile(file_path, "utf-8");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error reading file: ${message}` }],
+          details: { error: message },
+        };
+      }
+
+      const allLines = raw.split("\n");
+      const totalLines = allLines.length;
+
+      if (raw === "") {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "<system-reminder>File exists but has empty contents.</system-reminder>",
+            },
+          ],
+          details: { totalLines: 0, lines: [] },
+        };
+      }
+
+      const maxLines = limit ?? DEFAULT_READ_LINES;
+
+      let startIndex: number;
+      if (offset === undefined || offset === null) {
+        startIndex = 0;
+      } else if (offset < 0) {
+        startIndex = Math.max(0, totalLines + offset);
+      } else {
+        startIndex = Math.max(0, offset - 1);
+      }
+
+      const selectedLines = allLines.slice(startIndex, startIndex + maxLines);
+
+      const formattedLines = selectedLines.map((line, i) => {
+        const lineNum = startIndex + i + 1;
+        const truncated =
+          line.length > MAX_LINE_LENGTH ? line.slice(0, MAX_LINE_LENGTH) + " [truncated]" : line;
+        return `${String(lineNum).padStart(6)}|${truncated}`;
+      });
+
+      const text = formattedLines.join("\n");
+
       return {
-        content: [{ type: "text" as const, text: `Error reading file: ${message}` }],
-        details: { error: message },
+        content: [{ type: "text" as const, text }],
+        details: {
+          totalLines,
+          startLine: startIndex + 1,
+          endLine: startIndex + selectedLines.length,
+          lines: selectedLines,
+        },
       };
-    }
+    })
+    .build();
+}
 
-    const allLines = raw.split("\n");
-    const totalLines = allLines.length;
-
-    if (raw === "") {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: "<system-reminder>File exists but has empty contents.</system-reminder>",
-          },
-        ],
-        details: { totalLines: 0, lines: [] },
-      };
-    }
-
-    const maxLines = limit ?? DEFAULT_READ_LINES;
-
-    let startIndex: number;
-    if (offset === undefined || offset === null) {
-      startIndex = 0;
-    } else if (offset < 0) {
-      startIndex = Math.max(0, totalLines + offset);
-    } else {
-      startIndex = Math.max(0, offset - 1);
-    }
-
-    const selectedLines = allLines.slice(startIndex, startIndex + maxLines);
-
-    const formattedLines = selectedLines.map((line, i) => {
-      const lineNum = startIndex + i + 1;
-      const truncated =
-        line.length > MAX_LINE_LENGTH ? line.slice(0, MAX_LINE_LENGTH) + " [truncated]" : line;
-      return `${String(lineNum).padStart(6)}|${truncated}`;
-    });
-
-    const text = formattedLines.join("\n");
-
-    return {
-      content: [{ type: "text" as const, text }],
-      details: {
-        totalLines,
-        startLine: startIndex + 1,
-        endLine: startIndex + selectedLines.length,
-        lines: selectedLines,
-      },
-    };
-  })
-  .build();
+/** Non-sandboxed Read tool with no path restrictions (backward-compatible singleton). */
+export const readTool = createReadTool();

--- a/packages/capabilities/src/tools/write.ts
+++ b/packages/capabilities/src/tools/write.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 The Agentrail Authors
  */
 
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
+import { evaluatePolicy, isPathSafe, workspaceAnchor } from "@/permissions/index.js";
 import { tool } from "@agentrail/core";
 import { Type } from "@sinclair/typebox";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -27,26 +29,62 @@ const parametersSchema = Type.Object({
   }),
 });
 
-export const writeTool = tool()
-  .name(toolName)
-  .label(toolLabel)
-  .description(toolDescription)
-  .parameters(parametersSchema)
-  .execute(async ({ file_path, contents }) => {
-    try {
-      await mkdir(dirname(file_path), { recursive: true });
-      await writeFile(file_path, contents, "utf-8");
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: "text" as const, text: `Error writing file: ${message}` }],
-        details: { error: message },
-      };
-    }
+/** Options for `createWriteTool`. */
+export interface WriteToolOptions {
+  /** When set, file paths must be anchored within this directory. */
+  rootDir?: string;
+  /** Active permission policy evaluated before writing. */
+  policy?: ToolPermissionPolicy;
+}
 
-    return {
-      content: [{ type: "text" as const, text: `Successfully wrote ${file_path}` }],
-      details: { file_path },
-    };
-  })
-  .build();
+/**
+ * Creates a non-sandboxed Write tool with optional path anchoring and
+ * permission policy.
+ */
+export function createWriteTool(opts?: WriteToolOptions) {
+  return tool()
+    .name(toolName)
+    .label(toolLabel)
+    .description(toolDescription)
+    .parameters(parametersSchema)
+    .checkPermissions(({ file_path }) => {
+      if (!isPathSafe(file_path)) {
+        return { decision: "deny" as const, reason: `Path "${file_path}" is not allowed` };
+      }
+      if (opts?.rootDir) {
+        try {
+          workspaceAnchor(file_path, opts.rootDir);
+        } catch (err) {
+          return {
+            decision: "deny" as const,
+            reason: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+      if (opts?.policy) {
+        return evaluatePolicy(opts.policy, "Write", file_path);
+      }
+      return "allow";
+    })
+    .execute(async ({ file_path, contents }) => {
+      try {
+        await mkdir(dirname(file_path), { recursive: true });
+        await writeFile(file_path, contents, "utf-8");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error writing file: ${message}` }],
+          details: { error: message },
+        };
+      }
+
+      return {
+        content: [{ type: "text" as const, text: `Successfully wrote ${file_path}` }],
+        details: { file_path },
+      };
+    })
+    .build();
+}
+
+/** Non-sandboxed Write tool with no path restrictions (backward-compatible singleton). */
+export const writeTool = createWriteTool();

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { KnowledgeManager } from "@/knowledge/index.js";
+import type { ToolPermissionPolicy } from "@/permissions/index.js";
 import type { SandboxManager } from "@/sandbox/index.js";
 import type { SkillManager } from "@/skills/index.js";
 import type { WaitHandleRegistry } from "@/tools/index.js";
@@ -48,6 +49,12 @@ export interface CapabilityBuildContext {
    * `depth` is 0 for the root agent, incremented by 1 for each sub-agent level.
    */
   tracing?: { chainId: string; depth: number };
+  /**
+   * Active permission policy for this session.  When present, non-sandboxed
+   * file and shell tools evaluate it via `checkPermissions` before executing.
+   * Sandboxed Bash also honours command-level allow/deny/ask rules.
+   */
+  permissionPolicy?: ToolPermissionPolicy;
 }
 
 /**

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -50,9 +50,9 @@ export interface CapabilityBuildContext {
    */
   tracing?: { chainId: string; depth: number };
   /**
-   * Active permission policy for this session.  When present, non-sandboxed
-   * file and shell tools evaluate it via `checkPermissions` before executing.
-   * Sandboxed Bash also honours command-level allow/deny/ask rules.
+   * Active permission policy for this session.  When present, all file and
+   * shell tools — both sandboxed (Bash, Read, Write, Edit) and non-sandboxed
+   * — evaluate it via `checkPermissions` before executing.
    */
   permissionPolicy?: ToolPermissionPolicy;
 }

--- a/packages/capabilities/test/permissions/path-safety.test.ts
+++ b/packages/capabilities/test/permissions/path-safety.test.ts
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DANGEROUS_FILES,
+  DANGEROUS_PATHS,
+  isPathSafe,
+  workspaceAnchor,
+} from "../../src/permissions/path-safety.js";
+
+// ─── isPathSafe tests ─────────────────────────────────────────────────────────
+
+describe("isPathSafe", () => {
+  it("allows regular workspace paths", () => {
+    expect(isPathSafe("/home/user/projects/myapp/src/index.ts")).toBe(true);
+    expect(isPathSafe("/tmp/workspace/file.txt")).toBe(true);
+  });
+
+  it("blocks paths inside DANGEROUS_PATHS", () => {
+    for (const dangerousDir of DANGEROUS_PATHS) {
+      expect(isPathSafe(path.join(dangerousDir, "some-file"))).toBe(false);
+    }
+  });
+
+  it("blocks dangerous file names regardless of directory", () => {
+    for (const dangerousFile of DANGEROUS_FILES) {
+      expect(isPathSafe(path.join("/workspace", dangerousFile))).toBe(false);
+    }
+  });
+
+  it("blocks paths inside ~/.ssh", () => {
+    const sshKey = path.join(os.homedir(), ".ssh", "id_rsa");
+    expect(isPathSafe(sshKey)).toBe(false);
+  });
+
+  it("blocks paths inside ~/.aws", () => {
+    const awsConfig = path.join(os.homedir(), ".aws", "credentials");
+    expect(isPathSafe(awsConfig)).toBe(false);
+  });
+
+  it("blocks .env files", () => {
+    expect(isPathSafe("/workspace/.env")).toBe(false);
+    expect(isPathSafe("/workspace/.env.local")).toBe(false);
+  });
+});
+
+// ─── workspaceAnchor tests ────────────────────────────────────────────────────
+
+describe("workspaceAnchor", () => {
+  const tmpDir = os.tmpdir();
+
+  it("allows paths inside the rootDir", () => {
+    expect(() => workspaceAnchor(path.join(tmpDir, "file.txt"), tmpDir)).not.toThrow();
+  });
+
+  it("allows deeply nested paths inside rootDir", () => {
+    expect(() =>
+      workspaceAnchor(path.join(tmpDir, "a", "b", "c", "file.txt"), tmpDir),
+    ).not.toThrow();
+  });
+
+  it("blocks paths outside rootDir", () => {
+    expect(() => workspaceAnchor("/etc/passwd", tmpDir)).toThrow(/outside the allowed root/i);
+  });
+
+  it("blocks path traversal attempts", () => {
+    const traversal = path.join(tmpDir, "..", "etc", "passwd");
+    expect(() => workspaceAnchor(traversal, tmpDir)).toThrow(/outside the allowed root/i);
+  });
+
+  it("blocks absolute paths that share rootDir prefix but escape it", () => {
+    // tmpDir itself is the root; a sibling directory should be rejected.
+    // Use /etc as an example of an existing path clearly outside tmpDir.
+    expect(() => workspaceAnchor("/etc/passwd", tmpDir)).toThrow(/outside the allowed root/i);
+  });
+});

--- a/packages/capabilities/test/permissions/path-safety.test.ts
+++ b/packages/capabilities/test/permissions/path-safety.test.ts
@@ -78,4 +78,17 @@ describe("workspaceAnchor", () => {
     // Use /etc as an example of an existing path clearly outside tmpDir.
     expect(() => workspaceAnchor("/etc/passwd", tmpDir)).toThrow(/outside the allowed root/i);
   });
+
+  it("allows a non-existent path whose nearest existing ancestor is inside rootDir", () => {
+    // deep/non/existent.txt does not exist but its ancestor chain leads back to tmpDir
+    const nonExistent = path.join(tmpDir, "deep", "non", "existent.txt");
+    expect(() => workspaceAnchor(nonExistent, tmpDir)).not.toThrow();
+  });
+
+  it("blocks a non-existent path whose nearest existing ancestor is outside rootDir", () => {
+    // /etc exists and is outside tmpDir; a non-existent child must still be blocked
+    expect(() => workspaceAnchor("/etc/nonexistent/file.txt", tmpDir)).toThrow(
+      /outside the allowed root/i,
+    );
+  });
 });

--- a/packages/capabilities/test/permissions/rule-engine.test.ts
+++ b/packages/capabilities/test/permissions/rule-engine.test.ts
@@ -54,6 +54,11 @@ describe("normalizeBashCommand", () => {
   it("trims leading whitespace before splitting", () => {
     expect(normalizeBashCommand("  git log --oneline")).toBe("git:log --oneline");
   });
+
+  it("handles tab between verb and args", () => {
+    expect(normalizeBashCommand("git\tstatus")).toBe("git:status");
+    expect(normalizeBashCommand("npm\tinstall lodash")).toBe("npm:install lodash");
+  });
 });
 
 // ─── Bash DSL end-to-end (pattern matching after normalization) ────────────────
@@ -195,5 +200,89 @@ describe("evaluatePolicy — allow and default", () => {
   it("unrelated tool names do not trigger rules", () => {
     const policy = makePolicy({ deny: parseRules(["Bash"]) });
     expect(evaluatePolicy(policy, "Read", "/workspace/file.ts")).toBe("allow");
+  });
+});
+
+// ─── contentMode tests ────────────────────────────────────────────────────────
+//
+// The behavioral difference between path and command mode only matters when
+// the pattern has content AFTER the wildcard (e.g. "git:*/index.ts").
+// For suffix-only wildcards like "git:*", both modes behave identically
+// because the regex is prefix-anchored (no trailing $) and [^/]* can match
+// up to the first / in the content.
+
+describe("matchPattern — contentMode", () => {
+  it("command mode: * matches across / in suffix-wildcard patterns", () => {
+    expect(matchPattern("git:*", "git:add src/main.ts", "command")).toBe(true);
+    expect(matchPattern("git:*", "git:status", "command")).toBe(true);
+    expect(matchPattern("npm:*", "npm:install lodash", "command")).toBe(true);
+  });
+
+  it("path mode: * stops at / when pattern has content after the wildcard", () => {
+    // "git:*/index.ts" — path mode cannot skip "components/" to find "index.ts"
+    expect(matchPattern("git:*/index.ts", "git:src/components/index.ts", "path")).toBe(false);
+    // same pattern in a single-segment path does work in path mode
+    expect(matchPattern("git:*/index.ts", "git:src/index.ts", "path")).toBe(true);
+  });
+
+  it("command mode: * matches across / even with content after the wildcard", () => {
+    // "git:*/index.ts" — command mode can match multi-segment paths
+    expect(matchPattern("git:*/index.ts", "git:src/components/index.ts", "command")).toBe(true);
+  });
+
+  it("command mode: ** still matches across / as well", () => {
+    expect(matchPattern("/workspace/**", "/workspace/src/index.ts", "command")).toBe(true);
+  });
+
+  it("unrelated tool prefix never matches regardless of mode", () => {
+    expect(matchPattern("git:*", "npm:install", "command")).toBe(false);
+    expect(matchPattern("git:*", "npm:install", "path")).toBe(false);
+  });
+});
+
+describe("evaluatePolicy — contentMode plumbing", () => {
+  it("Bash allow rule in command mode correctly matches content with path separator", () => {
+    const policy = makePolicy({ allow: parseRules(["Bash(git:*)"]) });
+    // git:add src/main.ts — suffix wildcard; both modes match, but command mode
+    // is the documented convention for Bash tools
+    expect(evaluatePolicy(policy, "Bash", "git:add src/main.ts", "command")).toBe("allow");
+  });
+
+  it("Bash deny rule in command mode fires for path-containing arguments", () => {
+    // "Bash(git:add *)" with a .ts file deeper in a directory tree
+    // path mode: "^git:add [^/]*" matches prefix "git:add src" → deny fires
+    // command mode: "^git:add .*" matches full string → deny fires
+    // Both deny, confirming plumbing is intact in command mode
+    const policy = makePolicy({ deny: parseRules(["Bash(git:add *)"]) });
+    expect(evaluatePolicy(policy, "Bash", "git:add src/main.ts", "command")).toBe("deny");
+  });
+});
+
+// ─── strict mode tests ────────────────────────────────────────────────────────
+
+describe("evaluatePolicy — strict mode", () => {
+  it("returns deny by default when no rule matches", () => {
+    const policy = makePolicy({ mode: "strict" });
+    expect(evaluatePolicy(policy, "Bash", "git status")).toBe("deny");
+    expect(evaluatePolicy(policy, "Read", "/workspace/file.ts")).toBe("deny");
+  });
+
+  it("explicit allow rule overrides the strict deny default", () => {
+    const policy = makePolicy({
+      mode: "strict",
+      allow: parseRules(["Bash(git:*)"]),
+    });
+    expect(evaluatePolicy(policy, "Bash", "git:status", "command")).toBe("allow");
+    expect(evaluatePolicy(policy, "Bash", "npm:install", "command")).toBe("deny");
+  });
+
+  it("deny rules still work in strict mode", () => {
+    const policy = makePolicy({
+      mode: "strict",
+      allow: parseRules(["Bash"]),
+      deny: parseRules(["Bash(rm:*)"]),
+    });
+    expect(evaluatePolicy(policy, "Bash", "rm:-rf /", "command")).toBe("deny");
+    expect(evaluatePolicy(policy, "Bash", "git:status", "command")).toBe("allow");
   });
 });

--- a/packages/capabilities/test/permissions/rule-engine.test.ts
+++ b/packages/capabilities/test/permissions/rule-engine.test.ts
@@ -6,8 +6,37 @@
 import { describe, expect, it } from "vitest";
 import { evaluatePolicy, matchPattern } from "../../src/permissions/rule-engine.js";
 import { parseRules } from "../../src/permissions/rule-parser.js";
-import { normalizeBashCommand } from "../../src/permissions/shell-safety.js";
+import { isDangerousCommand, normalizeBashCommand } from "../../src/permissions/shell-safety.js";
 import type { ToolPermissionPolicy } from "../../src/permissions/types.js";
+
+// ─── isDangerousCommand tests ─────────────────────────────────────────────────
+
+describe("isDangerousCommand", () => {
+  it("blocks rm -rf / variants", () => {
+    // combined flag block
+    expect(isDangerousCommand("rm -rf /")).toBe(true);
+    expect(isDangerousCommand("rm -fr /")).toBe(true);
+    expect(isDangerousCommand("rm -Rf /")).toBe(true);
+    expect(isDangerousCommand("rm -rrf /")).toBe(true);
+    // separate flag tokens
+    expect(isDangerousCommand("rm -r -f /")).toBe(true);
+    expect(isDangerousCommand("rm -f -r /")).toBe(true);
+  });
+
+  it("blocks fork bomb", () => {
+    expect(isDangerousCommand(":(){:|:&};:")).toBe(true);
+  });
+
+  it("blocks dd writing to block device", () => {
+    expect(isDangerousCommand("dd if=/dev/zero of=/dev/sda")).toBe(true);
+  });
+
+  it("does not block safe rm commands", () => {
+    expect(isDangerousCommand("rm -rf ./build")).toBe(false);
+    expect(isDangerousCommand("rm -rf /tmp/workdir")).toBe(false);
+    expect(isDangerousCommand("rm file.txt")).toBe(false);
+  });
+});
 
 // ─── normalizeBashCommand tests ───────────────────────────────────────────────
 

--- a/packages/capabilities/test/permissions/rule-engine.test.ts
+++ b/packages/capabilities/test/permissions/rule-engine.test.ts
@@ -6,7 +6,54 @@
 import { describe, expect, it } from "vitest";
 import { evaluatePolicy, matchPattern } from "../../src/permissions/rule-engine.js";
 import { parseRules } from "../../src/permissions/rule-parser.js";
+import { normalizeBashCommand } from "../../src/permissions/shell-safety.js";
 import type { ToolPermissionPolicy } from "../../src/permissions/types.js";
+
+// ─── normalizeBashCommand tests ───────────────────────────────────────────────
+
+describe("normalizeBashCommand", () => {
+  it("converts first space to colon", () => {
+    expect(normalizeBashCommand("git status")).toBe("git:status");
+    expect(normalizeBashCommand("npm install lodash")).toBe("npm:install lodash");
+    expect(normalizeBashCommand("rm -rf /")).toBe("rm:-rf /");
+  });
+
+  it("returns single-word commands unchanged", () => {
+    expect(normalizeBashCommand("ls")).toBe("ls");
+  });
+
+  it("trims leading whitespace before splitting", () => {
+    expect(normalizeBashCommand("  git log --oneline")).toBe("git:log --oneline");
+  });
+});
+
+// ─── Bash DSL end-to-end (pattern matching after normalization) ────────────────
+
+describe("Bash DSL — colon-convention patterns via normalizeBashCommand", () => {
+  it("git:* matches any git command after normalization", () => {
+    const policy: ToolPermissionPolicy = {
+      mode: "default",
+      allow: parseRules(["Bash(git:*)"]),
+      deny: [],
+      ask: [],
+    };
+    expect(evaluatePolicy(policy, "Bash", normalizeBashCommand("git status"))).toBe("allow");
+    expect(evaluatePolicy(policy, "Bash", normalizeBashCommand("git log --oneline"))).toBe("allow");
+    expect(evaluatePolicy(policy, "Bash", normalizeBashCommand("npm install"))).toBe("allow"); // default
+  });
+
+  it("rm:* deny rule blocks rm commands", () => {
+    const policy: ToolPermissionPolicy = {
+      mode: "default",
+      allow: [],
+      deny: parseRules(["Bash(rm:*)"]),
+      ask: [],
+    };
+    expect(evaluatePolicy(policy, "Bash", normalizeBashCommand("rm -rf /"))).toBe("deny");
+    expect(evaluatePolicy(policy, "Bash", normalizeBashCommand("rm file.txt"))).toBe("deny");
+    expect(evaluatePolicy(policy, "Bash", normalizeBashCommand("git status"))).toBe("allow");
+  });
+});
 
 // ─── matchPattern tests ────────────────────────────────────────────────────────
 

--- a/packages/capabilities/test/permissions/rule-engine.test.ts
+++ b/packages/capabilities/test/permissions/rule-engine.test.ts
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import { describe, expect, it } from "vitest";
+import { evaluatePolicy, matchPattern } from "../../src/permissions/rule-engine.js";
+import { parseRules } from "../../src/permissions/rule-parser.js";
+import type { ToolPermissionPolicy } from "../../src/permissions/types.js";
+
+// ─── matchPattern tests ────────────────────────────────────────────────────────
+
+describe("matchPattern", () => {
+  it("matches literal strings exactly", () => {
+    expect(matchPattern("git status", "git status")).toBe(true);
+    expect(matchPattern("git status", "git log")).toBe(false);
+  });
+
+  it("* matches any segment without path separator", () => {
+    expect(matchPattern("git *", "git status")).toBe(true);
+    expect(matchPattern("git *", "git log --oneline")).toBe(true);
+    expect(matchPattern("git *", "npm install")).toBe(false);
+  });
+
+  it("** matches across path separators", () => {
+    expect(matchPattern("/workspace/**", "/workspace/src/index.ts")).toBe(true);
+    expect(matchPattern("/workspace/**", "/workspace/README.md")).toBe(true);
+    expect(matchPattern("/workspace/**", "/home/user/file.ts")).toBe(false);
+  });
+
+  it("prefix anchor: pattern must match from the start", () => {
+    expect(matchPattern("git:*", "git:status")).toBe(true);
+    expect(matchPattern("git:*", "npm:install")).toBe(false);
+  });
+
+  it("bare tool name pattern (no wildcards) matches exact prefix", () => {
+    expect(matchPattern("Bash", "Bash")).toBe(true);
+    expect(matchPattern("Bash", "BashExtra")).toBe(true); // prefix match
+    expect(matchPattern("Write", "Bash")).toBe(false);
+  });
+});
+
+// ─── evaluatePolicy tests ─────────────────────────────────────────────────────
+
+function makePolicy(overrides: Partial<ToolPermissionPolicy> = {}): ToolPermissionPolicy {
+  return {
+    mode: "default",
+    allow: [],
+    deny: [],
+    ask: [],
+    ...overrides,
+  };
+}
+
+describe("evaluatePolicy — bypassPermissions", () => {
+  it("always returns allow regardless of rules", () => {
+    const policy = makePolicy({
+      mode: "bypassPermissions",
+      deny: parseRules(["Bash"]),
+    });
+    expect(evaluatePolicy(policy, "Bash", "rm -rf /")).toBe("allow");
+  });
+});
+
+describe("evaluatePolicy — deny priority", () => {
+  it("deny rule wins over ask and allow rules for the same tool", () => {
+    const policy = makePolicy({
+      deny: parseRules(["Bash(rm *)"]),
+      ask: parseRules(["Bash"]),
+      allow: parseRules(["Bash(git *)"]),
+    });
+    expect(evaluatePolicy(policy, "Bash", "rm -rf /")).toBe("deny");
+  });
+
+  it("deny bare tool name blocks all calls", () => {
+    const policy = makePolicy({ deny: parseRules(["Write"]) });
+    expect(evaluatePolicy(policy, "Write", "/tmp/foo.txt")).toBe("deny");
+  });
+});
+
+describe("evaluatePolicy — ask behavior", () => {
+  it("returns ask in default mode", () => {
+    const policy = makePolicy({ ask: parseRules(["Write"]) });
+    expect(evaluatePolicy(policy, "Write", "/tmp/foo.txt")).toBe("ask");
+  });
+
+  it("dontAsk mode: ask is demoted to deny", () => {
+    const policy = makePolicy({ mode: "dontAsk", ask: parseRules(["Write"]) });
+    expect(evaluatePolicy(policy, "Write", "/tmp/foo.txt")).toBe("deny");
+  });
+
+  it("acceptEdits mode: ask on Write is promoted to allow", () => {
+    const policy = makePolicy({ mode: "acceptEdits", ask: parseRules(["Write"]) });
+    expect(evaluatePolicy(policy, "Write", "/tmp/foo.txt")).toBe("allow");
+  });
+
+  it("acceptEdits mode: ask on Edit is promoted to allow", () => {
+    const policy = makePolicy({ mode: "acceptEdits", ask: parseRules(["Edit"]) });
+    expect(evaluatePolicy(policy, "Edit", "/tmp/foo.ts")).toBe("allow");
+  });
+
+  it("acceptEdits mode: ask on Bash is still ask", () => {
+    const policy = makePolicy({ mode: "acceptEdits", ask: parseRules(["Bash"]) });
+    expect(evaluatePolicy(policy, "Bash", "npm install")).toBe("ask");
+  });
+});
+
+describe("evaluatePolicy — allow and default", () => {
+  it("explicit allow rule returns allow", () => {
+    const policy = makePolicy({ allow: parseRules(["Bash(git:*)"]) });
+    expect(evaluatePolicy(policy, "Bash", "git status")).toBe("allow");
+  });
+
+  it("no matching rule returns allow (default policy is permissive)", () => {
+    const policy = makePolicy();
+    expect(evaluatePolicy(policy, "Read", "/workspace/src/index.ts")).toBe("allow");
+  });
+
+  it("unrelated tool names do not trigger rules", () => {
+    const policy = makePolicy({ deny: parseRules(["Bash"]) });
+    expect(evaluatePolicy(policy, "Read", "/workspace/file.ts")).toBe("allow");
+  });
+});

--- a/packages/capabilities/test/permissions/rule-parser.test.ts
+++ b/packages/capabilities/test/permissions/rule-parser.test.ts
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 The Agentrail Authors
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseRule, parseRules } from "../../src/permissions/rule-parser.js";
+
+describe("parseRule", () => {
+  it("parses a bare tool name", () => {
+    expect(parseRule("Bash")).toEqual({ toolName: "Bash" });
+    expect(parseRule("Write")).toEqual({ toolName: "Write" });
+  });
+
+  it("trims whitespace around the input", () => {
+    expect(parseRule("  Bash  ")).toEqual({ toolName: "Bash" });
+  });
+
+  it("parses tool name with pattern", () => {
+    expect(parseRule("Bash(git:*)")).toEqual({ toolName: "Bash", pattern: "git:*" });
+    expect(parseRule("Write(/workspace/**)")).toEqual({
+      toolName: "Write",
+      pattern: "/workspace/**",
+    });
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseRule("")).toThrow();
+    expect(() => parseRule("   ")).toThrow();
+  });
+
+  it("throws when closing parenthesis is missing", () => {
+    expect(() => parseRule("Bash(git:*")).toThrow(/missing closing/i);
+  });
+
+  it("throws when tool name is missing before parenthesis", () => {
+    expect(() => parseRule("(git:*)")).toThrow(/tool name is empty/i);
+  });
+
+  it("throws when pattern inside parentheses is empty", () => {
+    expect(() => parseRule("Bash()")).toThrow(/pattern inside parentheses is empty/i);
+  });
+});
+
+describe("parseRules", () => {
+  it("parses an array of rule strings", () => {
+    const rules = parseRules(["Bash", "Write(/tmp/*)"]);
+    expect(rules).toHaveLength(2);
+    expect(rules[0]).toEqual({ toolName: "Bash" });
+    expect(rules[1]).toEqual({ toolName: "Write", pattern: "/tmp/*" });
+  });
+
+  it("throws with index info when one rule is invalid", () => {
+    expect(() => parseRules(["Bash", ""])).toThrow(/index 1/i);
+  });
+});

--- a/packages/core/src/agent/agent-impl.ts
+++ b/packages/core/src/agent/agent-impl.ts
@@ -112,6 +112,7 @@ export class AgentImpl implements Agent {
       reactiveCompaction: options?.reactiveCompaction,
       getSteeringMessages: options?.getSteeringMessages,
       toolInterceptor: options?.toolInterceptor,
+      permissionApprovalHandler: options?.permissionApprovalHandler,
     });
 
     return this.createAgentStream(eventStream);

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -14,7 +14,7 @@ import type {
 } from "@/types/agent.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
 import type { RuntimeEvent, RuntimeTracingFields } from "@/types/result.types.js";
-import type { RuntimeTool, ToolInterceptor } from "@/types/tool.types.js";
+import type { PermissionApprovalHandler, RuntimeTool, ToolInterceptor } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
 import { randomUUID } from "node:crypto";
 
@@ -62,6 +62,8 @@ export interface AgentLoopConfig {
   reactiveCompaction?: ReactiveCompactionController;
   /** Optional pre/post interceptor invoked around each tool execution. */
   toolInterceptor?: ToolInterceptor;
+  /** Optional handler that converts an "ask" permission decision into a suspend-and-resume. */
+  permissionApprovalHandler?: PermissionApprovalHandler;
 }
 
 /** Runs the core agent loop from the first user turn until completion. */
@@ -261,6 +263,7 @@ async function runLoop(
           tracing,
           config.getSteeringMessages,
           config.toolInterceptor,
+          config.permissionApprovalHandler,
         );
         toolResults.push(...toolExecution.toolResults);
         steeringAfterTools = toolExecution.steeringMessages ?? null;

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -136,6 +136,50 @@ export async function executeToolCalls(
       }
     }
 
+    // ── Permission check (tool.checkPermissions) ──────────────────────────────
+    // Runs after the interceptor (so effectiveArgs reflects any rewrites) but
+    // before tool.validate and execute.  onAfterToolCall is NOT called for
+    // permission-denied executions.
+    if (tool.checkPermissions) {
+      let permDecision: import("@/types/tool.types.js").PermissionDecision;
+      try {
+        permDecision = await tool.checkPermissions(effectiveArgs);
+      } catch (e) {
+        permDecision = {
+          decision: "deny",
+          reason: e instanceof Error ? e.message : String(e),
+        };
+      }
+      const decision = typeof permDecision === "string" ? permDecision : permDecision.decision;
+      const permReason =
+        typeof permDecision === "object" && "reason" in permDecision
+          ? permDecision.reason
+          : undefined;
+
+      if (decision === "ask" || decision === "deny") {
+        if (decision === "ask") {
+          stream.push({
+            type: "permission_request",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            reason: permReason,
+            ...tracing,
+          });
+        }
+        rejectToolCall(
+          toolCall,
+          permReason ?? `Permission denied for tool "${toolCall.name}"`,
+          effectiveArgs,
+          rawArgs,
+          stream,
+          tracing,
+          results,
+        );
+        // onAfterToolCall is NOT called for permission-denied executions.
+        continue;
+      }
+    }
+
     // ── Business-logic validation (tool.validate) ─────────────────────────────
     // Runs on the final effectiveArgs (post-interceptor) so tool-level
     // preconditions cannot be bypassed by a before-hook rewrite.

--- a/packages/core/src/executor/tool-executor.ts
+++ b/packages/core/src/executor/tool-executor.ts
@@ -10,6 +10,7 @@ import type { TextContent, ToolCall } from "@/types/content.types.js";
 import type { AssistantMessage, Message, ToolResultMessage } from "@/types/message.types.js";
 import type { RuntimeEvent, RuntimeTracingFields } from "@/types/result.types.js";
 import type {
+  PermissionApprovalHandler,
   RuntimeTool,
   ToolInterceptor,
   ToolResult,
@@ -32,6 +33,7 @@ export async function executeToolCalls(
   tracing: RuntimeTracingFields,
   getSteeringMessages?: () => Promise<Message[]>,
   toolInterceptor?: ToolInterceptor,
+  permissionApprovalHandler?: PermissionApprovalHandler,
 ): Promise<ToolExecutionResult> {
   const toolCalls = assistantMessage.content.filter((c): c is ToolCall => c.type === "toolCall");
   const results: ToolResultMessage[] = [];
@@ -156,16 +158,70 @@ export async function executeToolCalls(
           ? permDecision.reason
           : undefined;
 
-      if (decision === "ask" || decision === "deny") {
-        if (decision === "ask") {
-          stream.push({
-            type: "permission_request",
-            toolCallId: toolCall.id,
-            toolName: toolCall.name,
-            reason: permReason,
-            ...tracing,
-          });
+      if (decision === "ask") {
+        stream.push({
+          type: "permission_request",
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          reason: permReason,
+          ...tracing,
+        });
+
+        if (permissionApprovalHandler) {
+          let approval: "approved" | "rejected";
+          try {
+            approval = await permissionApprovalHandler.requestApproval({
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              reason: permReason,
+              signal,
+            });
+          } catch {
+            approval = "rejected";
+          }
+
+          if (approval === "approved") {
+            stream.push({
+              type: "permission_resolved",
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              decision: "approved",
+              ...tracing,
+            });
+            // Continue to validation and execution below.
+          } else {
+            stream.push({
+              type: "permission_resolved",
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              decision: "rejected",
+              ...tracing,
+            });
+            rejectToolCall(
+              toolCall,
+              permReason ?? `Permission denied for tool "${toolCall.name}"`,
+              effectiveArgs,
+              rawArgs,
+              stream,
+              tracing,
+              results,
+            );
+            continue;
+          }
+        } else {
+          // No interactive handler — treat ask as deny.
+          rejectToolCall(
+            toolCall,
+            permReason ?? `Permission denied for tool "${toolCall.name}"`,
+            effectiveArgs,
+            rawArgs,
+            stream,
+            tracing,
+            results,
+          );
+          continue;
         }
+      } else if (decision === "deny") {
         rejectToolCall(
           toolCall,
           permReason ?? `Permission denied for tool "${toolCall.name}"`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export type {
   BeforeToolCallResult,
   ExtractToolDetails,
   ExtractToolParams,
+  PermissionDecision,
   RuntimeTool,
   ToolDefinition,
   ToolInterceptor,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export type {
   BeforeToolCallResult,
   ExtractToolDetails,
   ExtractToolParams,
+  PermissionApprovalHandler,
   PermissionDecision,
   RuntimeTool,
   ToolDefinition,

--- a/packages/core/src/tools/tool-builder.ts
+++ b/packages/core/src/tools/tool-builder.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  PermissionDecision,
   RuntimeTool,
   ToolResult,
   ToolSignalEvent,
@@ -43,6 +44,7 @@ interface ToolConfig<TParams, TDetails> {
   label?: string;
   description?: string;
   parameters?: TSchema;
+  checkPermissions?: (params: TParams) => Promise<PermissionDecision> | PermissionDecision;
   validate?: (
     params: TParams,
     ctx: ToolValidationContext,
@@ -87,6 +89,21 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
   }
 
   /**
+   * Registers an optional permission check invoked before `validate` and
+   * `execute`.
+   *
+   * The function receives the effective (post-interceptor) arguments and
+   * returns a `PermissionDecision`. See `RuntimeTool.checkPermissions` for
+   * full semantics.
+   */
+  checkPermissions(
+    fn: (params: TParams) => Promise<PermissionDecision> | PermissionDecision,
+  ): this {
+    this.config.checkPermissions = fn;
+    return this;
+  }
+
+  /**
    * Registers an optional business-logic precondition check.
    *
    * The function is called after schema validation and after any
@@ -124,6 +141,7 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
     const parameters = this.config.parameters ?? Type.Object({});
     const executeFn = this.config.execute;
     const validateFn = this.config.validate;
+    const checkPermFn = this.config.checkPermissions;
 
     const runtimeTool: RuntimeTool<TSchema, TDetails> = {
       name: this.config.name,
@@ -146,6 +164,12 @@ export class ToolBuilder<TParams = undefined, TDetails = unknown> {
         return executeFn(params as TParams, ctx);
       },
     };
+
+    if (checkPermFn) {
+      runtimeTool.checkPermissions = (
+        params: unknown,
+      ): Promise<PermissionDecision> | PermissionDecision => checkPermFn(params as TParams);
+    }
 
     if (validateFn) {
       runtimeTool.validate = (

--- a/packages/core/src/types/agent.types.ts
+++ b/packages/core/src/types/agent.types.ts
@@ -6,7 +6,7 @@
 import type { ToolCall, UserContent } from "@/types/content.types.js";
 import type { AssistantMessage, Message, StopReason } from "@/types/message.types.js";
 import type { RuntimeEvent } from "@/types/result.types.js";
-import type { ToolInterceptor } from "@/types/tool.types.js";
+import type { PermissionApprovalHandler, ToolInterceptor } from "@/types/tool.types.js";
 import type { Usage } from "@/types/usage.types.js";
 
 // ============================================================================
@@ -111,6 +111,19 @@ export interface AgentRunOptions {
    * incremented by 1 for each orchestration level.  Defaults to `0`.
    */
   readonly depth?: number;
+
+  /**
+   * Optional handler that converts an `"ask"` permission decision into an
+   * interactive suspend-and-resume instead of an immediate denial.
+   *
+   * When provided and a tool's `checkPermissions` returns `"ask"`, the
+   * executor emits a `permission_request` event then awaits the handler's
+   * `requestApproval()`.  Execution continues if the result is `"approved"`
+   * and is denied if the result is `"rejected"`.
+   *
+   * When absent, `"ask"` behaves identically to `"deny"`.
+   */
+  readonly permissionApprovalHandler?: PermissionApprovalHandler;
 }
 
 // ============================================================================

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -213,6 +213,17 @@ export type RuntimeEvent =
         readonly toolName: string;
         readonly reason?: string;
       }
+    /**
+     * Emitted after interactive approval: `decision` is `"approved"` when the
+     * user allowed the tool call, `"rejected"` when they denied it.
+     * Always follows a `permission_request` event with the same `toolCallId`.
+     */
+    | {
+        readonly type: "permission_resolved";
+        readonly toolCallId: string;
+        readonly toolName: string;
+        readonly decision: "approved" | "rejected";
+      }
     // ── New lifecycle events ─────────────────────────────────────────────────
     /** Emitted when context compaction runs during a streaming request. */
     | {

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -119,7 +119,8 @@ export interface RuntimeTracingFields {
 export type RuntimeEvent =
   // ── Session lifecycle ────────────────────────────────────────────────────
   /** Emitted once when the agent begins processing the user input. */
-  (| { readonly type: "session.start" }
+  (
+    | { readonly type: "session.start" }
     /** Emitted once after all turns complete. Contains the full message list and token usage. */
     | { readonly type: "session.end"; readonly messages: Message[]; readonly usage: Usage }
     // ── Turn lifecycle ───────────────────────────────────────────────────────
@@ -194,6 +195,23 @@ export type RuntimeEvent =
         readonly options?: string[];
         readonly multiple?: boolean;
         readonly custom?: boolean;
+      }
+    /**
+     * Emitted when a tool's `checkPermissions` returns `"ask"` or `"deny"`.
+     *
+     * - `"ask"` decisions emit this event and then block execution until an
+     *   interactive approval mechanism is provided by the host layer.
+     * - `"deny"` decisions do **not** emit this event; they produce a standard
+     *   error tool result directly.
+     *
+     * The event is always followed immediately by an error `ToolResult` that
+     * the model sees as the tool's response.
+     */
+    | {
+        readonly type: "permission_request";
+        readonly toolCallId: string;
+        readonly toolName: string;
+        readonly reason?: string;
       }
     // ── New lifecycle events ─────────────────────────────────────────────────
     /** Emitted when context compaction runs during a streaming request. */

--- a/packages/core/src/types/result.types.ts
+++ b/packages/core/src/types/result.types.ts
@@ -197,15 +197,24 @@ export type RuntimeEvent =
         readonly custom?: boolean;
       }
     /**
-     * Emitted when a tool's `checkPermissions` returns `"ask"` or `"deny"`.
+     * Emitted when a tool's `checkPermissions` returns `"ask"`.
      *
-     * - `"ask"` decisions emit this event and then block execution until an
-     *   interactive approval mechanism is provided by the host layer.
-     * - `"deny"` decisions do **not** emit this event; they produce a standard
-     *   error tool result directly.
+     * After emitting this event, the runtime **suspends** the tool call and
+     * waits for the host-supplied `PermissionApprovalHandler.requestApproval`
+     * to resolve. The handler may approve or reject the call:
      *
-     * The event is always followed immediately by an error `ToolResult` that
-     * the model sees as the tool's response.
+     * - `"approved"` — the tool proceeds normally; a `permission_resolved`
+     *   event with `decision: "approved"` is emitted next.
+     * - `"rejected"` (or the handler throws / the signal aborts) — the tool
+     *   call receives an error `ToolResult`; a `permission_resolved` event
+     *   with `decision: "rejected"` is emitted next.
+     *
+     * When no `PermissionApprovalHandler` is registered, `"ask"` falls back
+     * to immediate denial (same behaviour as `"deny"`), without emitting this
+     * event.
+     *
+     * `"deny"` decisions never emit this event; they always produce a standard
+     * error `ToolResult` directly.
      */
     | {
         readonly type: "permission_request";

--- a/packages/core/src/types/tool.types.ts
+++ b/packages/core/src/types/tool.types.ts
@@ -61,6 +61,22 @@ export type PermissionDecision =
   | "ask"
   | { readonly decision: "allow" | "deny" | "ask"; readonly reason?: string };
 
+/**
+ * Host-provided callback that resolves a `"ask"` permission decision
+ * interactively instead of denying it immediately.
+ *
+ * Implementations should suspend the call until the user approves or rejects,
+ * then resolve with `"approved"` or `"rejected"`.
+ */
+export interface PermissionApprovalHandler {
+  requestApproval(input: {
+    toolCallId: string;
+    toolName: string;
+    reason?: string;
+    signal?: AbortSignal;
+  }): Promise<"approved" | "rejected">;
+}
+
 /** Full runtime representation of an executable tool. */
 export interface RuntimeTool<
   TParameters extends TSchema = TSchema,

--- a/packages/core/src/types/tool.types.ts
+++ b/packages/core/src/types/tool.types.ts
@@ -43,6 +43,24 @@ export type ToolSignalEvent = {
   readonly custom?: boolean;
 };
 
+/**
+ * The outcome of a `checkPermissions` call.
+ *
+ * - `"allow"` — execution may proceed.
+ * - `"deny"` — execution is blocked; the model receives an error result.
+ * - `"ask"` — execution requires user approval; the executor emits a
+ *   `permission_request` RuntimeEvent and then denies the call until an
+ *   interactive approval mechanism is wired in by the host layer.
+ *
+ * The object form allows attaching an optional human-readable `reason` that
+ * is surfaced in the error result and the `permission_request` event.
+ */
+export type PermissionDecision =
+  | "allow"
+  | "deny"
+  | "ask"
+  | { readonly decision: "allow" | "deny" | "ask"; readonly reason?: string };
+
 /** Full runtime representation of an executable tool. */
 export interface RuntimeTool<
   TParameters extends TSchema = TSchema,
@@ -50,6 +68,21 @@ export interface RuntimeTool<
 > extends ToolDefinition<TParameters> {
   /** Human-readable label used in logs and developer tooling. */
   label: string;
+
+  /**
+   * Optional permission check invoked after `onBeforeToolCall` and before
+   * `validate`.
+   *
+   * The function receives the effective (post-interceptor) arguments and
+   * returns a `PermissionDecision`:
+   * - `"allow"` — proceed to `validate` / `execute`.
+   * - `"deny"` — block execution; model receives an error result.
+   * - `"ask"` — emit a `permission_request` RuntimeEvent then block
+   *   (non-interactive until the host wires up an approval mechanism).
+   *
+   * `onAfterToolCall` is **not** called for permission-denied executions.
+   */
+  checkPermissions?(params: unknown): Promise<PermissionDecision> | PermissionDecision;
 
   /**
    * Optional business-logic precondition check.

--- a/packages/core/src/types/tool.types.ts
+++ b/packages/core/src/types/tool.types.ts
@@ -48,9 +48,12 @@ export type ToolSignalEvent = {
  *
  * - `"allow"` — execution may proceed.
  * - `"deny"` — execution is blocked; the model receives an error result.
- * - `"ask"` — execution requires user approval; the executor emits a
- *   `permission_request` RuntimeEvent and then denies the call until an
- *   interactive approval mechanism is wired in by the host layer.
+ * - `"ask"` — execution requires user approval. When a
+ *   `PermissionApprovalHandler` is available, the executor emits a
+ *   `permission_request` RuntimeEvent and then **suspends** the tool call
+ *   until the handler resolves. The handler's response determines whether
+ *   execution proceeds (`"approved"`) or the call receives an error result
+ *   (`"rejected"`). Without a handler the call is denied immediately.
  *
  * The object form allows attaching an optional human-readable `reason` that
  * is surfaced in the error result and the `permission_request` event.

--- a/packages/core/test/tool-executor.test.ts
+++ b/packages/core/test/tool-executor.test.ts
@@ -503,3 +503,140 @@ describe("executeToolCalls — tool.validate()", () => {
     expect(receivedParams[0]).toEqual({ value: "MODIFIED" });
   });
 });
+
+// ─── checkPermissions tests ───────────────────────────────────────────────────
+
+describe("executeToolCalls — checkPermissions", () => {
+  let stream!: EventStream<RuntimeEvent, Message[]>;
+  let collectedEvents!: RuntimeEvent[];
+
+  beforeEach(() => {
+    ({ stream, events: collectedEvents } = makeStream());
+  });
+
+  it("allow: tool executes normally when checkPermissions returns 'allow'", async () => {
+    const tool: RuntimeTool = {
+      ...makeTool("cmd"),
+      checkPermissions: vi.fn().mockResolvedValue("allow"),
+    };
+
+    const msg = makeAssistantMessage([{ id: "p1", name: "cmd", arguments: { value: "safe" } }]);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      undefined,
+    );
+
+    expect(tool.execute).toHaveBeenCalledOnce();
+    expect(result.toolResults[0].isError).toBe(false);
+    expect(collectedEvents.find((e) => e.type === "permission_request")).toBeUndefined();
+  });
+
+  it("deny: tool is blocked, error result returned, no permission_request event", async () => {
+    const tool: RuntimeTool = {
+      ...makeTool("cmd"),
+      checkPermissions: vi
+        .fn()
+        .mockResolvedValue({ decision: "deny", reason: "blocked by policy" }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "p2", name: "cmd", arguments: { value: "danger" } }]);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      undefined,
+    );
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(result.toolResults[0].content[0]).toMatchObject({
+      type: "text",
+      text: "blocked by policy",
+    });
+    // deny must NOT emit permission_request
+    expect(collectedEvents.find((e) => e.type === "permission_request")).toBeUndefined();
+  });
+
+  it("ask: tool is blocked AND permission_request event is emitted", async () => {
+    const tool: RuntimeTool = {
+      ...makeTool("cmd"),
+      checkPermissions: vi.fn().mockResolvedValue({ decision: "ask", reason: "needs approval" }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "p3", name: "cmd", arguments: { value: "risky" } }]);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      undefined,
+    );
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+
+    const permEvent = collectedEvents.find((e) => e.type === "permission_request") as
+      | Extract<RuntimeEvent, { type: "permission_request" }>
+      | undefined;
+    expect(permEvent).toBeDefined();
+    expect(permEvent!.toolCallId).toBe("p3");
+    expect(permEvent!.toolName).toBe("cmd");
+    expect(permEvent!.reason).toBe("needs approval");
+  });
+
+  it("checkPermissions throws: execution is blocked with deny semantics", async () => {
+    const tool: RuntimeTool = {
+      ...makeTool("cmd"),
+      checkPermissions: vi.fn().mockRejectedValue(new Error("perm check exploded")),
+    };
+
+    const msg = makeAssistantMessage([{ id: "p4", name: "cmd", arguments: { value: "x" } }]);
+    const result = await executeToolCalls(
+      [tool],
+      msg,
+      undefined,
+      stream,
+      TEST_TRACING,
+      undefined,
+      undefined,
+    );
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(result.toolResults[0].isError).toBe(true);
+    expect(collectedEvents.find((e) => e.type === "permission_request")).toBeUndefined();
+  });
+
+  it("checkPermissions runs after onBeforeToolCall interceptor", async () => {
+    const receivedParams: unknown[] = [];
+    const tool: RuntimeTool = {
+      ...makeTool("cmd"),
+      checkPermissions: vi.fn().mockImplementation((params) => {
+        receivedParams.push(params);
+        return "allow";
+      }),
+    };
+
+    const interceptor: ToolInterceptor = {
+      onBeforeToolCall: vi
+        .fn()
+        .mockResolvedValue({ action: "allow", input: { value: "MODIFIED" } }),
+    };
+
+    const msg = makeAssistantMessage([{ id: "p5", name: "cmd", arguments: { value: "original" } }]);
+    await executeToolCalls([tool], msg, undefined, stream, TEST_TRACING, undefined, interceptor);
+
+    // checkPermissions should see the modified value from the interceptor
+    expect(receivedParams[0]).toEqual({ value: "MODIFIED" });
+    expect(tool.execute).toHaveBeenCalledOnce();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,17 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
+
   .:
     devDependencies:
-      "@changesets/changelog-github":
+      '@changesets/changelog-github':
         specifier: ^0.6.0
         version: 0.6.0
-      "@changesets/cli":
+      '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@22.19.15)
       concurrently:
@@ -37,26 +38,26 @@ importers:
 
   examples/deep-research:
     dependencies:
-      "@agentrail/app":
+      '@agentrail/app':
         specifier: workspace:*
         version: link:../../packages/app
-      "@agentrail/capabilities":
+      '@agentrail/capabilities':
         specifier: workspace:*
         version: link:../../packages/capabilities
-      "@agentrail/core":
+      '@agentrail/core':
         specifier: workspace:*
         version: link:../../packages/core
-      "@agentrail/deep-research":
+      '@agentrail/deep-research':
         specifier: workspace:*
         version: link:../../packages/deep-research
-      "@hono/node-server":
+      '@hono/node-server':
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.12)
       hono:
         specifier: ^4.12.12
         version: 4.12.12
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -68,26 +69,26 @@ importers:
 
   examples/playground-server:
     dependencies:
-      "@agentrail/app":
+      '@agentrail/app':
         specifier: workspace:*
         version: link:../../packages/app
-      "@agentrail/capabilities":
+      '@agentrail/capabilities':
         specifier: workspace:*
         version: link:../../packages/capabilities
-      "@agentrail/core":
+      '@agentrail/core':
         specifier: workspace:*
         version: link:../../packages/core
-      "@agentrail/deep-research":
+      '@agentrail/deep-research':
         specifier: workspace:*
         version: link:../../packages/deep-research
-      "@hono/node-server":
+      '@hono/node-server':
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.12)
       hono:
         specifier: ^4.12.12
         version: 4.12.12
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -99,10 +100,10 @@ importers:
 
   examples/playground-ui:
     dependencies:
-      "@agentrail/app":
+      '@agentrail/app':
         specifier: workspace:*
         version: link:../../packages/app
-      "@types/dompurify":
+      '@types/dompurify':
         specifier: ^3.0.5
         version: 3.2.0
       dompurify:
@@ -130,28 +131,31 @@ importers:
         specifier: ^0.18.5
         version: 0.18.5
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
-      "@types/react":
+      '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
-      "@types/react-dom":
+      '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
-      "@vitejs/plugin-react":
+      '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/app:
     dependencies:
-      "@agentrail/capabilities":
+      '@agentrail/capabilities':
         specifier: workspace:*
         version: link:../capabilities
-      "@agentrail/core":
+      '@agentrail/core':
         specifier: workspace:*
         version: link:../core
       hono:
@@ -161,7 +165,7 @@ importers:
         specifier: ^2.0.0
         version: 2.8.3
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -176,13 +180,13 @@ importers:
 
   packages/capabilities:
     dependencies:
-      "@agentrail/core":
+      '@agentrail/core':
         specifier: workspace:*
         version: link:../core
-      "@mozilla/readability":
+      '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
-      "@sinclair/typebox":
+      '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.49
       dockerode:
@@ -201,19 +205,19 @@ importers:
         specifier: ^7.2.1
         version: 7.2.4
     devDependencies:
-      "@types/dockerode":
+      '@types/dockerode':
         specifier: ^3.3.38
         version: 3.3.47
-      "@types/jsdom":
+      '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
-      "@types/tar-stream":
+      '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
-      "@types/turndown":
+      '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
       tsc-alias:
@@ -228,14 +232,14 @@ importers:
 
   packages/cli:
     dependencies:
-      "@agentrail/app":
+      '@agentrail/app':
         specifier: workspace:*
         version: link:../app
-      "@clack/prompts":
+      '@clack/prompts':
         specifier: ^0.9.1
         version: 0.9.1
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -253,17 +257,17 @@ importers:
 
   packages/core:
     dependencies:
-      "@anthropic-ai/sdk":
+      '@anthropic-ai/sdk':
         specifier: ^0.39.0
         version: 0.39.0
-      "@sinclair/typebox":
+      '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.49
       openai:
         specifier: ^4.0.0
         version: 4.104.0(ws@8.20.0)
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -278,27 +282,27 @@ importers:
 
   packages/create-agentrail-app:
     dependencies:
-      "@agentrail/cli":
+      '@agentrail/cli':
         specifier: workspace:*
         version: link:../cli
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
 
   packages/deep-research:
     dependencies:
-      "@agentrail/capabilities":
+      '@agentrail/capabilities':
         specifier: workspace:*
         version: link:../capabilities
-      "@agentrail/core":
+      '@agentrail/core':
         specifier: workspace:*
         version: link:../core
       hono:
         specifier: ^4.12.12
         version: 4.12.12
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -313,11 +317,11 @@ importers:
 
   packages/testing:
     dependencies:
-      "@agentrail/core":
+      '@agentrail/core':
         specifier: workspace:*
         version: link:../core
     devDependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
       tsc-alias:
@@ -334,1894 +338,1121 @@ importers:
         version: 2.1.9(@types/node@22.19.15)(jsdom@26.1.0)
 
 packages:
-  "@antfu/install-pkg@1.1.0":
-    resolution:
-      {
-        integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==,
-      }
 
-  "@anthropic-ai/sdk@0.39.0":
-    resolution:
-      {
-        integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==,
-      }
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  "@asamuzakjp/css-color@3.2.0":
-    resolution:
-      {
-        integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==,
-      }
+  '@anthropic-ai/sdk@0.39.0':
+    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
-  "@babel/code-frame@7.29.0":
-    resolution:
-      {
-        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  "@babel/compat-data@7.29.0":
-    resolution:
-      {
-        integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/core@7.29.0":
-    resolution:
-      {
-        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/generator@7.29.1":
-    resolution:
-      {
-        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-compilation-targets@7.28.6":
-    resolution:
-      {
-        integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-globals@7.28.0":
-    resolution:
-      {
-        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-module-imports@7.28.6":
-    resolution:
-      {
-        integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-module-transforms@7.28.6":
-    resolution:
-      {
-        integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      "@babel/core": ^7.0.0
+      '@babel/core': ^7.0.0
 
-  "@babel/helper-plugin-utils@7.28.6":
-    resolution:
-      {
-        integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      {
-        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-validator-identifier@7.28.5":
-    resolution:
-      {
-        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-validator-option@7.27.1":
-    resolution:
-      {
-        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helpers@7.29.2":
-    resolution:
-      {
-        integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/parser@7.29.2":
-    resolution:
-      {
-        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
-  "@babel/plugin-transform-react-jsx-self@7.27.1":
-    resolution:
-      {
-        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      '@babel/core': ^7.0.0-0
 
-  "@babel/plugin-transform-react-jsx-source@7.27.1":
-    resolution:
-      {
-        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      '@babel/core': ^7.0.0-0
 
-  "@babel/runtime@7.29.2":
-    resolution:
-      {
-        integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/template@7.28.6":
-    resolution:
-      {
-        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/traverse@7.29.0":
-    resolution:
-      {
-        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/types@7.29.0":
-    resolution:
-      {
-        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
-  "@balena/dockerignore@1.0.2":
-    resolution:
-      {
-        integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==,
-      }
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  "@braintree/sanitize-url@7.1.2":
-    resolution:
-      {
-        integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==,
-      }
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  "@changesets/apply-release-plan@7.1.0":
-    resolution:
-      {
-        integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==,
-      }
+  '@changesets/apply-release-plan@7.1.0':
+    resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
 
-  "@changesets/assemble-release-plan@6.0.9":
-    resolution:
-      {
-        integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==,
-      }
+  '@changesets/assemble-release-plan@6.0.9':
+    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
 
-  "@changesets/changelog-git@0.2.1":
-    resolution:
-      {
-        integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
-      }
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  "@changesets/changelog-github@0.6.0":
-    resolution:
-      {
-        integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==,
-      }
+  '@changesets/changelog-github@0.6.0':
+    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
 
-  "@changesets/cli@2.30.0":
-    resolution:
-      {
-        integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==,
-      }
+  '@changesets/cli@2.30.0':
+    resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
     hasBin: true
 
-  "@changesets/config@3.1.3":
-    resolution:
-      {
-        integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==,
-      }
+  '@changesets/config@3.1.3':
+    resolution: {integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==}
 
-  "@changesets/errors@0.2.0":
-    resolution:
-      {
-        integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==,
-      }
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
 
-  "@changesets/get-dependents-graph@2.1.3":
-    resolution:
-      {
-        integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==,
-      }
+  '@changesets/get-dependents-graph@2.1.3':
+    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
 
-  "@changesets/get-github-info@0.8.0":
-    resolution:
-      {
-        integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==,
-      }
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
-  "@changesets/get-release-plan@4.0.15":
-    resolution:
-      {
-        integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==,
-      }
+  '@changesets/get-release-plan@4.0.15':
+    resolution: {integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==}
 
-  "@changesets/get-version-range-type@0.4.0":
-    resolution:
-      {
-        integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==,
-      }
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
 
-  "@changesets/git@3.0.4":
-    resolution:
-      {
-        integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==,
-      }
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
 
-  "@changesets/logger@0.1.1":
-    resolution:
-      {
-        integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==,
-      }
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
 
-  "@changesets/parse@0.4.3":
-    resolution:
-      {
-        integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==,
-      }
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
 
-  "@changesets/pre@2.0.2":
-    resolution:
-      {
-        integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==,
-      }
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
 
-  "@changesets/read@0.6.7":
-    resolution:
-      {
-        integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==,
-      }
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
 
-  "@changesets/should-skip-package@0.1.2":
-    resolution:
-      {
-        integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==,
-      }
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
 
-  "@changesets/types@4.1.0":
-    resolution:
-      {
-        integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==,
-      }
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
 
-  "@changesets/types@6.1.0":
-    resolution:
-      {
-        integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==,
-      }
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
 
-  "@changesets/write@0.4.0":
-    resolution:
-      {
-        integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
-      }
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  "@chevrotain/cst-dts-gen@11.1.2":
-    resolution:
-      {
-        integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==,
-      }
+  '@chevrotain/cst-dts-gen@11.1.2':
+    resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
 
-  "@chevrotain/gast@11.1.2":
-    resolution:
-      {
-        integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==,
-      }
+  '@chevrotain/gast@11.1.2':
+    resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
 
-  "@chevrotain/regexp-to-ast@11.1.2":
-    resolution:
-      {
-        integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==,
-      }
+  '@chevrotain/regexp-to-ast@11.1.2':
+    resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
 
-  "@chevrotain/types@11.1.2":
-    resolution:
-      {
-        integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==,
-      }
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
-  "@chevrotain/utils@11.1.2":
-    resolution:
-      {
-        integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==,
-      }
+  '@chevrotain/utils@11.1.2':
+    resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
-  "@clack/core@0.4.1":
-    resolution:
-      {
-        integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==,
-      }
+  '@clack/core@0.4.1':
+    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
 
-  "@clack/prompts@0.9.1":
-    resolution:
-      {
-        integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==,
-      }
+  '@clack/prompts@0.9.1':
+    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
 
-  "@csstools/color-helpers@5.1.0":
-    resolution:
-      {
-        integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==,
-      }
-    engines: { node: ">=18" }
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
 
-  "@csstools/css-calc@2.1.4":
-    resolution:
-      {
-        integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==,
-      }
-    engines: { node: ">=18" }
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      "@csstools/css-parser-algorithms": ^3.0.5
-      "@csstools/css-tokenizer": ^3.0.4
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
-  "@csstools/css-color-parser@3.1.0":
-    resolution:
-      {
-        integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==,
-      }
-    engines: { node: ">=18" }
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      "@csstools/css-parser-algorithms": ^3.0.5
-      "@csstools/css-tokenizer": ^3.0.4
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
-  "@csstools/css-parser-algorithms@3.0.5":
-    resolution:
-      {
-        integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==,
-      }
-    engines: { node: ">=18" }
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      "@csstools/css-tokenizer": ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.4
 
-  "@csstools/css-tokenizer@3.0.4":
-    resolution:
-      {
-        integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==,
-      }
-    engines: { node: ">=18" }
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
-  "@esbuild/aix-ppc64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/aix-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/aix-ppc64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm@0.21.5":
-    resolution:
-      {
-        integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-arm@0.27.4":
-    resolution:
-      {
-        integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/android-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm@0.21.5":
-    resolution:
-      {
-        integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-arm@0.27.4":
-    resolution:
-      {
-        integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.21.5":
-    resolution:
-      {
-        integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.27.4":
-    resolution:
-      {
-        integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.21.5":
-    resolution:
-      {
-        integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.27.4":
-    resolution:
-      {
-        integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.21.5":
-    resolution:
-      {
-        integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.27.4":
-    resolution:
-      {
-        integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/linux-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/openharmony-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/sunos-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/sunos-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-arm64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.21.5":
-    resolution:
-      {
-        integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.27.4":
-    resolution:
-      {
-        integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
-      }
-    engines: { node: ">=12" }
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  "@esbuild/win32-x64@0.27.4":
-    resolution:
-      {
-        integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  "@grpc/grpc-js@1.14.3":
-    resolution:
-      {
-        integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==,
-      }
-    engines: { node: ">=12.10.0" }
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
 
-  "@grpc/proto-loader@0.7.15":
-    resolution:
-      {
-        integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==,
-      }
-    engines: { node: ">=6" }
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
     hasBin: true
 
-  "@grpc/proto-loader@0.8.0":
-    resolution:
-      {
-        integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==,
-      }
-    engines: { node: ">=6" }
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
     hasBin: true
 
-  "@hono/node-server@1.19.13":
-    resolution:
-      {
-        integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==,
-      }
-    engines: { node: ">=18.14.1" }
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
 
-  "@iconify/types@2.0.0":
-    resolution:
-      {
-        integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==,
-      }
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  "@iconify/utils@3.1.0":
-    resolution:
-      {
-        integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==,
-      }
+  '@iconify/utils@3.1.0':
+    resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
 
-  "@inquirer/external-editor@1.0.3":
-    resolution:
-      {
-        integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==,
-      }
-    engines: { node: ">=18" }
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      "@types/node": ">=18"
+      '@types/node': '>=18'
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
 
-  "@jridgewell/gen-mapping@0.3.13":
-    resolution:
-      {
-        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-      }
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  "@jridgewell/remapping@2.3.5":
-    resolution:
-      {
-        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-      }
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
-  "@jridgewell/resolve-uri@3.1.2":
-    resolution:
-      {
-        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
 
-  "@jridgewell/sourcemap-codec@1.5.5":
-    resolution:
-      {
-        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-      }
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  "@jridgewell/trace-mapping@0.3.31":
-    resolution:
-      {
-        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-      }
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  "@js-sdsl/ordered-map@4.4.2":
-    resolution:
-      {
-        integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==,
-      }
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  "@manypkg/find-root@1.1.0":
-    resolution:
-      {
-        integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==,
-      }
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
-  "@manypkg/get-packages@1.1.3":
-    resolution:
-      {
-        integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==,
-      }
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  "@mermaid-js/parser@1.0.1":
-    resolution:
-      {
-        integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==,
-      }
+  '@mermaid-js/parser@1.0.1':
+    resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  "@mixmark-io/domino@2.2.0":
-    resolution:
-      {
-        integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==,
-      }
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
-  "@mozilla/readability@0.6.0":
-    resolution:
-      {
-        integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
 
-  "@nodelib/fs.scandir@2.1.5":
-    resolution:
-      {
-        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
-      }
-    engines: { node: ">= 8" }
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
 
-  "@nodelib/fs.stat@2.0.5":
-    resolution:
-      {
-        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
-      }
-    engines: { node: ">= 8" }
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
 
-  "@nodelib/fs.walk@1.2.8":
-    resolution:
-      {
-        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
-      }
-    engines: { node: ">= 8" }
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
-  "@protobufjs/aspromise@1.1.2":
-    resolution:
-      {
-        integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
-      }
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
-  "@protobufjs/base64@1.1.2":
-    resolution:
-      {
-        integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
-      }
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  "@protobufjs/codegen@2.0.4":
-    resolution:
-      {
-        integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
-      }
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
 
-  "@protobufjs/eventemitter@1.1.0":
-    resolution:
-      {
-        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
-      }
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
-  "@protobufjs/fetch@1.1.0":
-    resolution:
-      {
-        integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==,
-      }
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
 
-  "@protobufjs/float@1.0.2":
-    resolution:
-      {
-        integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
-      }
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  "@protobufjs/inquire@1.1.0":
-    resolution:
-      {
-        integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
-      }
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
-  "@protobufjs/path@1.1.2":
-    resolution:
-      {
-        integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
-      }
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
-  "@protobufjs/pool@1.1.0":
-    resolution:
-      {
-        integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
-      }
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  "@protobufjs/utf8@1.1.0":
-    resolution:
-      {
-        integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
-      }
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  "@rolldown/pluginutils@1.0.0-beta.27":
-    resolution:
-      {
-        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
-      }
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  "@rollup/rollup-android-arm-eabi@4.60.0":
-    resolution:
-      {
-        integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==,
-      }
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==,
-      }
+  '@rollup/rollup-android-arm64@4.60.0':
+    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==,
-      }
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==,
-      }
+  '@rollup/rollup-darwin-x64@4.60.0':
+    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==,
-      }
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==,
-      }
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.60.0":
-    resolution:
-      {
-        integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==,
-      }
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.60.0":
-    resolution:
-      {
-        integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==,
-      }
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==,
-      }
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-musl@4.60.0":
-    resolution:
-      {
-        integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==,
-      }
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==,
-      }
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-musl@4.60.0":
-    resolution:
-      {
-        integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==,
-      }
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==,
-      }
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-musl@4.60.0":
-    resolution:
-      {
-        integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==,
-      }
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==,
-      }
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-musl@4.60.0":
-    resolution:
-      {
-        integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==,
-      }
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-s390x-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==,
-      }
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==,
-      }
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-musl@4.60.0":
-    resolution:
-      {
-        integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==,
-      }
+  '@rollup/rollup-linux-x64-musl@4.60.0':
+    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-openbsd-x64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==,
-      }
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
     cpu: [x64]
     os: [openbsd]
 
-  "@rollup/rollup-openharmony-arm64@4.60.0":
-    resolution:
-      {
-        integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==,
-      }
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.60.0":
-    resolution:
-      {
-        integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==,
-      }
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.60.0":
-    resolution:
-      {
-        integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==,
-      }
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.60.0":
-    resolution:
-      {
-        integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==,
-      }
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.60.0":
-    resolution:
-      {
-        integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==,
-      }
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
+    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
     cpu: [x64]
     os: [win32]
 
-  "@sinclair/typebox@0.34.49":
-    resolution:
-      {
-        integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==,
-      }
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
-  "@standard-schema/spec@1.1.0":
-    resolution:
-      {
-        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
-      }
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  "@types/babel__core@7.20.5":
-    resolution:
-      {
-        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
-      }
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
-  "@types/babel__generator@7.27.0":
-    resolution:
-      {
-        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
-      }
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
 
-  "@types/babel__template@7.4.4":
-    resolution:
-      {
-        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
-      }
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
-  "@types/babel__traverse@7.28.0":
-    resolution:
-      {
-        integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
-      }
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  "@types/chai@5.2.3":
-    resolution:
-      {
-        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-      }
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  "@types/d3-array@3.2.2":
-    resolution:
-      {
-        integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==,
-      }
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
-  "@types/d3-axis@3.0.6":
-    resolution:
-      {
-        integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==,
-      }
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
 
-  "@types/d3-brush@3.0.6":
-    resolution:
-      {
-        integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==,
-      }
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
 
-  "@types/d3-chord@3.0.6":
-    resolution:
-      {
-        integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==,
-      }
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
 
-  "@types/d3-color@3.1.3":
-    resolution:
-      {
-        integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==,
-      }
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
-  "@types/d3-contour@3.0.6":
-    resolution:
-      {
-        integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==,
-      }
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
 
-  "@types/d3-delaunay@6.0.4":
-    resolution:
-      {
-        integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==,
-      }
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
 
-  "@types/d3-dispatch@3.0.7":
-    resolution:
-      {
-        integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==,
-      }
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
 
-  "@types/d3-drag@3.0.7":
-    resolution:
-      {
-        integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==,
-      }
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
-  "@types/d3-dsv@3.0.7":
-    resolution:
-      {
-        integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==,
-      }
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
 
-  "@types/d3-ease@3.0.2":
-    resolution:
-      {
-        integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==,
-      }
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
-  "@types/d3-fetch@3.0.7":
-    resolution:
-      {
-        integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==,
-      }
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
 
-  "@types/d3-force@3.0.10":
-    resolution:
-      {
-        integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==,
-      }
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
 
-  "@types/d3-format@3.0.4":
-    resolution:
-      {
-        integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==,
-      }
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
 
-  "@types/d3-geo@3.1.0":
-    resolution:
-      {
-        integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==,
-      }
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
 
-  "@types/d3-hierarchy@3.1.7":
-    resolution:
-      {
-        integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==,
-      }
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
-  "@types/d3-interpolate@3.0.4":
-    resolution:
-      {
-        integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==,
-      }
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
-  "@types/d3-path@3.1.1":
-    resolution:
-      {
-        integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==,
-      }
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
 
-  "@types/d3-polygon@3.0.2":
-    resolution:
-      {
-        integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==,
-      }
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
 
-  "@types/d3-quadtree@3.0.6":
-    resolution:
-      {
-        integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==,
-      }
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
 
-  "@types/d3-random@3.0.3":
-    resolution:
-      {
-        integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==,
-      }
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
 
-  "@types/d3-scale-chromatic@3.1.0":
-    resolution:
-      {
-        integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==,
-      }
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
 
-  "@types/d3-scale@4.0.9":
-    resolution:
-      {
-        integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==,
-      }
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
-  "@types/d3-selection@3.0.11":
-    resolution:
-      {
-        integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==,
-      }
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
 
-  "@types/d3-shape@3.1.8":
-    resolution:
-      {
-        integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==,
-      }
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
-  "@types/d3-time-format@4.0.3":
-    resolution:
-      {
-        integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==,
-      }
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
 
-  "@types/d3-time@3.0.4":
-    resolution:
-      {
-        integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==,
-      }
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
-  "@types/d3-timer@3.0.2":
-    resolution:
-      {
-        integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==,
-      }
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
-  "@types/d3-transition@3.0.9":
-    resolution:
-      {
-        integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==,
-      }
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
 
-  "@types/d3-zoom@3.0.8":
-    resolution:
-      {
-        integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==,
-      }
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
-  "@types/d3@7.4.3":
-    resolution:
-      {
-        integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==,
-      }
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
-  "@types/debug@4.1.13":
-    resolution:
-      {
-        integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
-      }
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
-  "@types/deep-eql@4.0.2":
-    resolution:
-      {
-        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-      }
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  "@types/docker-modem@3.0.6":
-    resolution:
-      {
-        integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==,
-      }
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
-  "@types/dockerode@3.3.47":
-    resolution:
-      {
-        integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==,
-      }
+  '@types/dockerode@3.3.47':
+    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
 
-  "@types/dompurify@3.2.0":
-    resolution:
-      {
-        integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==,
-      }
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
 
-  "@types/estree-jsx@1.0.5":
-    resolution:
-      {
-        integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
-      }
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
-  "@types/estree@1.0.8":
-    resolution:
-      {
-        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
-      }
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  "@types/geojson@7946.0.16":
-    resolution:
-      {
-        integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==,
-      }
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
-  "@types/hast@3.0.4":
-    resolution:
-      {
-        integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
-      }
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  "@types/jsdom@21.1.7":
-    resolution:
-      {
-        integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==,
-      }
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
-  "@types/mdast@4.0.4":
-    resolution:
-      {
-        integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
-      }
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
-  "@types/ms@2.1.0":
-    resolution:
-      {
-        integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
-      }
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  "@types/node-fetch@2.6.13":
-    resolution:
-      {
-        integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==,
-      }
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  "@types/node@12.20.55":
-    resolution:
-      {
-        integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==,
-      }
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  "@types/node@18.19.130":
-    resolution:
-      {
-        integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==,
-      }
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  "@types/node@22.19.15":
-    resolution:
-      {
-        integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==,
-      }
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
-  "@types/react-dom@19.2.3":
-    resolution:
-      {
-        integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
-      }
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      "@types/react": ^19.2.0
+      '@types/react': ^19.2.0
 
-  "@types/react@19.2.14":
-    resolution:
-      {
-        integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
-      }
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  "@types/ssh2@1.15.5":
-    resolution:
-      {
-        integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==,
-      }
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
-  "@types/tar-stream@3.1.4":
-    resolution:
-      {
-        integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==,
-      }
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
 
-  "@types/tough-cookie@4.0.5":
-    resolution:
-      {
-        integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==,
-      }
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
-  "@types/trusted-types@2.0.7":
-    resolution:
-      {
-        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
-      }
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  "@types/turndown@5.0.6":
-    resolution:
-      {
-        integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==,
-      }
+  '@types/turndown@5.0.6':
+    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
-  "@types/unist@2.0.11":
-    resolution:
-      {
-        integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==,
-      }
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  "@types/unist@3.0.3":
-    resolution:
-      {
-        integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
-      }
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  "@ungap/structured-clone@1.3.0":
-    resolution:
-      {
-        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
-      }
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  "@upsetjs/venn.js@2.0.0":
-    resolution:
-      {
-        integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==,
-      }
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
-  "@vitejs/plugin-react@4.7.0":
-    resolution:
-      {
-        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
-      }
-    engines: { node: ^14.18.0 || >=16.0.0 }
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  "@vitest/expect@2.1.9":
-    resolution:
-      {
-        integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==,
-      }
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
-  "@vitest/expect@4.1.3":
-    resolution:
-      {
-        integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==,
-      }
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
 
-  "@vitest/mocker@2.1.9":
-    resolution:
-      {
-        integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==,
-      }
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0
@@ -2231,11 +1462,8 @@ packages:
       vite:
         optional: true
 
-  "@vitest/mocker@4.1.3":
-    resolution:
-      {
-        integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==,
-      }
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2245,250 +1473,145 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@2.1.9":
-    resolution:
-      {
-        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
-      }
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  "@vitest/pretty-format@4.1.3":
-    resolution:
-      {
-        integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==,
-      }
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
 
-  "@vitest/runner@2.1.9":
-    resolution:
-      {
-        integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==,
-      }
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
-  "@vitest/runner@4.1.3":
-    resolution:
-      {
-        integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==,
-      }
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
 
-  "@vitest/snapshot@2.1.9":
-    resolution:
-      {
-        integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==,
-      }
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
-  "@vitest/snapshot@4.1.3":
-    resolution:
-      {
-        integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==,
-      }
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
 
-  "@vitest/spy@2.1.9":
-    resolution:
-      {
-        integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==,
-      }
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
-  "@vitest/spy@4.1.3":
-    resolution:
-      {
-        integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==,
-      }
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
 
-  "@vitest/utils@2.1.9":
-    resolution:
-      {
-        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
-      }
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
-  "@vitest/utils@4.1.3":
-    resolution:
-      {
-        integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==,
-      }
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
-  "@xmldom/xmldom@0.8.11":
-    resolution:
-      {
-        integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==,
-      }
-    engines: { node: ">=10.0.0" }
+  '@xmldom/xmldom@0.8.11':
+    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+    engines: {node: '>=10.0.0'}
 
   abort-controller@3.0.0:
-    resolution:
-      {
-        integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==,
-      }
-    engines: { node: ">=6.5" }
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
 
   accepts@1.3.8:
-    resolution:
-      {
-        integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
 
   acorn@8.16.0:
-    resolution:
-      {
-        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
-      }
-    engines: { node: ">=0.4.0" }
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
     hasBin: true
 
   adler-32@1.3.1:
-    resolution:
-      {
-        integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
 
   agent-base@7.1.4:
-    resolution:
-      {
-        integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   agentkeepalive@4.6.0:
-    resolution:
-      {
-        integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==,
-      }
-    engines: { node: ">= 8.0.0" }
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ansi-colors@4.1.3:
-    resolution:
-      {
-        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
-    resolution:
-      {
-        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-styles@4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   anymatch@3.1.3:
-    resolution:
-      {
-        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
 
   argparse@1.0.10:
-    resolution:
-      {
-        integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
-      }
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
-    resolution:
-      {
-        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-      }
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   array-flatten@1.1.1:
-    resolution:
-      {
-        integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==,
-      }
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-union@2.1.0:
-    resolution:
-      {
-        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   asn1@0.2.6:
-    resolution:
-      {
-        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==,
-      }
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assertion-error@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
-    resolution:
-      {
-        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
-      }
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   b4a@1.8.0:
-    resolution:
-      {
-        integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==,
-      }
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
     peerDependencies:
-      react-native-b4a: "*"
+      react-native-b4a: '*'
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
 
   bail@2.0.2:
-    resolution:
-      {
-        integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
-      }
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   bare-events@2.8.2:
-    resolution:
-      {
-        integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==,
-      }
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
-      bare-abort-controller: "*"
+      bare-abort-controller: '*'
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
 
   bare-fs@4.5.6:
-    resolution:
-      {
-        integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==,
-      }
-    engines: { bare: ">=1.16.0" }
+    resolution: {integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==}
+    engines: {bare: '>=1.16.0'}
     peerDependencies:
-      bare-buffer: "*"
+      bare-buffer: '*'
     peerDependenciesMeta:
       bare-buffer:
         optional: true
 
   bare-os@3.8.6:
-    resolution:
-      {
-        integrity: sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==,
-      }
-    engines: { bare: ">=1.14.0" }
+    resolution: {integrity: sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==}
+    engines: {bare: '>=1.14.0'}
 
   bare-path@3.0.0:
-    resolution:
-      {
-        integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==,
-      }
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
 
   bare-stream@2.11.0:
-    resolution:
-      {
-        integrity: sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==,
-      }
+    resolution: {integrity: sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==}
     peerDependencies:
-      bare-abort-controller: "*"
-      bare-buffer: "*"
-      bare-events: "*"
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
@@ -2498,1039 +1621,583 @@ packages:
         optional: true
 
   bare-url@2.4.0:
-    resolution:
-      {
-        integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==,
-      }
+    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
   base64-js@1.5.1:
-    resolution:
-      {
-        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
-      }
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.12:
-    resolution:
-      {
-        integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==,
-      }
-    engines: { node: ">=6.0.0" }
+    resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   bcrypt-pbkdf@1.0.2:
-    resolution:
-      {
-        integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==,
-      }
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-path-resolve@1.0.0:
-    resolution:
-      {
-        integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
 
   binary-extensions@2.3.0:
-    resolution:
-      {
-        integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   bl@4.1.0:
-    resolution:
-      {
-        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
-      }
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   bluebird@3.4.7:
-    resolution:
-      {
-        integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==,
-      }
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   body-parser@1.20.4:
-    resolution:
-      {
-        integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==,
-      }
-    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   braces@3.0.3:
-    resolution:
-      {
-        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   browserslist@4.28.1:
-    resolution:
-      {
-        integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
   buffer@5.7.1:
-    resolution:
-      {
-        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
-      }
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buildcheck@0.0.7:
-    resolution:
-      {
-        integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==,
-      }
-    engines: { node: ">=10.0.0" }
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bytes@3.1.2:
-    resolution:
-      {
-        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
-    resolution:
-      {
-        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
-    resolution:
-      {
-        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
-    resolution:
-      {
-        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001781:
-    resolution:
-      {
-        integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==,
-      }
+    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
   ccount@2.0.1:
-    resolution:
-      {
-        integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
-      }
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   cfb@1.2.2:
-    resolution:
-      {
-        integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
 
   chai@5.3.3:
-    resolution:
-      {
-        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chai@6.2.2:
-    resolution:
-      {
-        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   character-entities-html4@2.1.0:
-    resolution:
-      {
-        integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
-      }
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
   character-entities-legacy@3.0.0:
-    resolution:
-      {
-        integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
-      }
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   character-entities@2.0.2:
-    resolution:
-      {
-        integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
-      }
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   character-reference-invalid@2.0.1:
-    resolution:
-      {
-        integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
-      }
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
-    resolution:
-      {
-        integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
-      }
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
   check-error@2.1.3:
-    resolution:
-      {
-        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
-      }
-    engines: { node: ">= 16" }
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.3.1:
-    resolution:
-      {
-        integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==,
-      }
+    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
     peerDependencies:
       chevrotain: ^11.0.0
 
   chevrotain@11.1.2:
-    resolution:
-      {
-        integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==,
-      }
+    resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
 
   chokidar@3.6.0:
-    resolution:
-      {
-        integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
-      }
-    engines: { node: ">= 8.10.0" }
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
 
   chownr@1.1.4:
-    resolution:
-      {
-        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
-      }
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   cliui@8.0.1:
-    resolution:
-      {
-        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   codepage@1.15.0:
-    resolution:
-      {
-        integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-      }
-    engines: { node: ">=7.0.0" }
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-      }
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   combined-stream@1.0.8:
-    resolution:
-      {
-        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
-    resolution:
-      {
-        integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
-      }
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@7.2.0:
-    resolution:
-      {
-        integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==,
-      }
-    engines: { node: ">= 10" }
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
 
   commander@8.3.0:
-    resolution:
-      {
-        integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==,
-      }
-    engines: { node: ">= 12" }
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commander@9.5.0:
-    resolution:
-      {
-        integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==,
-      }
-    engines: { node: ^12.20.0 || >=14 }
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   concurrently@9.2.1:
-    resolution:
-      {
-        integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
     hasBin: true
 
   confbox@0.1.8:
-    resolution:
-      {
-        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
-      }
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   content-disposition@0.5.4:
-    resolution:
-      {
-        integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
 
   content-type@1.0.5:
-    resolution:
-      {
-        integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
 
   convert-source-map@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-      }
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.0.7:
-    resolution:
-      {
-        integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==,
-      }
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie@0.7.2:
-    resolution:
-      {
-        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
-    resolution:
-      {
-        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
-      }
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cose-base@1.0.3:
-    resolution:
-      {
-        integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==,
-      }
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
 
   cose-base@2.2.0:
-    resolution:
-      {
-        integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==,
-      }
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cpu-features@0.0.10:
-    resolution:
-      {
-        integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==,
-      }
-    engines: { node: ">=10.0.0" }
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
-    resolution:
-      {
-        integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
     hasBin: true
 
   cross-spawn@7.0.6:
-    resolution:
-      {
-        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   cssstyle@4.6.0:
-    resolution:
-      {
-        integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
-    resolution:
-      {
-        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
-      }
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   cytoscape-cose-bilkent@4.1.0:
-    resolution:
-      {
-        integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==,
-      }
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
     peerDependencies:
       cytoscape: ^3.2.0
 
   cytoscape-fcose@2.2.0:
-    resolution:
-      {
-        integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==,
-      }
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
     peerDependencies:
       cytoscape: ^3.2.0
 
   cytoscape@3.33.1:
-    resolution:
-      {
-        integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==,
-      }
-    engines: { node: ">=0.10" }
+    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+    engines: {node: '>=0.10'}
 
   d3-array@2.12.1:
-    resolution:
-      {
-        integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==,
-      }
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
 
   d3-array@3.2.4:
-    resolution:
-      {
-        integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
 
   d3-axis@3.0.0:
-    resolution:
-      {
-        integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
 
   d3-brush@3.0.0:
-    resolution:
-      {
-        integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
 
   d3-chord@3.0.1:
-    resolution:
-      {
-        integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
 
   d3-color@3.1.0:
-    resolution:
-      {
-        integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
 
   d3-contour@4.0.2:
-    resolution:
-      {
-        integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
 
   d3-delaunay@6.0.4:
-    resolution:
-      {
-        integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
 
   d3-dispatch@3.0.1:
-    resolution:
-      {
-        integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
 
   d3-drag@3.0.0:
-    resolution:
-      {
-        integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
 
   d3-dsv@3.0.1:
-    resolution:
-      {
-        integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
     hasBin: true
 
   d3-ease@3.0.1:
-    resolution:
-      {
-        integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
 
   d3-fetch@3.0.1:
-    resolution:
-      {
-        integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
 
   d3-force@3.0.0:
-    resolution:
-      {
-        integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
 
   d3-format@3.1.2:
-    resolution:
-      {
-        integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
 
   d3-geo@3.1.1:
-    resolution:
-      {
-        integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
 
   d3-hierarchy@3.1.2:
-    resolution:
-      {
-        integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
 
   d3-interpolate@3.0.1:
-    resolution:
-      {
-        integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
 
   d3-path@1.0.9:
-    resolution:
-      {
-        integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==,
-      }
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
   d3-path@3.1.0:
-    resolution:
-      {
-        integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
 
   d3-polygon@3.0.1:
-    resolution:
-      {
-        integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
 
   d3-quadtree@3.0.1:
-    resolution:
-      {
-        integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
 
   d3-random@3.0.1:
-    resolution:
-      {
-        integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
 
   d3-sankey@0.12.3:
-    resolution:
-      {
-        integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==,
-      }
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
 
   d3-scale-chromatic@3.1.0:
-    resolution:
-      {
-        integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
 
   d3-scale@4.0.2:
-    resolution:
-      {
-        integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
 
   d3-selection@3.0.0:
-    resolution:
-      {
-        integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
 
   d3-shape@1.3.7:
-    resolution:
-      {
-        integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==,
-      }
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
 
   d3-shape@3.2.0:
-    resolution:
-      {
-        integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
 
   d3-time-format@4.1.0:
-    resolution:
-      {
-        integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
 
   d3-time@3.1.0:
-    resolution:
-      {
-        integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
 
   d3-timer@3.0.1:
-    resolution:
-      {
-        integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   d3-transition@3.0.1:
-    resolution:
-      {
-        integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
     peerDependencies:
       d3-selection: 2 - 3
 
   d3-zoom@3.0.0:
-    resolution:
-      {
-        integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   d3@7.9.0:
-    resolution:
-      {
-        integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
 
   dagre-d3-es@7.0.14:
-    resolution:
-      {
-        integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==,
-      }
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   data-urls@5.0.0:
-    resolution:
-      {
-        integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   dataloader@1.4.0:
-    resolution:
-      {
-        integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
-      }
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
   dayjs@1.11.20:
-    resolution:
-      {
-        integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==,
-      }
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@2.6.9:
-    resolution:
-      {
-        integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
-      }
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
-      supports-color: "*"
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   debug@4.4.3:
-    resolution:
-      {
-        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-      }
-    engines: { node: ">=6.0" }
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
     peerDependencies:
-      supports-color: "*"
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   decimal.js@10.6.0:
-    resolution:
-      {
-        integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
-      }
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
-    resolution:
-      {
-        integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
-      }
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   deep-eql@5.0.2:
-    resolution:
-      {
-        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   delaunator@5.1.0:
-    resolution:
-      {
-        integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==,
-      }
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
-    resolution:
-      {
-        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
-      }
-    engines: { node: ">=0.4.0" }
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
-    resolution:
-      {
-        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
-    resolution:
-      {
-        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
-    resolution:
-      {
-        integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==,
-      }
-    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-indent@6.1.0:
-    resolution:
-      {
-        integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
 
   devlop@1.1.0:
-    resolution:
-      {
-        integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
-      }
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dingbat-to-unicode@1.0.1:
-    resolution:
-      {
-        integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==,
-      }
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
 
   dir-glob@3.0.1:
-    resolution:
-      {
-        integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
 
   docker-modem@5.0.7:
-    resolution:
-      {
-        integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==,
-      }
-    engines: { node: ">= 8.0" }
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
 
   dockerode@4.0.10:
-    resolution:
-      {
-        integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==,
-      }
-    engines: { node: ">= 8.0" }
+    resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
+    engines: {node: '>= 8.0'}
 
   dompurify@3.3.3:
-    resolution:
-      {
-        integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==,
-      }
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dotenv@8.6.0:
-    resolution:
-      {
-        integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   duck@0.1.12:
-    resolution:
-      {
-        integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==,
-      }
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   dunder-proto@1.0.1:
-    resolution:
-      {
-        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   ee-first@1.1.1:
-    resolution:
-      {
-        integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
-      }
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.328:
-    resolution:
-      {
-        integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==,
-      }
+    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
   emoji-regex@8.0.0:
-    resolution:
-      {
-        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
-      }
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encodeurl@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
-    resolution:
-      {
-        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
-      }
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
-    resolution:
-      {
-        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   entities@6.0.1:
-    resolution:
-      {
-        integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
-      }
-    engines: { node: ">=0.12" }
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
-    resolution:
-      {
-        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
-    resolution:
-      {
-        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   es-module-lexer@1.7.0:
-    resolution:
-      {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
-      }
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
-    resolution:
-      {
-        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
-      }
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
-    resolution:
-      {
-        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
-    resolution:
-      {
-        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
-    resolution:
-      {
-        integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
     hasBin: true
 
   esbuild@0.25.12:
-    resolution:
-      {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.27.4:
-    resolution:
-      {
-        integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
-    resolution:
-      {
-        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
-    resolution:
-      {
-        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
-      }
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@5.0.0:
-    resolution:
-      {
-        integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   esprima@4.0.1:
-    resolution:
-      {
-        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
     hasBin: true
 
   estree-util-is-identifier-name@3.0.0:
-    resolution:
-      {
-        integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
-      }
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   estree-walker@3.0.3:
-    resolution:
-      {
-        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-      }
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
-    resolution:
-      {
-        integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   event-target-shim@5.0.1:
-    resolution:
-      {
-        integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
 
   events-universal@1.0.1:
-    resolution:
-      {
-        integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==,
-      }
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   expect-type@1.3.0:
-    resolution:
-      {
-        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
-    resolution:
-      {
-        integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==,
-      }
-    engines: { node: ">= 0.10.0" }
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
 
   extend@3.0.2:
-    resolution:
-      {
-        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
-      }
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extendable-error@0.1.7:
-    resolution:
-      {
-        integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==,
-      }
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
   fast-fifo@1.3.2:
-    resolution:
-      {
-        integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==,
-      }
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
-    resolution:
-      {
-        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
-      }
-    engines: { node: ">=8.6.0" }
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
 
   fastq@1.20.1:
-    resolution:
-      {
-        integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
-      }
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
-    resolution:
-      {
-        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -3538,472 +2205,262 @@ packages:
         optional: true
 
   fill-range@7.1.1:
-    resolution:
-      {
-        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@1.3.2:
-    resolution:
-      {
-        integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
 
   find-up@4.1.0:
-    resolution:
-      {
-        integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   form-data-encoder@1.7.2:
-    resolution:
-      {
-        integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==,
-      }
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
   form-data@4.0.5:
-    resolution:
-      {
-        integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
-    resolution:
-      {
-        integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==,
-      }
-    engines: { node: ">= 12.20" }
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   forwarded@0.2.0:
-    resolution:
-      {
-        integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   frac@1.1.2:
-    resolution:
-      {
-        integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fresh@0.5.2:
-    resolution:
-      {
-        integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fs-constants@1.0.0:
-    resolution:
-      {
-        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
-      }
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
-    resolution:
-      {
-        integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==,
-      }
-    engines: { node: ">=6 <7 || >=8" }
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fs-extra@8.1.0:
-    resolution:
-      {
-        integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
-      }
-    engines: { node: ">=6 <7 || >=8" }
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fsevents@2.3.2:
-    resolution:
-      {
-        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
-      }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution:
-      {
-        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-      }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution:
-      {
-        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
-      }
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
-    resolution:
-      {
-        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
-      }
-    engines: { node: ">=6.9.0" }
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
-    resolution:
-      {
-        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
-      }
-    engines: { node: 6.* || 8.* || >= 10.* }
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
-    resolution:
-      {
-        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
 
   get-proto@1.0.1:
-    resolution:
-      {
-        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.7:
-    resolution:
-      {
-        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
-      }
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   glob-parent@5.1.2:
-    resolution:
-      {
-        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   globby@11.1.0:
-    resolution:
-      {
-        integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
 
   globrex@0.1.2:
-    resolution:
-      {
-        integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==,
-      }
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
   gopd@1.2.0:
-    resolution:
-      {
-        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
-    resolution:
-      {
-        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   hachure-fill@0.5.2:
-    resolution:
-      {
-        integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==,
-      }
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
   has-flag@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
-    resolution:
-      {
-        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.2:
-    resolution:
-      {
-        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
-    resolution:
-      {
-        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
-    resolution:
-      {
-        integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
-      }
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-whitespace@3.0.0:
-    resolution:
-      {
-        integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
-      }
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   hono@4.12.12:
-    resolution:
-      {
-        integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==,
-      }
-    engines: { node: ">=16.9.0" }
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
-    resolution:
-      {
-        integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
 
   html-url-attributes@3.0.1:
-    resolution:
-      {
-        integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==,
-      }
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
-    resolution:
-      {
-        integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
-    resolution:
-      {
-        integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
-    resolution:
-      {
-        integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.3:
-    resolution:
-      {
-        integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==,
-      }
+    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
   humanize-ms@1.2.1:
-    resolution:
-      {
-        integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==,
-      }
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.4.24:
-    resolution:
-      {
-        integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
-    resolution:
-      {
-        integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
-    resolution:
-      {
-        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
-    resolution:
-      {
-        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
-      }
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
-    resolution:
-      {
-        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
-      }
-    engines: { node: ">= 4" }
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   immediate@3.0.6:
-    resolution:
-      {
-        integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==,
-      }
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   inherits@2.0.4:
-    resolution:
-      {
-        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.7:
-    resolution:
-      {
-        integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==,
-      }
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   internmap@1.0.1:
-    resolution:
-      {
-        integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==,
-      }
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   internmap@2.0.3:
-    resolution:
-      {
-        integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ipaddr.js@1.9.1:
-    resolution:
-      {
-        integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==,
-      }
-    engines: { node: ">= 0.10" }
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
-    resolution:
-      {
-        integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
-      }
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
   is-alphanumerical@2.0.1:
-    resolution:
-      {
-        integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
-      }
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-binary-path@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
 
   is-decimal@2.0.1:
-    resolution:
-      {
-        integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
-      }
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
-    resolution:
-      {
-        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@3.0.0:
-    resolution:
-      {
-        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
-    resolution:
-      {
-        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
-    resolution:
-      {
-        integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
-      }
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-number@7.0.0:
-    resolution:
-      {
-        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-      }
-    engines: { node: ">=0.12.0" }
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-plain-obj@4.1.0:
-    resolution:
-      {
-        integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
-    resolution:
-      {
-        integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==,
-      }
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-subdir@1.2.0:
-    resolution:
-      {
-        integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
 
   is-windows@1.0.2:
-    resolution:
-      {
-        integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
 
   isarray@1.0.0:
-    resolution:
-      {
-        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
-      }
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
-    resolution:
-      {
-        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-      }
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   js-tokens@4.0.0:
-    resolution:
-      {
-        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-      }
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@3.14.2:
-    resolution:
-      {
-        integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
-      }
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.1.1:
-    resolution:
-      {
-        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
-      }
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsdom@26.1.0:
-    resolution:
-      {
-        integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
     peerDependencies:
       canvas: ^3.0.0
     peerDependenciesMeta:
@@ -4011,560 +2468,296 @@ packages:
         optional: true
 
   jsesc@3.1.0:
-    resolution:
-      {
-        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json5@2.2.3:
-    resolution:
-      {
-        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsonfile@4.0.0:
-    resolution:
-      {
-        integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
-      }
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jszip@3.10.1:
-    resolution:
-      {
-        integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==,
-      }
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   katex@0.16.44:
-    resolution:
-      {
-        integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==,
-      }
+    resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
     hasBin: true
 
   khroma@2.1.0:
-    resolution:
-      {
-        integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==,
-      }
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   langium@4.2.1:
-    resolution:
-      {
-        integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==,
-      }
-    engines: { node: ">=20.10.0", npm: ">=10.2.3" }
+    resolution: {integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
   layout-base@1.0.2:
-    resolution:
-      {
-        integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==,
-      }
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
   layout-base@2.0.1:
-    resolution:
-      {
-        integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==,
-      }
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lie@3.3.0:
-    resolution:
-      {
-        integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==,
-      }
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   locate-path@5.0.0:
-    resolution:
-      {
-        integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   lodash-es@4.17.23:
-    resolution:
-      {
-        integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==,
-      }
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   lodash.camelcase@4.3.0:
-    resolution:
-      {
-        integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==,
-      }
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.startcase@4.4.0:
-    resolution:
-      {
-        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
-      }
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
   long@5.3.2:
-    resolution:
-      {
-        integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==,
-      }
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
-    resolution:
-      {
-        integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
-      }
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   lop@0.4.2:
-    resolution:
-      {
-        integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==,
-      }
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
 
   loupe@3.2.1:
-    resolution:
-      {
-        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-      }
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@10.4.3:
-    resolution:
-      {
-        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
-      }
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
-    resolution:
-      {
-        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
-      }
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
-    resolution:
-      {
-        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-      }
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   mammoth@1.12.0:
-    resolution:
-      {
-        integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
+    engines: {node: '>=12.0.0'}
     hasBin: true
 
   markdown-table@3.0.4:
-    resolution:
-      {
-        integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
-      }
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
   marked@16.4.2:
-    resolution:
-      {
-        integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==,
-      }
-    engines: { node: ">= 20" }
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
-    resolution:
-      {
-        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-find-and-replace@3.0.2:
-    resolution:
-      {
-        integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
-      }
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
   mdast-util-from-markdown@2.0.3:
-    resolution:
-      {
-        integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
-      }
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-gfm-autolink-literal@2.0.1:
-    resolution:
-      {
-        integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==,
-      }
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
   mdast-util-gfm-footnote@2.1.0:
-    resolution:
-      {
-        integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==,
-      }
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
 
   mdast-util-gfm-strikethrough@2.0.0:
-    resolution:
-      {
-        integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==,
-      }
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
 
   mdast-util-gfm-table@2.0.0:
-    resolution:
-      {
-        integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==,
-      }
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
 
   mdast-util-gfm-task-list-item@2.0.0:
-    resolution:
-      {
-        integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==,
-      }
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
 
   mdast-util-gfm@3.1.0:
-    resolution:
-      {
-        integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==,
-      }
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
-    resolution:
-      {
-        integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==,
-      }
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
   mdast-util-mdx-jsx@3.2.0:
-    resolution:
-      {
-        integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==,
-      }
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
 
   mdast-util-mdxjs-esm@2.0.1:
-    resolution:
-      {
-        integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
-      }
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
-    resolution:
-      {
-        integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
-      }
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
   mdast-util-to-hast@13.2.1:
-    resolution:
-      {
-        integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
-      }
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
-    resolution:
-      {
-        integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==,
-      }
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
   mdast-util-to-string@4.0.0:
-    resolution:
-      {
-        integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
-      }
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   media-typer@0.3.0:
-    resolution:
-      {
-        integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
 
   merge-descriptors@1.0.3:
-    resolution:
-      {
-        integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==,
-      }
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge2@1.4.1:
-    resolution:
-      {
-        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
 
   mermaid@11.13.0:
-    resolution:
-      {
-        integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==,
-      }
+    resolution: {integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==}
 
   methods@1.1.2:
-    resolution:
-      {
-        integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-core-commonmark@2.0.3:
-    resolution:
-      {
-        integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
-      }
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
-    resolution:
-      {
-        integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==,
-      }
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
 
   micromark-extension-gfm-footnote@2.1.0:
-    resolution:
-      {
-        integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==,
-      }
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
 
   micromark-extension-gfm-strikethrough@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==,
-      }
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
 
   micromark-extension-gfm-table@2.1.1:
-    resolution:
-      {
-        integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==,
-      }
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
 
   micromark-extension-gfm-tagfilter@2.0.0:
-    resolution:
-      {
-        integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==,
-      }
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
 
   micromark-extension-gfm-task-list-item@2.1.0:
-    resolution:
-      {
-        integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==,
-      }
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
 
   micromark-extension-gfm@3.0.0:
-    resolution:
-      {
-        integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==,
-      }
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==,
-      }
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
 
   micromark-factory-label@2.0.1:
-    resolution:
-      {
-        integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==,
-      }
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
 
   micromark-factory-space@2.0.1:
-    resolution:
-      {
-        integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==,
-      }
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
 
   micromark-factory-title@2.0.1:
-    resolution:
-      {
-        integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==,
-      }
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
 
   micromark-factory-whitespace@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==,
-      }
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
 
   micromark-util-character@2.1.1:
-    resolution:
-      {
-        integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==,
-      }
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
 
   micromark-util-chunked@2.0.1:
-    resolution:
-      {
-        integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==,
-      }
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
 
   micromark-util-classify-character@2.0.1:
-    resolution:
-      {
-        integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==,
-      }
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
 
   micromark-util-combine-extensions@2.0.1:
-    resolution:
-      {
-        integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==,
-      }
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
 
   micromark-util-decode-numeric-character-reference@2.0.2:
-    resolution:
-      {
-        integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==,
-      }
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
 
   micromark-util-decode-string@2.0.1:
-    resolution:
-      {
-        integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==,
-      }
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
-    resolution:
-      {
-        integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==,
-      }
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
   micromark-util-html-tag-name@2.0.1:
-    resolution:
-      {
-        integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==,
-      }
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
 
   micromark-util-normalize-identifier@2.0.1:
-    resolution:
-      {
-        integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==,
-      }
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
 
   micromark-util-resolve-all@2.0.1:
-    resolution:
-      {
-        integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==,
-      }
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
 
   micromark-util-sanitize-uri@2.0.1:
-    resolution:
-      {
-        integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==,
-      }
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
 
   micromark-util-subtokenize@2.1.0:
-    resolution:
-      {
-        integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==,
-      }
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
-    resolution:
-      {
-        integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==,
-      }
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==,
-      }
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromark@4.0.2:
-    resolution:
-      {
-        integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
-      }
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
-    resolution:
-      {
-        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
-    resolution:
-      {
-        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
-    resolution:
-      {
-        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mime@1.6.0:
-    resolution:
-      {
-        integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
     hasBin: true
 
   mkdirp-classic@0.5.3:
-    resolution:
-      {
-        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
-      }
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
-    resolution:
-      {
-        integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
-      }
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mri@1.2.0:
-    resolution:
-      {
-        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
 
   ms@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==,
-      }
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
-    resolution:
-      {
-        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-      }
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   mylas@2.1.14:
-    resolution:
-      {
-        integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==,
-      }
-    engines: { node: ">=16.0.0" }
+    resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
+    engines: {node: '>=16.0.0'}
 
   nan@2.26.2:
-    resolution:
-      {
-        integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==,
-      }
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   negotiator@0.6.3:
-    resolution:
-      {
-        integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   node-domexception@1.0.0:
-    resolution:
-      {
-        integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==,
-      }
-    engines: { node: ">=10.5.0" }
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
-    resolution:
-      {
-        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
-      }
-    engines: { node: 4.x || >=6.0.0 }
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
     peerDependenciesMeta:
@@ -4572,55 +2765,31 @@ packages:
         optional: true
 
   node-releases@2.0.36:
-    resolution:
-      {
-        integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==,
-      }
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   normalize-path@3.0.0:
-    resolution:
-      {
-        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   nwsapi@2.2.23:
-    resolution:
-      {
-        integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==,
-      }
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   object-inspect@1.13.4:
-    resolution:
-      {
-        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.1:
-    resolution:
-      {
-        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
-      }
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.4.1:
-    resolution:
-      {
-        integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
-      }
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   openai@4.104.0:
-    resolution:
-      {
-        integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==,
-      }
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -4632,963 +2801,531 @@ packages:
         optional: true
 
   option@0.2.4:
-    resolution:
-      {
-        integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==,
-      }
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
 
   outdent@0.5.0:
-    resolution:
-      {
-        integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==,
-      }
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
   p-filter@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
-    resolution:
-      {
-        integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
 
   p-locate@4.1.0:
-    resolution:
-      {
-        integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-map@2.1.0:
-    resolution:
-      {
-        integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
 
   p-try@2.2.0:
-    resolution:
-      {
-        integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-manager-detector@0.2.11:
-    resolution:
-      {
-        integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==,
-      }
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   package-manager-detector@1.6.0:
-    resolution:
-      {
-        integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==,
-      }
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   pako@1.0.11:
-    resolution:
-      {
-        integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==,
-      }
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parse-entities@4.0.2:
-    resolution:
-      {
-        integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
-      }
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@7.3.0:
-    resolution:
-      {
-        integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
-      }
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
-    resolution:
-      {
-        integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
 
   path-data-parser@0.1.0:
-    resolution:
-      {
-        integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==,
-      }
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
-    resolution:
-      {
-        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-is-absolute@1.0.1:
-    resolution:
-      {
-        integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
-    resolution:
-      {
-        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-to-regexp@0.1.13:
-    resolution:
-      {
-        integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==,
-      }
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-type@4.0.0:
-    resolution:
-      {
-        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@1.1.2:
-    resolution:
-      {
-        integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
-      }
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
   pathe@2.0.3:
-    resolution:
-      {
-        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-      }
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
-    resolution:
-      {
-        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-      }
-    engines: { node: ">= 14.16" }
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
-    resolution:
-      {
-        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-      }
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.2:
-    resolution:
-      {
-        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
-    resolution:
-      {
-        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pify@4.0.1:
-    resolution:
-      {
-        integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
 
   pkg-types@1.3.1:
-    resolution:
-      {
-        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
-      }
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.58.2:
-    resolution:
-      {
-        integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   playwright@1.58.2:
-    resolution:
-      {
-        integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
     hasBin: true
 
   plimit-lit@1.6.1:
-    resolution:
-      {
-        integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
 
   points-on-curve@0.2.0:
-    resolution:
-      {
-        integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==,
-      }
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
 
   points-on-path@0.2.1:
-    resolution:
-      {
-        integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==,
-      }
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.8:
-    resolution:
-      {
-        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prettier-plugin-organize-imports@4.3.0:
-    resolution:
-      {
-        integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==,
-      }
+    resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
     peerDependencies:
-      prettier: ">=2.0"
-      typescript: ">=2.9"
+      prettier: '>=2.0'
+      typescript: '>=2.9'
       vue-tsc: ^2.1.0 || 3
     peerDependenciesMeta:
       vue-tsc:
         optional: true
 
   prettier@2.8.8:
-    resolution:
-      {
-        integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
-      }
-    engines: { node: ">=10.13.0" }
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
 
   prettier@3.8.1:
-    resolution:
-      {
-        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
     hasBin: true
 
   process-nextick-args@2.0.1:
-    resolution:
-      {
-        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
-      }
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   property-information@7.1.0:
-    resolution:
-      {
-        integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
-      }
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   protobufjs@7.5.4:
-    resolution:
-      {
-        integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
-    resolution:
-      {
-        integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
-      }
-    engines: { node: ">= 0.10" }
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   pump@3.0.4:
-    resolution:
-      {
-        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
-      }
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
-    resolution:
-      {
-        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.2:
-    resolution:
-      {
-        integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==,
-      }
-    engines: { node: ">=0.6" }
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
-    resolution:
-      {
-        integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
-      }
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-lit@1.5.2:
-    resolution:
-      {
-        integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
 
   queue-microtask@1.2.3:
-    resolution:
-      {
-        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
-      }
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   range-parser@1.2.1:
-    resolution:
-      {
-        integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
 
   raw-body@2.5.3:
-    resolution:
-      {
-        integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
 
   react-dom@19.2.4:
-    resolution:
-      {
-        integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==,
-      }
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
 
   react-markdown@10.1.0:
-    resolution:
-      {
-        integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==,
-      }
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
-      "@types/react": ">=18"
-      react: ">=18"
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.17.0:
-    resolution:
-      {
-        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.4:
-    resolution:
-      {
-        integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
-    resolution:
-      {
-        integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
 
   readable-stream@2.3.8:
-    resolution:
-      {
-        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
-      }
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
-    resolution:
-      {
-        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@3.6.0:
-    resolution:
-      {
-        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-      }
-    engines: { node: ">=8.10.0" }
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   remark-gfm@4.0.1:
-    resolution:
-      {
-        integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==,
-      }
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
   remark-parse@11.0.0:
-    resolution:
-      {
-        integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
-      }
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
-    resolution:
-      {
-        integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==,
-      }
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   remark-stringify@11.0.0:
-    resolution:
-      {
-        integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
-      }
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
-    resolution:
-      {
-        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
-    resolution:
-      {
-        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
-    resolution:
-      {
-        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
-      }
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   reusify@1.1.0:
-    resolution:
-      {
-        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
-      }
-    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   robust-predicates@3.0.3:
-    resolution:
-      {
-        integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==,
-      }
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   rollup@4.60.0:
-    resolution:
-      {
-        integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==,
-      }
-    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   roughjs@4.6.6:
-    resolution:
-      {
-        integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==,
-      }
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   rrweb-cssom@0.8.0:
-    resolution:
-      {
-        integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==,
-      }
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   run-parallel@1.2.0:
-    resolution:
-      {
-        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
-      }
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rw@1.3.3:
-    resolution:
-      {
-        integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==,
-      }
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
-    resolution:
-      {
-        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
-      }
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.1.2:
-    resolution:
-      {
-        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
-      }
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
-    resolution:
-      {
-        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
-      }
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
-    resolution:
-      {
-        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
-      }
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
-    resolution:
-      {
-        integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
-      }
-    engines: { node: ">=v12.22.7" }
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
-    resolution:
-      {
-        integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
-      }
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
-    resolution:
-      {
-        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
-      }
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   semver@7.7.4:
-    resolution:
-      {
-        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   send@0.19.2:
-    resolution:
-      {
-        integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@1.16.3:
-    resolution:
-      {
-        integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   setimmediate@1.0.5:
-    resolution:
-      {
-        integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==,
-      }
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
-    resolution:
-      {
-        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
-      }
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
-    resolution:
-      {
-        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
 
   shebang-regex@3.0.0:
-    resolution:
-      {
-        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   shell-quote@1.8.3:
-    resolution:
-      {
-        integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
-    resolution:
-      {
-        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
-    resolution:
-      {
-        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
 
   side-channel-weakmap@1.0.2:
-    resolution:
-      {
-        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
 
   side-channel@1.1.0:
-    resolution:
-      {
-        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
-    resolution:
-      {
-        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
-      }
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@4.1.0:
-    resolution:
-      {
-        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
-    resolution:
-      {
-        integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
-      }
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
-    resolution:
-      {
-        integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
 
   source-map-js@1.2.1:
-    resolution:
-      {
-        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
-    resolution:
-      {
-        integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
-      }
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   spawndamnit@3.0.1:
-    resolution:
-      {
-        integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==,
-      }
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
   split-ca@1.0.1:
-    resolution:
-      {
-        integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==,
-      }
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
 
   sprintf-js@1.0.3:
-    resolution:
-      {
-        integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
-      }
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   ssf@0.11.2:
-    resolution:
-      {
-        integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
 
   ssh2@1.17.0:
-    resolution:
-      {
-        integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==,
-      }
-    engines: { node: ">=10.16.0" }
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stackback@0.0.2:
-    resolution:
-      {
-        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-      }
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   statuses@2.0.2:
-    resolution:
-      {
-        integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
-    resolution:
-      {
-        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
-      }
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   std-env@4.0.0:
-    resolution:
-      {
-        integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
-      }
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   streamx@2.25.0:
-    resolution:
-      {
-        integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==,
-      }
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   string-width@4.2.3:
-    resolution:
-      {
-        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string_decoder@1.1.1:
-    resolution:
-      {
-        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
-      }
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
-    resolution:
-      {
-        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
-      }
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
-    resolution:
-      {
-        integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
-      }
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
-    resolution:
-      {
-        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
-    resolution:
-      {
-        integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   style-to-js@1.1.21:
-    resolution:
-      {
-        integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==,
-      }
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
   style-to-object@1.0.14:
-    resolution:
-      {
-        integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
-      }
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   stylis@4.3.6:
-    resolution:
-      {
-        integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==,
-      }
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   supports-color@7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   supports-color@8.1.1:
-    resolution:
-      {
-        integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   symbol-tree@3.2.4:
-    resolution:
-      {
-        integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
-      }
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tar-fs@2.1.4:
-    resolution:
-      {
-        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
-      }
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
-    resolution:
-      {
-        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.8:
-    resolution:
-      {
-        integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==,
-      }
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
   teex@1.0.1:
-    resolution:
-      {
-        integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==,
-      }
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   term-size@2.2.1:
-    resolution:
-      {
-        integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
 
   text-decoder@1.2.7:
-    resolution:
-      {
-        integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==,
-      }
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinybench@2.9.0:
-    resolution:
-      {
-        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
-      }
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
-    resolution:
-      {
-        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
-      }
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.4:
-    resolution:
-      {
-        integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
-    resolution:
-      {
-        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
-    resolution:
-      {
-        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
-    resolution:
-      {
-        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
-    resolution:
-      {
-        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
-    resolution:
-      {
-        integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
-    resolution:
-      {
-        integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
-      }
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
   tldts@6.1.86:
-    resolution:
-      {
-        integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
-      }
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
   to-regex-range@5.0.1:
-    resolution:
-      {
-        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-      }
-    engines: { node: ">=8.0" }
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
-    resolution:
-      {
-        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
-      }
-    engines: { node: ">=0.6" }
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   tough-cookie@5.1.2:
-    resolution:
-      {
-        integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
-      }
-    engines: { node: ">=16" }
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
-    resolution:
-      {
-        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
-      }
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
-    resolution:
-      {
-        integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
-    resolution:
-      {
-        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
-      }
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   trim-lines@3.0.1:
-    resolution:
-      {
-        integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
-      }
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
-    resolution:
-      {
-        integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
-      }
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-dedent@2.2.0:
-    resolution:
-      {
-        integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==,
-      }
-    engines: { node: ">=6.10" }
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tsc-alias@1.8.16:
-    resolution:
-      {
-        integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==,
-      }
-    engines: { node: ">=16.20.2" }
+    resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
+    engines: {node: '>=16.20.2'}
     hasBin: true
 
   tsconfck@3.1.6:
-    resolution:
-      {
-        integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
-      }
-    engines: { node: ^18 || >=20 }
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -5597,210 +3334,123 @@ packages:
         optional: true
 
   tslib@2.8.1:
-    resolution:
-      {
-        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-      }
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
-    resolution:
-      {
-        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
-      }
-    engines: { node: ">=18.0.0" }
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   turndown@7.2.4:
-    resolution:
-      {
-        integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==,
-      }
-    engines: { node: ">=18", npm: ">=9" }
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
 
   tweetnacl@0.14.5:
-    resolution:
-      {
-        integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==,
-      }
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-is@1.6.18:
-    resolution:
-      {
-        integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
-    resolution:
-      {
-        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
-      }
-    engines: { node: ">=14.17" }
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.3:
-    resolution:
-      {
-        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
-      }
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   underscore@1.13.8:
-    resolution:
-      {
-        integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==,
-      }
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@5.26.5:
-    resolution:
-      {
-        integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==,
-      }
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
-    resolution:
-      {
-        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
-      }
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unified@11.0.5:
-    resolution:
-      {
-        integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
-      }
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
   unist-util-is@6.0.1:
-    resolution:
-      {
-        integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==,
-      }
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
-    resolution:
-      {
-        integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
-      }
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
   unist-util-stringify-position@4.0.0:
-    resolution:
-      {
-        integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
-      }
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
   unist-util-visit-parents@6.0.2:
-    resolution:
-      {
-        integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==,
-      }
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
   unist-util-visit@5.1.0:
-    resolution:
-      {
-        integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
-      }
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.1.2:
-    resolution:
-      {
-        integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==,
-      }
-    engines: { node: ">= 4.0.0" }
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   unpipe@1.0.0:
-    resolution:
-      {
-        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   update-browserslist-db@1.2.3:
-    resolution:
-      {
-        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
-      }
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: ">= 4.21.0"
+      browserslist: '>= 4.21.0'
 
   util-deprecate@1.0.2:
-    resolution:
-      {
-        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-      }
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
-    resolution:
-      {
-        integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
-      }
-    engines: { node: ">= 0.4.0" }
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   uuid@10.0.0:
-    resolution:
-      {
-        integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
-      }
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
   uuid@11.1.0:
-    resolution:
-      {
-        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
-      }
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   vary@1.1.2:
-    resolution:
-      {
-        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
-    resolution:
-      {
-        integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
-      }
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
   vfile@6.0.3:
-    resolution:
-      {
-        integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
-      }
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@2.1.9:
-    resolution:
-      {
-        integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   vite-tsconfig-paths@6.1.1:
-    resolution:
-      {
-        integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==,
-      }
+    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
     peerDependencies:
-      vite: "*"
+      vite: '*'
 
   vite@5.4.21:
-    resolution:
-      {
-        integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || >=20.0.0
-      less: "*"
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.4.0
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
       less:
         optional: true
@@ -5818,26 +3468,23 @@ packages:
         optional: true
 
   vite@6.4.2:
-    resolution:
-      {
-        integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: ">=1.21.0"
-      less: "*"
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
       jiti:
         optional: true
@@ -5861,27 +3508,24 @@ packages:
         optional: true
 
   vitest@2.1.9:
-    resolution:
-      {
-        integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      "@edge-runtime/vm": "*"
-      "@types/node": ^18.0.0 || >=20.0.0
-      "@vitest/browser": 2.1.9
-      "@vitest/ui": 2.1.9
-      happy-dom: "*"
-      jsdom: "*"
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
     peerDependenciesMeta:
-      "@edge-runtime/vm":
+      '@edge-runtime/vm':
         optional: true
-      "@types/node":
+      '@types/node':
         optional: true
-      "@vitest/browser":
+      '@vitest/browser':
         optional: true
-      "@vitest/ui":
+      '@vitest/ui':
         optional: true
       happy-dom:
         optional: true
@@ -5889,43 +3533,40 @@ packages:
         optional: true
 
   vitest@4.1.3:
-    resolution:
-      {
-        integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==,
-      }
-    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
-      "@edge-runtime/vm": "*"
-      "@opentelemetry/api": ^1.9.0
-      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.1.3
-      "@vitest/browser-preview": 4.1.3
-      "@vitest/browser-webdriverio": 4.1.3
-      "@vitest/coverage-istanbul": 4.1.3
-      "@vitest/coverage-v8": 4.1.3
-      "@vitest/ui": 4.1.3
-      happy-dom: "*"
-      jsdom: "*"
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
-      "@edge-runtime/vm":
+      '@edge-runtime/vm':
         optional: true
-      "@opentelemetry/api":
+      '@opentelemetry/api':
         optional: true
-      "@types/node":
+      '@types/node':
         optional: true
-      "@vitest/browser-playwright":
+      '@vitest/browser-playwright':
         optional: true
-      "@vitest/browser-preview":
+      '@vitest/browser-preview':
         optional: true
-      "@vitest/browser-webdriverio":
+      '@vitest/browser-webdriverio':
         optional: true
-      "@vitest/coverage-istanbul":
+      '@vitest/coverage-istanbul':
         optional: true
-      "@vitest/coverage-v8":
+      '@vitest/coverage-v8':
         optional: true
-      "@vitest/ui":
+      '@vitest/ui':
         optional: true
       happy-dom:
         optional: true
@@ -5933,150 +3574,87 @@ packages:
         optional: true
 
   vscode-jsonrpc@8.2.0:
-    resolution:
-      {
-        integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
 
   vscode-languageserver-protocol@3.17.5:
-    resolution:
-      {
-        integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==,
-      }
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
 
   vscode-languageserver-textdocument@1.0.12:
-    resolution:
-      {
-        integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==,
-      }
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
 
   vscode-languageserver-types@3.17.5:
-    resolution:
-      {
-        integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==,
-      }
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
   vscode-languageserver@9.0.1:
-    resolution:
-      {
-        integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==,
-      }
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
     hasBin: true
 
   vscode-uri@3.1.0:
-    resolution:
-      {
-        integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==,
-      }
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   w3c-xmlserializer@5.0.0:
-    resolution:
-      {
-        integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   web-streams-polyfill@4.0.0-beta.3:
-    resolution:
-      {
-        integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==,
-      }
-    engines: { node: ">= 14" }
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
 
   webidl-conversions@3.0.1:
-    resolution:
-      {
-        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
-      }
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@7.0.0:
-    resolution:
-      {
-        integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   whatwg-encoding@3.1.1:
-    resolution:
-      {
-        integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
-    resolution:
-      {
-        integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@14.2.0:
-    resolution:
-      {
-        integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
-    resolution:
-      {
-        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
-      }
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
-    resolution:
-      {
-        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution:
-      {
-        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wmf@1.0.2:
-    resolution:
-      {
-        integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
 
   word@0.3.0:
-    resolution:
-      {
-        integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@7.0.0:
-    resolution:
-      {
-        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
 
   wrappy@1.0.2:
-    resolution:
-      {
-        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
-      }
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.0:
-    resolution:
-      {
-        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
-      }
-    engines: { node: ">=10.0.0" }
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ">=5.0.2"
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -6084,84 +3662,55 @@ packages:
         optional: true
 
   xlsx@0.18.5:
-    resolution:
-      {
-        integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
     hasBin: true
 
   xml-name-validator@5.0.0:
-    resolution:
-      {
-        integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xmlbuilder@10.1.1:
-    resolution:
-      {
-        integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==,
-      }
-    engines: { node: ">=4.0" }
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
 
   xmlchars@2.2.0:
-    resolution:
-      {
-        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
-      }
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
-    resolution:
-      {
-        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@3.1.1:
-    resolution:
-      {
-        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
-      }
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.8.3:
-    resolution:
-      {
-        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
-      }
-    engines: { node: ">= 14.6" }
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@21.1.1:
-    resolution:
-      {
-        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
 
   yargs@17.7.2:
-    resolution:
-      {
-        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   zwitch@2.0.4:
-    resolution:
-      {
-        integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
-      }
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-  "@antfu/install-pkg@1.1.0":
+
+  '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
 
-  "@anthropic-ai/sdk@0.39.0":
+  '@anthropic-ai/sdk@0.39.0':
     dependencies:
-      "@types/node": 18.19.130
-      "@types/node-fetch": 2.6.13
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
@@ -6170,34 +3719,34 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  "@asamuzakjp/css-color@3.2.0":
+  '@asamuzakjp/css-color@3.2.0':
     dependencies:
-      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-tokenizer": 3.0.4
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  "@babel/code-frame@7.29.0":
+  '@babel/code-frame@7.29.0':
     dependencies:
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/compat-data@7.29.0": {}
+  '@babel/compat-data@7.29.0': {}
 
-  "@babel/core@7.29.0":
+  '@babel/core@7.29.0':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/helper-compilation-targets": 7.28.6
-      "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
-      "@babel/helpers": 7.29.2
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.28.6
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      "@jridgewell/remapping": 2.3.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -6206,104 +3755,104 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/generator@7.29.1":
+  '@babel/generator@7.29.1':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  "@babel/helper-compilation-targets@7.28.6":
+  '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      "@babel/compat-data": 7.29.0
-      "@babel/helper-validator-option": 7.27.1
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  "@babel/helper-globals@7.28.0": {}
+  '@babel/helper-globals@7.28.0': {}
 
-  "@babel/helper-module-imports@7.28.6":
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)":
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/helper-module-imports": 7.28.6
-      "@babel/helper-validator-identifier": 7.28.5
-      "@babel/traverse": 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-plugin-utils@7.28.6": {}
+  '@babel/helper-plugin-utils@7.28.6': {}
 
-  "@babel/helper-string-parser@7.27.1": {}
+  '@babel/helper-string-parser@7.27.1': {}
 
-  "@babel/helper-validator-identifier@7.28.5": {}
+  '@babel/helper-validator-identifier@7.28.5': {}
 
-  "@babel/helper-validator-option@7.27.1": {}
+  '@babel/helper-validator-option@7.27.1': {}
 
-  "@babel/helpers@7.29.2":
+  '@babel/helpers@7.29.2':
     dependencies:
-      "@babel/template": 7.28.6
-      "@babel/types": 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
-  "@babel/parser@7.29.2":
+  '@babel/parser@7.29.2':
     dependencies:
-      "@babel/types": 7.29.0
+      '@babel/types': 7.29.0
 
-  "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)":
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/helper-plugin-utils": 7.28.6
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
-  "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)":
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/helper-plugin-utils": 7.28.6
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
-  "@babel/runtime@7.29.2": {}
+  '@babel/runtime@7.29.2': {}
 
-  "@babel/template@7.28.6":
+  '@babel/template@7.28.6':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
-  "@babel/traverse@7.29.0":
+  '@babel/traverse@7.29.0':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/helper-globals": 7.28.0
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.28.6
-      "@babel/types": 7.29.0
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/types@7.29.0":
+  '@babel/types@7.29.0':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
-  "@balena/dockerignore@1.0.2": {}
+  '@balena/dockerignore@1.0.2': {}
 
-  "@braintree/sanitize-url@7.1.2": {}
+  '@braintree/sanitize-url@7.1.2': {}
 
-  "@changesets/apply-release-plan@7.1.0":
+  '@changesets/apply-release-plan@7.1.0':
     dependencies:
-      "@changesets/config": 3.1.3
-      "@changesets/get-version-range-type": 0.4.0
-      "@changesets/git": 3.0.4
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/config': 3.1.3
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
       detect-indent: 6.1.0
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
@@ -6312,45 +3861,45 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  "@changesets/assemble-release-plan@6.0.9":
+  '@changesets/assemble-release-plan@6.0.9':
     dependencies:
-      "@changesets/errors": 0.2.0
-      "@changesets/get-dependents-graph": 2.1.3
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
       semver: 7.7.4
 
-  "@changesets/changelog-git@0.2.1":
+  '@changesets/changelog-git@0.2.1':
     dependencies:
-      "@changesets/types": 6.1.0
+      '@changesets/types': 6.1.0
 
-  "@changesets/changelog-github@0.6.0":
+  '@changesets/changelog-github@0.6.0':
     dependencies:
-      "@changesets/get-github-info": 0.8.0
-      "@changesets/types": 6.1.0
+      '@changesets/get-github-info': 0.8.0
+      '@changesets/types': 6.1.0
       dotenv: 8.6.0
     transitivePeerDependencies:
       - encoding
 
-  "@changesets/cli@2.30.0(@types/node@22.19.15)":
+  '@changesets/cli@2.30.0(@types/node@22.19.15)':
     dependencies:
-      "@changesets/apply-release-plan": 7.1.0
-      "@changesets/assemble-release-plan": 6.0.9
-      "@changesets/changelog-git": 0.2.1
-      "@changesets/config": 3.1.3
-      "@changesets/errors": 0.2.0
-      "@changesets/get-dependents-graph": 2.1.3
-      "@changesets/get-release-plan": 4.0.15
-      "@changesets/git": 3.0.4
-      "@changesets/logger": 0.1.1
-      "@changesets/pre": 2.0.2
-      "@changesets/read": 0.6.7
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@changesets/write": 0.4.0
-      "@inquirer/external-editor": 1.0.3(@types/node@22.19.15)
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/apply-release-plan': 7.1.0
+      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.3
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-release-plan': 4.0.15
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
+      '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
       fs-extra: 7.0.1
@@ -6362,901 +3911,901 @@ snapshots:
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
-      - "@types/node"
+      - '@types/node'
 
-  "@changesets/config@3.1.3":
+  '@changesets/config@3.1.3':
     dependencies:
-      "@changesets/errors": 0.2.0
-      "@changesets/get-dependents-graph": 2.1.3
-      "@changesets/logger": 0.1.1
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
       micromatch: 4.0.8
 
-  "@changesets/errors@0.2.0":
+  '@changesets/errors@0.2.0':
     dependencies:
       extendable-error: 0.1.7
 
-  "@changesets/get-dependents-graph@2.1.3":
+  '@changesets/get-dependents-graph@2.1.3':
     dependencies:
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.4
 
-  "@changesets/get-github-info@0.8.0":
+  '@changesets/get-github-info@0.8.0':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
-  "@changesets/get-release-plan@4.0.15":
+  '@changesets/get-release-plan@4.0.15':
     dependencies:
-      "@changesets/assemble-release-plan": 6.0.9
-      "@changesets/config": 3.1.3
-      "@changesets/pre": 2.0.2
-      "@changesets/read": 0.6.7
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/config': 3.1.3
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
 
-  "@changesets/get-version-range-type@0.4.0": {}
+  '@changesets/get-version-range-type@0.4.0': {}
 
-  "@changesets/git@3.0.4":
+  '@changesets/git@3.0.4':
     dependencies:
-      "@changesets/errors": 0.2.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
       micromatch: 4.0.8
       spawndamnit: 3.0.1
 
-  "@changesets/logger@0.1.1":
+  '@changesets/logger@0.1.1':
     dependencies:
       picocolors: 1.1.1
 
-  "@changesets/parse@0.4.3":
+  '@changesets/parse@0.4.3':
     dependencies:
-      "@changesets/types": 6.1.0
+      '@changesets/types': 6.1.0
       js-yaml: 4.1.1
 
-  "@changesets/pre@2.0.2":
+  '@changesets/pre@2.0.2':
     dependencies:
-      "@changesets/errors": 0.2.0
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
 
-  "@changesets/read@0.6.7":
+  '@changesets/read@0.6.7':
     dependencies:
-      "@changesets/git": 3.0.4
-      "@changesets/logger": 0.1.1
-      "@changesets/parse": 0.4.3
-      "@changesets/types": 6.1.0
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.3
+      '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
       picocolors: 1.1.1
 
-  "@changesets/should-skip-package@0.1.2":
+  '@changesets/should-skip-package@0.1.2':
     dependencies:
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
 
-  "@changesets/types@4.1.0": {}
+  '@changesets/types@4.1.0': {}
 
-  "@changesets/types@6.1.0": {}
+  '@changesets/types@6.1.0': {}
 
-  "@changesets/write@0.4.0":
+  '@changesets/write@0.4.0':
     dependencies:
-      "@changesets/types": 6.1.0
+      '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
 
-  "@chevrotain/cst-dts-gen@11.1.2":
+  '@chevrotain/cst-dts-gen@11.1.2':
     dependencies:
-      "@chevrotain/gast": 11.1.2
-      "@chevrotain/types": 11.1.2
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/types': 11.1.2
       lodash-es: 4.17.23
 
-  "@chevrotain/gast@11.1.2":
+  '@chevrotain/gast@11.1.2':
     dependencies:
-      "@chevrotain/types": 11.1.2
+      '@chevrotain/types': 11.1.2
       lodash-es: 4.17.23
 
-  "@chevrotain/regexp-to-ast@11.1.2": {}
+  '@chevrotain/regexp-to-ast@11.1.2': {}
 
-  "@chevrotain/types@11.1.2": {}
+  '@chevrotain/types@11.1.2': {}
 
-  "@chevrotain/utils@11.1.2": {}
+  '@chevrotain/utils@11.1.2': {}
 
-  "@clack/core@0.4.1":
+  '@clack/core@0.4.1':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  "@clack/prompts@0.9.1":
+  '@clack/prompts@0.9.1':
     dependencies:
-      "@clack/core": 0.4.1
+      '@clack/core': 0.4.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  "@csstools/color-helpers@5.1.0": {}
+  '@csstools/color-helpers@5.1.0': {}
 
-  "@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)":
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
-      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-tokenizer": 3.0.4
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
-  "@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)":
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
-      "@csstools/color-helpers": 5.1.0
-      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-tokenizer": 3.0.4
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
-  "@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)":
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
-      "@csstools/css-tokenizer": 3.0.4
+      '@csstools/css-tokenizer': 3.0.4
 
-  "@csstools/css-tokenizer@3.0.4": {}
+  '@csstools/css-tokenizer@3.0.4': {}
 
-  "@esbuild/aix-ppc64@0.21.5":
+  '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
-  "@esbuild/aix-ppc64@0.25.12":
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  "@esbuild/aix-ppc64@0.27.4":
+  '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
-  "@esbuild/android-arm64@0.21.5":
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
-  "@esbuild/android-arm64@0.25.12":
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  "@esbuild/android-arm64@0.27.4":
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
-  "@esbuild/android-arm@0.21.5":
+  '@esbuild/android-arm@0.21.5':
     optional: true
 
-  "@esbuild/android-arm@0.25.12":
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  "@esbuild/android-arm@0.27.4":
+  '@esbuild/android-arm@0.27.4':
     optional: true
 
-  "@esbuild/android-x64@0.21.5":
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
-  "@esbuild/android-x64@0.25.12":
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  "@esbuild/android-x64@0.27.4":
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
-  "@esbuild/darwin-arm64@0.21.5":
+  '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.12":
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  "@esbuild/darwin-arm64@0.27.4":
+  '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
-  "@esbuild/darwin-x64@0.21.5":
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
-  "@esbuild/darwin-x64@0.25.12":
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  "@esbuild/darwin-x64@0.27.4":
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
-  "@esbuild/freebsd-arm64@0.21.5":
+  '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.12":
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  "@esbuild/freebsd-arm64@0.27.4":
+  '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
-  "@esbuild/freebsd-x64@0.21.5":
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.12":
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  "@esbuild/freebsd-x64@0.27.4":
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
-  "@esbuild/linux-arm64@0.21.5":
+  '@esbuild/linux-arm64@0.21.5':
     optional: true
 
-  "@esbuild/linux-arm64@0.25.12":
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  "@esbuild/linux-arm64@0.27.4":
+  '@esbuild/linux-arm64@0.27.4':
     optional: true
 
-  "@esbuild/linux-arm@0.21.5":
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
-  "@esbuild/linux-arm@0.25.12":
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  "@esbuild/linux-arm@0.27.4":
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
-  "@esbuild/linux-ia32@0.21.5":
+  '@esbuild/linux-ia32@0.21.5':
     optional: true
 
-  "@esbuild/linux-ia32@0.25.12":
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  "@esbuild/linux-ia32@0.27.4":
+  '@esbuild/linux-ia32@0.27.4':
     optional: true
 
-  "@esbuild/linux-loong64@0.21.5":
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
-  "@esbuild/linux-loong64@0.25.12":
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  "@esbuild/linux-loong64@0.27.4":
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
-  "@esbuild/linux-mips64el@0.21.5":
+  '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.12":
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  "@esbuild/linux-mips64el@0.27.4":
+  '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
-  "@esbuild/linux-ppc64@0.21.5":
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
-  "@esbuild/linux-ppc64@0.25.12":
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  "@esbuild/linux-ppc64@0.27.4":
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
-  "@esbuild/linux-riscv64@0.21.5":
+  '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
-  "@esbuild/linux-riscv64@0.25.12":
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  "@esbuild/linux-riscv64@0.27.4":
+  '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
-  "@esbuild/linux-s390x@0.21.5":
+  '@esbuild/linux-s390x@0.21.5':
     optional: true
 
-  "@esbuild/linux-s390x@0.25.12":
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  "@esbuild/linux-s390x@0.27.4":
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
-  "@esbuild/linux-x64@0.21.5":
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
-  "@esbuild/linux-x64@0.25.12":
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  "@esbuild/linux-x64@0.27.4":
+  '@esbuild/linux-x64@0.27.4':
     optional: true
 
-  "@esbuild/netbsd-arm64@0.25.12":
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  "@esbuild/netbsd-arm64@0.27.4":
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
-  "@esbuild/netbsd-x64@0.21.5":
+  '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
-  "@esbuild/netbsd-x64@0.25.12":
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  "@esbuild/netbsd-x64@0.27.4":
+  '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
-  "@esbuild/openbsd-arm64@0.25.12":
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  "@esbuild/openbsd-arm64@0.27.4":
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
-  "@esbuild/openbsd-x64@0.21.5":
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
-  "@esbuild/openbsd-x64@0.25.12":
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  "@esbuild/openbsd-x64@0.27.4":
+  '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
-  "@esbuild/openharmony-arm64@0.25.12":
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  "@esbuild/openharmony-arm64@0.27.4":
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
-  "@esbuild/sunos-x64@0.21.5":
+  '@esbuild/sunos-x64@0.21.5':
     optional: true
 
-  "@esbuild/sunos-x64@0.25.12":
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  "@esbuild/sunos-x64@0.27.4":
+  '@esbuild/sunos-x64@0.27.4':
     optional: true
 
-  "@esbuild/win32-arm64@0.21.5":
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
-  "@esbuild/win32-arm64@0.25.12":
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  "@esbuild/win32-arm64@0.27.4":
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
-  "@esbuild/win32-ia32@0.21.5":
+  '@esbuild/win32-ia32@0.21.5':
     optional: true
 
-  "@esbuild/win32-ia32@0.25.12":
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  "@esbuild/win32-ia32@0.27.4":
+  '@esbuild/win32-ia32@0.27.4':
     optional: true
 
-  "@esbuild/win32-x64@0.21.5":
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  "@esbuild/win32-x64@0.25.12":
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  "@esbuild/win32-x64@0.27.4":
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  "@grpc/grpc-js@1.14.3":
+  '@grpc/grpc-js@1.14.3':
     dependencies:
-      "@grpc/proto-loader": 0.8.0
-      "@js-sdsl/ordered-map": 4.4.2
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
 
-  "@grpc/proto-loader@0.7.15":
+  '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  "@grpc/proto-loader@0.8.0":
+  '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  "@hono/node-server@1.19.13(hono@4.12.12)":
+  '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
 
-  "@iconify/types@2.0.0": {}
+  '@iconify/types@2.0.0': {}
 
-  "@iconify/utils@3.1.0":
+  '@iconify/utils@3.1.0':
     dependencies:
-      "@antfu/install-pkg": 1.1.0
-      "@iconify/types": 2.0.0
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
       mlly: 1.8.2
 
-  "@inquirer/external-editor@1.0.3(@types/node@22.19.15)":
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
 
-  "@jridgewell/gen-mapping@0.3.13":
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
-  "@jridgewell/remapping@2.3.5":
+  '@jridgewell/remapping@2.3.5':
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
-  "@jridgewell/resolve-uri@3.1.2": {}
+  '@jridgewell/resolve-uri@3.1.2': {}
 
-  "@jridgewell/sourcemap-codec@1.5.5": {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  "@jridgewell/trace-mapping@0.3.31":
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.2
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  "@js-sdsl/ordered-map@4.4.2": {}
+  '@js-sdsl/ordered-map@4.4.2': {}
 
-  "@manypkg/find-root@1.1.0":
+  '@manypkg/find-root@1.1.0':
     dependencies:
-      "@babel/runtime": 7.29.2
-      "@types/node": 12.20.55
+      '@babel/runtime': 7.29.2
+      '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
-  "@manypkg/get-packages@1.1.3":
+  '@manypkg/get-packages@1.1.3':
     dependencies:
-      "@babel/runtime": 7.29.2
-      "@changesets/types": 4.1.0
-      "@manypkg/find-root": 1.1.0
+      '@babel/runtime': 7.29.2
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  "@mermaid-js/parser@1.0.1":
+  '@mermaid-js/parser@1.0.1':
     dependencies:
       langium: 4.2.1
 
-  "@mixmark-io/domino@2.2.0": {}
+  '@mixmark-io/domino@2.2.0': {}
 
-  "@mozilla/readability@0.6.0": {}
+  '@mozilla/readability@0.6.0': {}
 
-  "@nodelib/fs.scandir@2.1.5":
+  '@nodelib/fs.scandir@2.1.5':
     dependencies:
-      "@nodelib/fs.stat": 2.0.5
+      '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
 
-  "@nodelib/fs.stat@2.0.5": {}
+  '@nodelib/fs.stat@2.0.5': {}
 
-  "@nodelib/fs.walk@1.2.8":
+  '@nodelib/fs.walk@1.2.8':
     dependencies:
-      "@nodelib/fs.scandir": 2.1.5
+      '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  "@protobufjs/aspromise@1.1.2": {}
+  '@protobufjs/aspromise@1.1.2': {}
 
-  "@protobufjs/base64@1.1.2": {}
+  '@protobufjs/base64@1.1.2': {}
 
-  "@protobufjs/codegen@2.0.4": {}
+  '@protobufjs/codegen@2.0.4': {}
 
-  "@protobufjs/eventemitter@1.1.0": {}
+  '@protobufjs/eventemitter@1.1.0': {}
 
-  "@protobufjs/fetch@1.1.0":
+  '@protobufjs/fetch@1.1.0':
     dependencies:
-      "@protobufjs/aspromise": 1.1.2
-      "@protobufjs/inquire": 1.1.0
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
 
-  "@protobufjs/float@1.0.2": {}
+  '@protobufjs/float@1.0.2': {}
 
-  "@protobufjs/inquire@1.1.0": {}
+  '@protobufjs/inquire@1.1.0': {}
 
-  "@protobufjs/path@1.1.2": {}
+  '@protobufjs/path@1.1.2': {}
 
-  "@protobufjs/pool@1.1.0": {}
+  '@protobufjs/pool@1.1.0': {}
 
-  "@protobufjs/utf8@1.1.0": {}
+  '@protobufjs/utf8@1.1.0': {}
 
-  "@rolldown/pluginutils@1.0.0-beta.27": {}
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  "@rollup/rollup-android-arm-eabi@4.60.0":
+  '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
-  "@rollup/rollup-android-arm64@4.60.0":
+  '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.60.0":
+  '@rollup/rollup-darwin-arm64@4.60.0':
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.60.0":
+  '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.60.0":
+  '@rollup/rollup-freebsd-arm64@4.60.0':
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.60.0":
+  '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.60.0":
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.60.0":
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.60.0":
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.60.0":
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.60.0":
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-loong64-musl@4.60.0":
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.60.0":
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-musl@4.60.0":
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.60.0":
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.60.0":
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.60.0":
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.60.0":
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.60.0":
+  '@rollup/rollup-linux-x64-musl@4.60.0':
     optional: true
 
-  "@rollup/rollup-openbsd-x64@4.60.0":
+  '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.60.0":
+  '@rollup/rollup-openharmony-arm64@4.60.0':
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.60.0":
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.60.0":
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.60.0":
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.60.0":
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
-  "@sinclair/typebox@0.34.49": {}
+  '@sinclair/typebox@0.34.49': {}
 
-  "@standard-schema/spec@1.1.0": {}
+  '@standard-schema/spec@1.1.0': {}
 
-  "@types/babel__core@7.20.5":
+  '@types/babel__core@7.20.5':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
-      "@types/babel__generator": 7.27.0
-      "@types/babel__template": 7.4.4
-      "@types/babel__traverse": 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
 
-  "@types/babel__generator@7.27.0":
+  '@types/babel__generator@7.27.0':
     dependencies:
-      "@babel/types": 7.29.0
+      '@babel/types': 7.29.0
 
-  "@types/babel__template@7.4.4":
+  '@types/babel__template@7.4.4':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
-  "@types/babel__traverse@7.28.0":
+  '@types/babel__traverse@7.28.0':
     dependencies:
-      "@babel/types": 7.29.0
+      '@babel/types': 7.29.0
 
-  "@types/chai@5.2.3":
+  '@types/chai@5.2.3':
     dependencies:
-      "@types/deep-eql": 4.0.2
+      '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  "@types/d3-array@3.2.2": {}
+  '@types/d3-array@3.2.2': {}
 
-  "@types/d3-axis@3.0.6":
+  '@types/d3-axis@3.0.6':
     dependencies:
-      "@types/d3-selection": 3.0.11
+      '@types/d3-selection': 3.0.11
 
-  "@types/d3-brush@3.0.6":
+  '@types/d3-brush@3.0.6':
     dependencies:
-      "@types/d3-selection": 3.0.11
+      '@types/d3-selection': 3.0.11
 
-  "@types/d3-chord@3.0.6": {}
+  '@types/d3-chord@3.0.6': {}
 
-  "@types/d3-color@3.1.3": {}
+  '@types/d3-color@3.1.3': {}
 
-  "@types/d3-contour@3.0.6":
+  '@types/d3-contour@3.0.6':
     dependencies:
-      "@types/d3-array": 3.2.2
-      "@types/geojson": 7946.0.16
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
 
-  "@types/d3-delaunay@6.0.4": {}
+  '@types/d3-delaunay@6.0.4': {}
 
-  "@types/d3-dispatch@3.0.7": {}
+  '@types/d3-dispatch@3.0.7': {}
 
-  "@types/d3-drag@3.0.7":
+  '@types/d3-drag@3.0.7':
     dependencies:
-      "@types/d3-selection": 3.0.11
+      '@types/d3-selection': 3.0.11
 
-  "@types/d3-dsv@3.0.7": {}
+  '@types/d3-dsv@3.0.7': {}
 
-  "@types/d3-ease@3.0.2": {}
+  '@types/d3-ease@3.0.2': {}
 
-  "@types/d3-fetch@3.0.7":
+  '@types/d3-fetch@3.0.7':
     dependencies:
-      "@types/d3-dsv": 3.0.7
+      '@types/d3-dsv': 3.0.7
 
-  "@types/d3-force@3.0.10": {}
+  '@types/d3-force@3.0.10': {}
 
-  "@types/d3-format@3.0.4": {}
+  '@types/d3-format@3.0.4': {}
 
-  "@types/d3-geo@3.1.0":
+  '@types/d3-geo@3.1.0':
     dependencies:
-      "@types/geojson": 7946.0.16
+      '@types/geojson': 7946.0.16
 
-  "@types/d3-hierarchy@3.1.7": {}
+  '@types/d3-hierarchy@3.1.7': {}
 
-  "@types/d3-interpolate@3.0.4":
+  '@types/d3-interpolate@3.0.4':
     dependencies:
-      "@types/d3-color": 3.1.3
+      '@types/d3-color': 3.1.3
 
-  "@types/d3-path@3.1.1": {}
+  '@types/d3-path@3.1.1': {}
 
-  "@types/d3-polygon@3.0.2": {}
+  '@types/d3-polygon@3.0.2': {}
 
-  "@types/d3-quadtree@3.0.6": {}
+  '@types/d3-quadtree@3.0.6': {}
 
-  "@types/d3-random@3.0.3": {}
+  '@types/d3-random@3.0.3': {}
 
-  "@types/d3-scale-chromatic@3.1.0": {}
+  '@types/d3-scale-chromatic@3.1.0': {}
 
-  "@types/d3-scale@4.0.9":
+  '@types/d3-scale@4.0.9':
     dependencies:
-      "@types/d3-time": 3.0.4
+      '@types/d3-time': 3.0.4
 
-  "@types/d3-selection@3.0.11": {}
+  '@types/d3-selection@3.0.11': {}
 
-  "@types/d3-shape@3.1.8":
+  '@types/d3-shape@3.1.8':
     dependencies:
-      "@types/d3-path": 3.1.1
+      '@types/d3-path': 3.1.1
 
-  "@types/d3-time-format@4.0.3": {}
+  '@types/d3-time-format@4.0.3': {}
 
-  "@types/d3-time@3.0.4": {}
+  '@types/d3-time@3.0.4': {}
 
-  "@types/d3-timer@3.0.2": {}
+  '@types/d3-timer@3.0.2': {}
 
-  "@types/d3-transition@3.0.9":
+  '@types/d3-transition@3.0.9':
     dependencies:
-      "@types/d3-selection": 3.0.11
+      '@types/d3-selection': 3.0.11
 
-  "@types/d3-zoom@3.0.8":
+  '@types/d3-zoom@3.0.8':
     dependencies:
-      "@types/d3-interpolate": 3.0.4
-      "@types/d3-selection": 3.0.11
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
-  "@types/d3@7.4.3":
+  '@types/d3@7.4.3':
     dependencies:
-      "@types/d3-array": 3.2.2
-      "@types/d3-axis": 3.0.6
-      "@types/d3-brush": 3.0.6
-      "@types/d3-chord": 3.0.6
-      "@types/d3-color": 3.1.3
-      "@types/d3-contour": 3.0.6
-      "@types/d3-delaunay": 6.0.4
-      "@types/d3-dispatch": 3.0.7
-      "@types/d3-drag": 3.0.7
-      "@types/d3-dsv": 3.0.7
-      "@types/d3-ease": 3.0.2
-      "@types/d3-fetch": 3.0.7
-      "@types/d3-force": 3.0.10
-      "@types/d3-format": 3.0.4
-      "@types/d3-geo": 3.1.0
-      "@types/d3-hierarchy": 3.1.7
-      "@types/d3-interpolate": 3.0.4
-      "@types/d3-path": 3.1.1
-      "@types/d3-polygon": 3.0.2
-      "@types/d3-quadtree": 3.0.6
-      "@types/d3-random": 3.0.3
-      "@types/d3-scale": 4.0.9
-      "@types/d3-scale-chromatic": 3.1.0
-      "@types/d3-selection": 3.0.11
-      "@types/d3-shape": 3.1.8
-      "@types/d3-time": 3.0.4
-      "@types/d3-time-format": 4.0.3
-      "@types/d3-timer": 3.0.2
-      "@types/d3-transition": 3.0.9
-      "@types/d3-zoom": 3.0.8
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
-  "@types/debug@4.1.13":
+  '@types/debug@4.1.13':
     dependencies:
-      "@types/ms": 2.1.0
+      '@types/ms': 2.1.0
 
-  "@types/deep-eql@4.0.2": {}
+  '@types/deep-eql@4.0.2': {}
 
-  "@types/docker-modem@3.0.6":
+  '@types/docker-modem@3.0.6':
     dependencies:
-      "@types/node": 22.19.15
-      "@types/ssh2": 1.15.5
+      '@types/node': 22.19.15
+      '@types/ssh2': 1.15.5
 
-  "@types/dockerode@3.3.47":
+  '@types/dockerode@3.3.47':
     dependencies:
-      "@types/docker-modem": 3.0.6
-      "@types/node": 22.19.15
-      "@types/ssh2": 1.15.5
+      '@types/docker-modem': 3.0.6
+      '@types/node': 22.19.15
+      '@types/ssh2': 1.15.5
 
-  "@types/dompurify@3.2.0":
+  '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.3.3
 
-  "@types/estree-jsx@1.0.5":
+  '@types/estree-jsx@1.0.5':
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
-  "@types/estree@1.0.8": {}
+  '@types/estree@1.0.8': {}
 
-  "@types/geojson@7946.0.16": {}
+  '@types/geojson@7946.0.16': {}
 
-  "@types/hast@3.0.4":
+  '@types/hast@3.0.4':
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
-  "@types/jsdom@21.1.7":
+  '@types/jsdom@21.1.7':
     dependencies:
-      "@types/node": 22.19.15
-      "@types/tough-cookie": 4.0.5
+      '@types/node': 22.19.15
+      '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
-  "@types/mdast@4.0.4":
+  '@types/mdast@4.0.4':
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
-  "@types/ms@2.1.0": {}
+  '@types/ms@2.1.0': {}
 
-  "@types/node-fetch@2.6.13":
+  '@types/node-fetch@2.6.13':
     dependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
       form-data: 4.0.5
 
-  "@types/node@12.20.55": {}
+  '@types/node@12.20.55': {}
 
-  "@types/node@18.19.130":
+  '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
-  "@types/node@22.19.15":
+  '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
 
-  "@types/react-dom@19.2.3(@types/react@19.2.14)":
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
-      "@types/react": 19.2.14
+      '@types/react': 19.2.14
 
-  "@types/react@19.2.14":
+  '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 
-  "@types/ssh2@1.15.5":
+  '@types/ssh2@1.15.5':
     dependencies:
-      "@types/node": 18.19.130
+      '@types/node': 18.19.130
 
-  "@types/tar-stream@3.1.4":
+  '@types/tar-stream@3.1.4':
     dependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
 
-  "@types/tough-cookie@4.0.5": {}
+  '@types/tough-cookie@4.0.5': {}
 
-  "@types/trusted-types@2.0.7":
+  '@types/trusted-types@2.0.7':
     optional: true
 
-  "@types/turndown@5.0.6": {}
+  '@types/turndown@5.0.6': {}
 
-  "@types/unist@2.0.11": {}
+  '@types/unist@2.0.11': {}
 
-  "@types/unist@3.0.3": {}
+  '@types/unist@3.0.3': {}
 
-  "@ungap/structured-clone@1.3.0": {}
+  '@ungap/structured-clone@1.3.0': {}
 
-  "@upsetjs/venn.js@2.0.0":
+  '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  "@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))":
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
-      "@rolldown/pluginutils": 1.0.0-beta.27
-      "@types/babel__core": 7.20.5
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  "@vitest/expect@2.1.9":
+  '@vitest/expect@2.1.9':
     dependencies:
-      "@vitest/spy": 2.1.9
-      "@vitest/utils": 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  "@vitest/expect@4.1.3":
+  '@vitest/expect@4.1.3':
     dependencies:
-      "@standard-schema/spec": 1.1.0
-      "@types/chai": 5.2.3
-      "@vitest/spy": 4.1.3
-      "@vitest/utils": 4.1.3
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.15))":
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.15))':
     dependencies:
-      "@vitest/spy": 2.1.9
+      '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.15)
 
-  "@vitest/mocker@4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))":
+  '@vitest/mocker@4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      "@vitest/spy": 4.1.3
+      '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
 
-  "@vitest/pretty-format@2.1.9":
+  '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
 
-  "@vitest/pretty-format@4.1.3":
+  '@vitest/pretty-format@4.1.3':
     dependencies:
       tinyrainbow: 3.1.0
 
-  "@vitest/runner@2.1.9":
+  '@vitest/runner@2.1.9':
     dependencies:
-      "@vitest/utils": 2.1.9
+      '@vitest/utils': 2.1.9
       pathe: 1.1.2
 
-  "@vitest/runner@4.1.3":
+  '@vitest/runner@4.1.3':
     dependencies:
-      "@vitest/utils": 4.1.3
+      '@vitest/utils': 4.1.3
       pathe: 2.0.3
 
-  "@vitest/snapshot@2.1.9":
+  '@vitest/snapshot@2.1.9':
     dependencies:
-      "@vitest/pretty-format": 2.1.9
+      '@vitest/pretty-format': 2.1.9
       magic-string: 0.30.21
       pathe: 1.1.2
 
-  "@vitest/snapshot@4.1.3":
+  '@vitest/snapshot@4.1.3':
     dependencies:
-      "@vitest/pretty-format": 4.1.3
-      "@vitest/utils": 4.1.3
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@2.1.9":
+  '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
 
-  "@vitest/spy@4.1.3": {}
+  '@vitest/spy@4.1.3': {}
 
-  "@vitest/utils@2.1.9":
+  '@vitest/utils@2.1.9':
     dependencies:
-      "@vitest/pretty-format": 2.1.9
+      '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  "@vitest/utils@4.1.3":
+  '@vitest/utils@4.1.3':
     dependencies:
-      "@vitest/pretty-format": 4.1.3
+      '@vitest/pretty-format': 4.1.3
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  "@xmldom/xmldom@0.8.11": {}
+  '@xmldom/xmldom@0.8.11': {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -7460,11 +5009,11 @@ snapshots:
 
   chevrotain@11.1.2:
     dependencies:
-      "@chevrotain/cst-dts-gen": 11.1.2
-      "@chevrotain/gast": 11.1.2
-      "@chevrotain/regexp-to-ast": 11.1.2
-      "@chevrotain/types": 11.1.2
-      "@chevrotain/utils": 11.1.2
+      '@chevrotain/cst-dts-gen': 11.1.2
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/regexp-to-ast': 11.1.2
+      '@chevrotain/types': 11.1.2
+      '@chevrotain/utils': 11.1.2
       lodash-es: 4.17.23
 
   chokidar@3.6.0:
@@ -7556,7 +5105,7 @@ snapshots:
 
   cssstyle@4.6.0:
     dependencies:
-      "@asamuzakjp/css-color": 3.2.0
+      '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
@@ -7805,9 +5354,9 @@ snapshots:
 
   dockerode@4.0.10:
     dependencies:
-      "@balena/dockerignore": 1.0.2
-      "@grpc/grpc-js": 1.14.3
-      "@grpc/proto-loader": 0.7.15
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
       protobufjs: 7.5.4
       tar-fs: 2.1.4
@@ -7817,7 +5366,7 @@ snapshots:
 
   dompurify@3.3.3:
     optionalDependencies:
-      "@types/trusted-types": 2.0.7
+      '@types/trusted-types': 2.0.7
 
   dotenv@8.6.0: {}
 
@@ -7871,87 +5420,87 @@ snapshots:
 
   esbuild@0.21.5:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.21.5
-      "@esbuild/android-arm": 0.21.5
-      "@esbuild/android-arm64": 0.21.5
-      "@esbuild/android-x64": 0.21.5
-      "@esbuild/darwin-arm64": 0.21.5
-      "@esbuild/darwin-x64": 0.21.5
-      "@esbuild/freebsd-arm64": 0.21.5
-      "@esbuild/freebsd-x64": 0.21.5
-      "@esbuild/linux-arm": 0.21.5
-      "@esbuild/linux-arm64": 0.21.5
-      "@esbuild/linux-ia32": 0.21.5
-      "@esbuild/linux-loong64": 0.21.5
-      "@esbuild/linux-mips64el": 0.21.5
-      "@esbuild/linux-ppc64": 0.21.5
-      "@esbuild/linux-riscv64": 0.21.5
-      "@esbuild/linux-s390x": 0.21.5
-      "@esbuild/linux-x64": 0.21.5
-      "@esbuild/netbsd-x64": 0.21.5
-      "@esbuild/openbsd-x64": 0.21.5
-      "@esbuild/sunos-x64": 0.21.5
-      "@esbuild/win32-arm64": 0.21.5
-      "@esbuild/win32-ia32": 0.21.5
-      "@esbuild/win32-x64": 0.21.5
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.4
-      "@esbuild/android-arm": 0.27.4
-      "@esbuild/android-arm64": 0.27.4
-      "@esbuild/android-x64": 0.27.4
-      "@esbuild/darwin-arm64": 0.27.4
-      "@esbuild/darwin-x64": 0.27.4
-      "@esbuild/freebsd-arm64": 0.27.4
-      "@esbuild/freebsd-x64": 0.27.4
-      "@esbuild/linux-arm": 0.27.4
-      "@esbuild/linux-arm64": 0.27.4
-      "@esbuild/linux-ia32": 0.27.4
-      "@esbuild/linux-loong64": 0.27.4
-      "@esbuild/linux-mips64el": 0.27.4
-      "@esbuild/linux-ppc64": 0.27.4
-      "@esbuild/linux-riscv64": 0.27.4
-      "@esbuild/linux-s390x": 0.27.4
-      "@esbuild/linux-x64": 0.27.4
-      "@esbuild/netbsd-arm64": 0.27.4
-      "@esbuild/netbsd-x64": 0.27.4
-      "@esbuild/openbsd-arm64": 0.27.4
-      "@esbuild/openbsd-x64": 0.27.4
-      "@esbuild/openharmony-arm64": 0.27.4
-      "@esbuild/sunos-x64": 0.27.4
-      "@esbuild/win32-arm64": 0.27.4
-      "@esbuild/win32-ia32": 0.27.4
-      "@esbuild/win32-x64": 0.27.4
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
 
   escalade@3.2.0: {}
 
@@ -7965,7 +5514,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   etag@1.8.1: {}
 
@@ -8023,8 +5572,8 @@ snapshots:
 
   fast-glob@3.3.3:
     dependencies:
-      "@nodelib/fs.stat": 2.0.5
-      "@nodelib/fs.walk": 1.2.8
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
@@ -8162,9 +5711,9 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      "@types/estree": 1.0.8
-      "@types/hast": 3.0.4
-      "@types/unist": 3.0.3
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -8182,7 +5731,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      '@types/hast': 3.0.4
 
   hono@4.12.12: {}
 
@@ -8392,11 +5941,11 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   mammoth@1.12.0:
     dependencies:
-      "@xmldom/xmldom": 0.8.11
+      '@xmldom/xmldom': 0.8.11
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7
@@ -8415,15 +5964,15 @@ snapshots:
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
-      "@types/mdast": 4.0.4
-      "@types/unist": 3.0.3
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
@@ -8439,7 +5988,7 @@ snapshots:
 
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-find-and-replace: 3.0.2
@@ -8447,7 +5996,7 @@ snapshots:
 
   mdast-util-gfm-footnote@2.1.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8457,7 +6006,7 @@ snapshots:
 
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
@@ -8465,7 +6014,7 @@ snapshots:
 
   mdast-util-gfm-table@2.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
       mdast-util-from-markdown: 2.0.3
@@ -8475,7 +6024,7 @@ snapshots:
 
   mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8496,9 +6045,9 @@ snapshots:
 
   mdast-util-mdx-expression@2.0.1:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8507,10 +6056,10 @@ snapshots:
 
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@types/unist": 3.0.3
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -8524,9 +6073,9 @@ snapshots:
 
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
@@ -8535,14 +6084,14 @@ snapshots:
 
   mdast-util-phrasing@4.1.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.0
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -8552,8 +6101,8 @@ snapshots:
 
   mdast-util-to-markdown@2.1.2:
     dependencies:
-      "@types/mdast": 4.0.4
-      "@types/unist": 3.0.3
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
@@ -8564,7 +6113,7 @@ snapshots:
 
   mdast-util-to-string@4.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
 
   media-typer@0.3.0: {}
 
@@ -8574,11 +6123,11 @@ snapshots:
 
   mermaid@11.13.0:
     dependencies:
-      "@braintree/sanitize-url": 7.1.2
-      "@iconify/utils": 3.1.0
-      "@mermaid-js/parser": 1.0.1
-      "@types/d3": 7.4.3
-      "@upsetjs/venn.js": 2.0.0
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.0
+      '@mermaid-js/parser': 1.0.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.1
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
       cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
@@ -8769,7 +6318,7 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      "@types/debug": 4.1.13
+      '@types/debug': 4.1.13
       debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
@@ -8852,8 +6401,8 @@ snapshots:
 
   openai@4.104.0(ws@8.20.0):
     dependencies:
-      "@types/node": 18.19.130
-      "@types/node-fetch": 2.6.13
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
@@ -8894,7 +6443,7 @@ snapshots:
 
   parse-entities@4.0.2:
     dependencies:
-      "@types/unist": 2.0.11
+      '@types/unist': 2.0.11
       character-entities-legacy: 3.0.0
       character-reference-invalid: 2.0.1
       decode-named-character-reference: 1.3.0
@@ -8980,17 +6529,17 @@ snapshots:
 
   protobufjs@7.5.4:
     dependencies:
-      "@protobufjs/aspromise": 1.1.2
-      "@protobufjs/base64": 1.1.2
-      "@protobufjs/codegen": 2.0.4
-      "@protobufjs/eventemitter": 1.1.0
-      "@protobufjs/fetch": 1.1.0
-      "@protobufjs/float": 1.0.2
-      "@protobufjs/inquire": 1.1.0
-      "@protobufjs/path": 1.1.2
-      "@protobufjs/pool": 1.1.0
-      "@protobufjs/utf8": 1.1.0
-      "@types/node": 22.19.15
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -9031,9 +6580,9 @@ snapshots:
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@types/react": 19.2.14
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
@@ -9080,7 +6629,7 @@ snapshots:
 
   remark-gfm@4.0.1:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
@@ -9091,7 +6640,7 @@ snapshots:
 
   remark-parse@11.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
@@ -9100,15 +6649,15 @@ snapshots:
 
   remark-rehype@11.1.2:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
   remark-stringify@11.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
@@ -9124,33 +6673,33 @@ snapshots:
 
   rollup@4.60.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.60.0
-      "@rollup/rollup-android-arm64": 4.60.0
-      "@rollup/rollup-darwin-arm64": 4.60.0
-      "@rollup/rollup-darwin-x64": 4.60.0
-      "@rollup/rollup-freebsd-arm64": 4.60.0
-      "@rollup/rollup-freebsd-x64": 4.60.0
-      "@rollup/rollup-linux-arm-gnueabihf": 4.60.0
-      "@rollup/rollup-linux-arm-musleabihf": 4.60.0
-      "@rollup/rollup-linux-arm64-gnu": 4.60.0
-      "@rollup/rollup-linux-arm64-musl": 4.60.0
-      "@rollup/rollup-linux-loong64-gnu": 4.60.0
-      "@rollup/rollup-linux-loong64-musl": 4.60.0
-      "@rollup/rollup-linux-ppc64-gnu": 4.60.0
-      "@rollup/rollup-linux-ppc64-musl": 4.60.0
-      "@rollup/rollup-linux-riscv64-gnu": 4.60.0
-      "@rollup/rollup-linux-riscv64-musl": 4.60.0
-      "@rollup/rollup-linux-s390x-gnu": 4.60.0
-      "@rollup/rollup-linux-x64-gnu": 4.60.0
-      "@rollup/rollup-linux-x64-musl": 4.60.0
-      "@rollup/rollup-openbsd-x64": 4.60.0
-      "@rollup/rollup-openharmony-arm64": 4.60.0
-      "@rollup/rollup-win32-arm64-msvc": 4.60.0
-      "@rollup/rollup-win32-ia32-msvc": 4.60.0
-      "@rollup/rollup-win32-x64-gnu": 4.60.0
-      "@rollup/rollup-win32-x64-msvc": 4.60.0
+      '@rollup/rollup-android-arm-eabi': 4.60.0
+      '@rollup/rollup-android-arm64': 4.60.0
+      '@rollup/rollup-darwin-arm64': 4.60.0
+      '@rollup/rollup-darwin-x64': 4.60.0
+      '@rollup/rollup-freebsd-arm64': 4.60.0
+      '@rollup/rollup-freebsd-x64': 4.60.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
+      '@rollup/rollup-linux-arm64-gnu': 4.60.0
+      '@rollup/rollup-linux-arm64-musl': 4.60.0
+      '@rollup/rollup-linux-loong64-gnu': 4.60.0
+      '@rollup/rollup-linux-loong64-musl': 4.60.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
+      '@rollup/rollup-linux-ppc64-musl': 4.60.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
+      '@rollup/rollup-linux-riscv64-musl': 4.60.0
+      '@rollup/rollup-linux-s390x-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-musl': 4.60.0
+      '@rollup/rollup-openbsd-x64': 4.60.0
+      '@rollup/rollup-openharmony-arm64': 4.60.0
+      '@rollup/rollup-win32-arm64-msvc': 4.60.0
+      '@rollup/rollup-win32-ia32-msvc': 4.60.0
+      '@rollup/rollup-win32-x64-gnu': 4.60.0
+      '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
   roughjs@4.6.6:
@@ -9465,7 +7014,7 @@ snapshots:
 
   turndown@7.2.4:
     dependencies:
-      "@mixmark-io/domino": 2.2.0
+      '@mixmark-io/domino': 2.2.0
 
   tweetnacl@0.14.5: {}
 
@@ -9486,7 +7035,7 @@ snapshots:
 
   unified@11.0.5:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       bail: 2.0.2
       devlop: 1.1.0
       extend: 3.0.2
@@ -9496,24 +7045,24 @@ snapshots:
 
   unist-util-is@6.0.1:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-stringify-position@4.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-visit-parents@6.0.2:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
   unist-util-visit@5.1.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
@@ -9539,12 +7088,12 @@ snapshots:
 
   vfile-message@4.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
   vfile@6.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
   vite-node@2.1.9(@types/node@22.19.15):
@@ -9555,7 +7104,7 @@ snapshots:
       pathe: 1.1.2
       vite: 5.4.21(@types/node@22.19.15)
     transitivePeerDependencies:
-      - "@types/node"
+      - '@types/node'
       - less
       - lightningcss
       - sass
@@ -9591,7 +7140,7 @@ snapshots:
       postcss: 8.5.8
       rollup: 4.60.0
     optionalDependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
       fsevents: 2.3.3
 
   vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
@@ -9603,20 +7152,20 @@ snapshots:
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
       fsevents: 2.3.3
       tsx: 4.21.0
       yaml: 2.8.3
 
   vitest@2.1.9(@types/node@22.19.15)(jsdom@26.1.0):
     dependencies:
-      "@vitest/expect": 2.1.9
-      "@vitest/mocker": 2.1.9(vite@5.4.21(@types/node@22.19.15))
-      "@vitest/pretty-format": 2.1.9
-      "@vitest/runner": 2.1.9
-      "@vitest/snapshot": 2.1.9
-      "@vitest/spy": 2.1.9
-      "@vitest/utils": 2.1.9
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.15))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -9631,7 +7180,7 @@ snapshots:
       vite-node: 2.1.9(@types/node@22.19.15)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
       jsdom: 26.1.0
     transitivePeerDependencies:
       - less
@@ -9646,13 +7195,13 @@ snapshots:
 
   vitest@4.1.3(@types/node@22.19.15)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      "@vitest/expect": 4.1.3
-      "@vitest/mocker": 4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
-      "@vitest/pretty-format": 4.1.3
-      "@vitest/runner": 4.1.3
-      "@vitest/snapshot": 4.1.3
-      "@vitest/spy": 4.1.3
-      "@vitest/utils": 4.1.3
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -9667,7 +7216,7 @@ snapshots:
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 22.19.15
+      '@types/node': 22.19.15
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Implements [Issue #67](https://github.com/yai-dev/agentrail/issues/67) — a rule-based tool permission policy system that intercepts tool calls before execution and supports `allow`, `deny`, and `ask` decisions.

### What's included

- **`@agentrail/capabilities`** — new `permissions/` module with:
  - `types.ts` — `ToolPermissionPolicy`, `PermissionRule`, `PermissionMode`
  - `rule-parser.ts` — parses DSL strings like `"Bash(git:*)"` into `PermissionRule[]`
  - `rule-engine.ts` — evaluates `deny → ask → allow → default` priority chain
  - `path-safety.ts` — `workspaceAnchor` validates paths against `rootDir` using nearest-ancestor traversal
  - `shell-safety.ts` — `isDangerousCommand`, `isReadOnlyCommand`, `normalizeBashCommand` (converts `"git status"` → `"git:status"` so `git:*` DSL patterns match correctly)
  - All sandboxed file tools (Bash, **Read, Write, Edit**) and non-sandboxed tools wired to `checkPermissions`

- **`@agentrail/core`** — `PermissionDecision` type + `.checkPermissions()` builder method on `RuntimeTool`; `tool-executor` enforces the hook after interceptors; `RuntimeEvent.permission_request` emitted on `ask`

- **`@agentrail/app`** — `permissionPolicy?` option on `createAgentApp` / `createStreamRoute` / `createChatRoute`; `AgentrailPermissionsConfig` parsed from `agentrail.yaml`; `configPermissionsToPolicy()` exported for converting config → runtime policy

### Bash DSL convention

Rules use a `verb:args` form — `Bash(git:*)` matches any command starting with `git`. The tool normalises `"git status"` → `"git:status"` before pattern matching so glob patterns work as documented.

### Loading from `agentrail.yaml`

```yaml
permissions:
  mode: default
  allow:
    - "Bash(git:*)"
    - "Bash(npm:*)"
  deny:
    - "Bash(rm:*)"
  ask:
    - "Write"
    - "Edit"
```

```ts
import { createAgentApp, loadAgentrailConfig, configPermissionsToPolicy } from "@agentrail/app";

const config = loadAgentrailConfig();
const app = createAgentApp({
  permissionPolicy: config.permissions
    ? configPermissionsToPolicy(config.permissions)
    : undefined,
});
```

## Test plan

- [x] `pnpm --filter @agentrail/capabilities test -- permissions` — rule-engine, path-safety, shell-safety (including Bash DSL colon-convention end-to-end)
- [x] `pnpm --filter @agentrail/core test -- tool-executor` — deny/ask paths in executor
- [x] `pnpm --filter @agentrail/app test` — config parsing, `configPermissionsToPolicy`, assembly-hop (`profileCtx.permissionPolicy` → `CapabilityBuildContext.permissionPolicy`)
- [x] `pnpm test` — full suite green (240 tests across all packages)
- [x] `pnpm typecheck` — no errors

Closes #67